### PR TITLE
Lazy load ad script to reduce forced reflow

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -99,5 +98,6 @@
   </footer>
   <script defer src="/js/menu.js"></script>
   <script defer src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -112,5 +111,6 @@
   </footer>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -112,5 +111,6 @@
   </footer>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -182,5 +181,6 @@
   </footer>
   <script defer src="/js/menu.js"></script>
   <script defer src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/js/ads.js
+++ b/js/ads.js
@@ -1,0 +1,14 @@
+(function(){
+  function loadAds(){
+    var s=document.createElement('script');
+    s.src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690';
+    s.async=true;
+    s.crossOrigin='anonymous';
+    document.head.appendChild(s);
+  }
+  if(window.requestIdleCallback){
+    requestIdleCallback(loadAds);
+  }else{
+    window.addEventListener('load', loadAds);
+  }
+})();

--- a/privacy.html
+++ b/privacy.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -114,5 +113,6 @@
   </footer>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -815,6 +814,7 @@ document.addEventListener('DOMContentLoaded', function() {
   </script>
   <script defer src="/js/menu.js"></script>
   <script defer src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>
 

--- a/terms.html
+++ b/terms.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -116,5 +115,6 @@
   </footer>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/tv.html
+++ b/tv.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690" crossorigin="anonymous"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" href="/css/theme.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -329,5 +328,6 @@
   <script src="/js/fullscreen-orientation.js"></script>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/youtube.html
+++ b/youtube.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690"
      crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -335,5 +334,6 @@
   <script src="/js/fullscreen-orientation.js"></script>
   <script src="/js/menu.js"></script>
   <script src="/js/lazyload.js"></script>
+  <script defer src="/js/ads.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove synchronous AdSense script tags from page heads
- add deferred loader that injects AdSense script during idle time

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afe83a3a48320bc193750dba47f1d