### PR TITLE
Lock orientation on fullscreen

### DIFF
--- a/js/fullscreen-orientation.js
+++ b/js/fullscreen-orientation.js
@@ -1,0 +1,20 @@
+(function(){
+  function lockLandscape() {
+    if (screen.orientation && screen.orientation.lock) {
+      screen.orientation.lock('landscape').catch(function(){});
+    }
+  }
+  function unlockOrientation() {
+    if (screen.orientation && screen.orientation.unlock) {
+      screen.orientation.unlock();
+    }
+  }
+  function handleChange() {
+    if (document.fullscreenElement) {
+      lockLandscape();
+    } else {
+      unlockOrientation();
+    }
+  }
+  ['fullscreenchange','webkitfullscreenchange','mozfullscreenchange','MSFullscreenChange'].forEach(function(evt){document.addEventListener(evt, handleChange);});
+})();

--- a/tv.html
+++ b/tv.html
@@ -316,6 +316,7 @@
       }
     });
   </script>
+  <script src="/js/fullscreen-orientation.js"></script>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
 </body>

--- a/youtube.html
+++ b/youtube.html
@@ -322,6 +322,7 @@
   handleChannelClick(cards[0]);
   }
 </script>
+  <script src="/js/fullscreen-orientation.js"></script>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- lock screen orientation to landscape when any element enters fullscreen
- include orientation script on YouTube and TV pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689450e11c5c83209f28ec199c55a602