### PR TITLE
Include long-term caching for WebP assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,13 +9,14 @@
   ExpiresByType image/jpeg "access plus 1 year"
   ExpiresByType image/gif "access plus 1 year"
   ExpiresByType image/svg+xml "access plus 1 year"
+  ExpiresByType image/webp "access plus 1 year"
   ExpiresByType image/x-icon "access plus 1 year"
   ExpiresByType text/css "access plus 1 year"
   ExpiresByType application/javascript "access plus 1 year"
 </IfModule>
 
 <IfModule mod_headers.c>
-  <FilesMatch "\.(js|css|png|jpg|jpeg|gif|svg|ico)$">
+  <FilesMatch "\.(js|css|png|jpg|jpeg|gif|svg|ico|webp)$">
     Header set Cache-Control "public, max-age=31536000, immutable"
   </FilesMatch>
   <FilesMatch "\.(html)$">


### PR DESCRIPTION
## Summary
- extend `.htaccess` caching rules to cover `.webp` files
- configure WebP resources with one-year `Cache-Control` and `Expires` headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba278452083209836d48c55682631