### PR TITLE
Ensure TV page loads default channel and stops previous player

### DIFF
--- a/tv.html
+++ b/tv.html
@@ -226,6 +226,9 @@
     };
     const urlParams = new URLSearchParams(window.location.search);
     const initialChannel = tvAnchorMap[urlParams.get('tvchannel')] || 'geo';
+    if (!urlParams.has('tvchannel')) {
+      history.replaceState(null, '', `${window.location.pathname}?tvchannel=${initialChannel}`);
+    }
 
     function loadPlayer(id) {
       const iframe = document.getElementById(`${id}-player`);
@@ -240,11 +243,11 @@
       });
     }
 
-    function onYouTubeIframeAPIReady() {
+    window.onYouTubeIframeAPIReady = function() {
       const initialCard = document.querySelector(`.channel-card[onclick*="${initialChannel}"]`) ||
         document.querySelector('.channel-card');
       showStream(initialChannel, initialCard);
-    }
+    };
 
     function showStream(id, element) {
       // Hide all video divs
@@ -255,8 +258,8 @@
 
       // Pause all players
       for (const key in players) {
-        if (players[key].pauseVideo) {
-          players[key].pauseVideo();
+        if (players[key].stopVideo) {
+          players[key].stopVideo();
         }
       }
 


### PR DESCRIPTION
## Summary
- Default to the first TV channel when no `tvchannel` is specified and update URL accordingly
- Stop currently playing videos when switching channels to avoid overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b888b600832085bcde3a07d8a82f