### PR TITLE
Increase cache lifetime for static assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,9 @@
 <IfModule mod_expires.c>
   ExpiresActive On
-  ExpiresDefault "access plus 10 minutes"
+  # Default to a long cache lifetime so assets without an explicit rule
+  # still benefit from caching. HTML files are overridden below.
+  ExpiresDefault "access plus 1 year"
+  ExpiresByType text/html "access plus 10 minutes"
   ExpiresByType image/png "access plus 1 year"
   ExpiresByType image/jpg "access plus 1 year"
   ExpiresByType image/jpeg "access plus 1 year"


### PR DESCRIPTION
## Summary
- default asset caching is 1 year, with HTML explicitly at 10 minutes

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b04dda584832098916ed4d24d8048