### PR TITLE
Serve JavaScript as modules

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,8 +95,8 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script defer src="/js/menu.js"></script>
-  <script defer src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -138,7 +138,7 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -108,8 +108,8 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -108,8 +108,8 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -178,8 +178,8 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script defer src="/js/menu.js"></script>
-  <script defer src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -153,8 +153,8 @@
       img.src = preview.src;
     };
   </script>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
   <footer>
     <nav class="footer-nav">
       <a href="/about.html">About Us</a>

--- a/privacy.html
+++ b/privacy.html
@@ -110,8 +110,8 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -810,9 +810,9 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
   </script>
-  <script defer src="/js/menu.js"></script>
-  <script defer src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>
 

--- a/terms.html
+++ b/terms.html
@@ -112,8 +112,8 @@
     </nav>
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/tv.html
+++ b/tv.html
@@ -325,9 +325,9 @@
       }
     });
   </script>
-  <script src="/js/fullscreen-orientation.js"></script>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>

--- a/youtube.html
+++ b/youtube.html
@@ -330,9 +330,9 @@
   handleChannelClick(cards[0]);
   }
 </script>
-  <script src="/js/fullscreen-orientation.js"></script>
-  <script src="/js/menu.js"></script>
-  <script src="/js/lazyload.js"></script>
-  <script defer src="/js/ads.js"></script>
+  <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script type="module" src="/js/menu.js"></script>
+  <script type="module" src="/js/lazyload.js"></script>
+  <script type="module" defer src="/js/ads.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- deliver first-party scripts as ES modules instead of legacy scripts
- retain defer on ads loader while serving as module

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b02c12b4083208af41b54d5a75a0b