### PR TITLE
Defer Google Ads script until user interaction

### DIFF
--- a/js/ads.js
+++ b/js/ads.js
@@ -1,14 +1,21 @@
 (function(){
+  var loaded=false;
   function loadAds(){
+    if(loaded) return;
+    loaded=true;
     var s=document.createElement('script');
     s.src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5427964157655690';
     s.async=true;
     s.crossOrigin='anonymous';
     document.head.appendChild(s);
   }
-  if(window.requestIdleCallback){
-    requestIdleCallback(loadAds);
-  }else{
-    window.addEventListener('load', loadAds);
+  function onUserInteraction(){
+    loadAds();
+    window.removeEventListener('scroll', onUserInteraction);
+    window.removeEventListener('mousemove', onUserInteraction);
+    window.removeEventListener('touchstart', onUserInteraction);
   }
+  window.addEventListener('scroll', onUserInteraction, {once:true});
+  window.addEventListener('mousemove', onUserInteraction, {once:true});
+  window.addEventListener('touchstart', onUserInteraction, {once:true});
 })();


### PR DESCRIPTION
## Summary
- Load Google Ads script only after user interaction to cut unused JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b02fdd09c8320bd7c50ddff95bbe9