### PR TITLE
Fix stray crossorigin text showing on pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" href="/css/theme.css" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/about.html
+++ b/about.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/contact.html
+++ b/contact.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/privacy.html
+++ b/privacy.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/radio.html
+++ b/radio.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/terms.html
+++ b/terms.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/youtube.html
+++ b/youtube.html
@@ -45,7 +45,6 @@
   }
   </script>
 
-     crossorigin="anonymous"></script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- remove stray `crossorigin="anonymous">` text from default layout and duplicated pages
- ensure Jekyll site builds cleanly

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689b00ae6b44832085deda4652324f07