### PR TITLE
Add CSP meta tags and SRI for external scripts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
   <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}">
   <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,7 @@
   <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;" />
   <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}" />
   <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}" />
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
@@ -114,7 +115,7 @@
            data-page-title="{{ page.title }}">
       </div>
       
-      <script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
+      <script async defer src="https://cusdis.com/js/cusdis.es.js" integrity="sha384-K8JQBqTnKbFxb1EJ2OmQbJzrCtUjB4unTDO9yt8PQpm2Vyk+IFYeCQzl5founzmx" crossorigin="anonymous"></script>
 
     </article>
   </main>

--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,7 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <meta name="title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube">
   <meta name="description" content="Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -8,6 +8,7 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
@@ -79,8 +80,8 @@
   <img id="preview" alt="Captured image appears here" loading="lazy" /><br>
   <button id="downloadBtn" style="display:none;">🪄 Resize & Download</button>
 
-  <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/piexifjs"></script>
+  <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js" integrity="sha384-PlRSzpewlarQuj5alIadXwjNUX+2eNMKwr0f07ShWYLy8B6TjEbm7ZlcN/ScSbwy" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/piexifjs@1.0.6/piexif.min.js" integrity="sha384-MlO+zFNXGYz1yVixxasJvwtfht0kwZbxPq9WYuBvOPoUQ6bJCvwEHfCgv7bnUp3N" crossorigin="anonymous"></script>
 
   <script>
     const video = document.getElementById("video");

--- a/privacy.html
+++ b/privacy.html
@@ -8,6 +8,7 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/radio.html
+++ b/radio.html
@@ -5,6 +5,7 @@
   <title>PakStream Radio - Listen to Pakistani Radio Stations Online</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <meta name="title" content="PakStream Radio - Listen to Pakistani Radio Stations Online">
   <meta name="description" content="Stream live Pakistani FM, talk, and news radio from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">

--- a/terms.html
+++ b/terms.html
@@ -8,6 +8,7 @@
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/tv.html
+++ b/tv.html
@@ -5,6 +5,7 @@
   <title>PakStream TV - Watch Pakistani TV Channels Live</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;" />
   <meta name="title" content="PakStream TV - Watch Pakistani TV Channels Live" />
   <meta name="description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />

--- a/youtube.html
+++ b/youtube.html
@@ -5,6 +5,7 @@
   <title>PakStream YouTube - Watch Independent Pakistani News YouTubers</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.youtube.com https://cdn.jsdelivr.net https://cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://adservice.google.com https://*.google.com https://*.doubleclick.net https://cdn.jsdelivr.net https://cusdis.com; frame-src https://www.youtube.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net;">
   <meta name="title" content="PakStream YouTube - Watch Independent Pakistani News YouTubers">
   <meta name="description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">


### PR DESCRIPTION
## Summary
- enforce Content Security Policy across templates and pages to limit third-party resource loading
- secure external scripts with Subresource Integrity for Cusdis, FileSaver, and Piexif dependencies
- relax CSP to permit inline styles and network connections needed for Google Ads

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893a5b8f43483208da6c2a5f148a812