### PR TITLE
Enhance static asset caching

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,19 @@
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresDefault "access plus 10 minutes"
+  ExpiresByType image/png "access plus 1 year"
+  ExpiresByType image/jpg "access plus 1 year"
+  ExpiresByType image/jpeg "access plus 1 year"
+  ExpiresByType image/gif "access plus 1 year"
+  ExpiresByType image/svg+xml "access plus 1 year"
+  ExpiresByType image/x-icon "access plus 1 year"
+  ExpiresByType text/css "access plus 1 year"
+  ExpiresByType application/javascript "access plus 1 year"
+</IfModule>
+
 <IfModule mod_headers.c>
   <FilesMatch "\.(js|css|png|jpg|jpeg|gif|svg|ico)$">
-    Header set Cache-Control "public, max-age=31536000"
+    Header set Cache-Control "public, max-age=31536000, immutable"
   </FilesMatch>
   <FilesMatch "\.(html)$">
     Header set Cache-Control "public, max-age=600"


### PR DESCRIPTION
## Summary
- Add `mod_expires` directives to control cache lifetimes for images, stylesheets, and scripts
- Mark long-lived assets as immutable for stronger browser caching

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689b00f6992483208a3bdc08492bde37