### PR TITLE
Auto-select next channel after video finishes

### DIFF
--- a/youtube.html
+++ b/youtube.html
@@ -106,7 +106,7 @@
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()">Channels</button>
       <div class="live-player">
-        <iframe id="playerFrame" src="" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+        <div id="playerFrame"></div>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -129,6 +129,7 @@
   </footer>
 
   <!-- JavaScript for dynamically loading latest videos from the selected channel -->
+<script src="https://www.youtube.com/iframe_api"></script>
 <script>
   const anchorMap = {
     ImranRiazKhan: "UCaszgR2TH3qNw_CxLHAd2SQ",
@@ -157,7 +158,8 @@
 
   const cards = document.querySelectorAll('.channel-card');
   const videoListEl = document.getElementById('videoList');
-  const playerFrame = document.getElementById('playerFrame');
+  let player;
+  let pendingVideoId = null;
 
   function setActiveCard(clickedCard) {
     cards.forEach(c => c.classList.remove('active'));
@@ -169,9 +171,34 @@
     clickedItem.classList.add('active');
   }
 
+  function onYouTubeIframeAPIReady() {
+    player = new YT.Player('playerFrame', {
+      events: { 'onStateChange': onPlayerStateChange },
+      playerVars: { autoplay: 1, rel: 0 },
+      videoId: pendingVideoId
+    });
+  }
+
+  function onPlayerStateChange(event) {
+    if (event.data === YT.PlayerState.ENDED) {
+      const active = document.querySelector('.channel-card.active');
+      let next = active ? active.nextElementSibling : null;
+      if (!next || !next.classList.contains('channel-card')) {
+        next = document.querySelector('.channel-card');
+      }
+      if (next) {
+        handleChannelClick(next);
+      }
+    }
+  }
+
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+      if (player && typeof player.loadVideoById === 'function') {
+        player.loadVideoById(videoId);
+      } else {
+        pendingVideoId = videoId;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- load YouTube IFrame API to monitor playback
- automatically switch to the next channel when a video ends

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893d94f1d008320861fe1f55ad735eb