### PR TITLE
refactor: simplify navigation markup

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,22 +61,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -57,22 +57,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/about.html
+++ b/about.html
@@ -62,22 +62,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/contact.html
+++ b/contact.html
@@ -63,22 +63,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/css/style.css
+++ b/css/style.css
@@ -38,7 +38,7 @@ body {
   z-index: 1002;
 }
 
-.logo-title h1 {
+.logo-title {
   font-size: 1.25rem;
   margin: 0;
   line-height: 56px;
@@ -59,31 +59,22 @@ body {
   text-decoration: none;
 }
 
-nav {
+.top-bar nav {
   flex-grow: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
   transition: transform 0.4s ease-in-out;
 }
 
-nav ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-}
-
-nav li {
-  margin-right: 16px;
-}
-
-nav a {
+.top-bar nav a {
   color: var(--on-primary);
   text-decoration: none;
   font-weight: 500;
 }
 
-nav a:hover,
-nav a.active,
+.top-bar nav a:hover,
+.top-bar nav a.active,
 .post-share a:hover,
 footer nav a:hover {
   color: var(--accent-link);
@@ -342,6 +333,9 @@ section {
     overflow-y: auto;
     padding: 16px 8px;
     z-index: 1001;
+    flex-direction: column;
+    padding: 16px;
+    gap: 8px;
   }
   .youtube-section .channel-list.open {
     transform: translateX(0);
@@ -640,7 +634,7 @@ table tbody tr.favorite {
     margin: 15px 0;
   }
 
-  nav {
+  .top-bar nav {
     position: fixed;
     top: 56px;
     left: 0;
@@ -653,22 +647,16 @@ table tbody tr.favorite {
     will-change: transform;
     box-shadow: 2px 0 5px rgba(0,0,0,0.3);
     z-index: 1001;
+    flex-direction: column;
+    padding: 16px;
+    gap: 8px;
   }
 
   #nav-toggle:checked ~ nav {
     transform: translateX(0);
   }
 
-  nav ul {
-    flex-direction: column;
-    padding: 16px;
-  }
-
-  nav li {
-    margin: 8px 0;
-  }
-
-  nav a {
+  .top-bar nav a {
     color: var(--on-surface);
     display: block;
     padding: 8px 0;
@@ -697,10 +685,8 @@ table tbody tr.favorite {
   .back-button {
     display: none;
   }
-  nav {
+  .top-bar nav {
     margin-left: auto;
-  }
-  nav ul {
     justify-content: flex-end;
     flex-wrap: nowrap;
   }

--- a/index.html
+++ b/index.html
@@ -68,22 +68,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -61,22 +61,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/nav.html
+++ b/nav.html
@@ -12,22 +12,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
     <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
     <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/privacy.html
+++ b/privacy.html
@@ -63,22 +63,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/radio.html
+++ b/radio.html
@@ -62,22 +62,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/terms.html
+++ b/terms.html
@@ -63,22 +63,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/tv.html
+++ b/tv.html
@@ -61,22 +61,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>

--- a/youtube.html
+++ b/youtube.html
@@ -62,22 +62,18 @@
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <div class="logo-title">
-      <h1>PakStream</h1>
-    </div>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/youtube.html">YouTube</a></li>
-        <li><a href="/tv.html">TV</a></li>
-        <li><a href="/radio.html">Radio</a></li>
-        <li><a href="/blog.html">Blog</a></li>
-        <li><a href="/about.html">About</a></li>
-        <li><a href="/contact.html">Contact</a></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-      </ul>
-    </nav>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/youtube.html">YouTube</a>
+        <a href="/tv.html">TV</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>


### PR DESCRIPTION
## Summary
- streamline navigation structure across pages to reduce DOM depth
- consolidate navigation styles and scope them to the top bar

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689ba3a179848320a546854350487a0b