### PR TITLE
Maintain high contrast for top-bar navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -90,6 +90,13 @@ footer nav a:hover {
   text-decoration: underline;
 }
 
+.top-bar nav a:hover,
+.top-bar nav a:focus,
+.top-bar nav a.active {
+  color: var(--on-primary);
+  text-decoration: underline;
+}
+
 /* Keep existing styles untouched below here */
 /* The rest of the existing style.css remains the same... */
 


### PR DESCRIPTION
## Summary
- ensure hovered, focused and active top-bar links retain `--on-primary` color for better contrast

## Testing
- `npx prettier --check css/style.css` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_689b09fdce548320b1ef5475b8537df8