### PR TITLE
Prioritize hero image for faster LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
   <link rel="preload" as="image"
     href="/images/pakistan-abstract-380.webp"
     imagesrcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
-    imagesizes="(max-width: 420px) 80vw, 380px">
+    imagesizes="(max-width: 420px) 80vw, 380px"
+    fetchpriority="high">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -99,8 +100,8 @@
         width="380"
         height="380"
         alt="Abstract Pakistan crescent and star"
-        loading="lazy"
         decoding="async"
+        fetchpriority="high"
         style="aspect-ratio: 1 / 1; object-fit: cover;" />
     </picture>
     <div class="hero-text">


### PR DESCRIPTION
## Summary
- Boost hero image priority for Largest Contentful Paint
- Remove lazy loading from the main hero image
- Preload hero image with high fetch priority

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba19ae6c88320a9b0b59554ae016c