### PR TITLE
Rename TV tab to Live TV and YouTube tab to Free Press

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,8 +60,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -60,8 +60,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/_posts/2025-07-29-welcome-to-blog.md
+++ b/_posts/2025-07-29-welcome-to-blog.md
@@ -39,7 +39,7 @@ In this blog, I’ll be sharing:
 - Recommendations, radio stations, YouTubers, TV channels
 - Messages from users like you who share feedback and ideas
 
-If you're looking to [watch Pakistani TV channels live](/tv.html), check out our TV section where you can stream Urdu news and dramas online. We've also written about [popular Pakistani YouTubers that every expat should follow](/blog/2025/07/31/youtubers-for-news.html).
+If you're looking to [watch Pakistani TV channels live](/livetv.html), check out our TV section where you can stream Urdu news and dramas online. We've also written about [popular Pakistani YouTubers that every expat should follow](/blog/2025/07/31/youtubers-for-news.html).
 
 It’s also a space to **connect with like-minded Pakistanis abroad**. If you relate to any of this, drop a comment, say hello, or share a suggestion. I genuinely read them all, and many of the features on the site are inspired by conversations I’ve had with people just like you.
 

--- a/_posts/2025-07-30-why-pakstream.md
+++ b/_posts/2025-07-30-why-pakstream.md
@@ -78,7 +78,7 @@ This is just the beginning. Here’s what I’m planning next:
 - **Blog Posts** – sharing stories like this one, contributed by fellow Pakistanis abroad
 - **User Suggestions Section** – so you can tell me what else you want added
 
-If you're looking to [watch Pakistani TV channels live](/tv.html), check out our TV section where you can stream Urdu news and dramas online. We've also written about [popular Pakistani YouTubers that every expat should follow](/blog/2025/07/31/youtubers-for-news.html).
+If you're looking to [watch Pakistani TV channels live](/livetv.html), check out our TV section where you can stream Urdu news and dramas online. We've also written about [popular Pakistani YouTubers that every expat should follow](/blog/2025/07/31/youtubers-for-news.html).
 
 If the site grows and people find value in it, I may even consider adding native mobile apps or features like saving your favorite stations, scheduling reminders for programs, and more.
 

--- a/_posts/2025-07-31-youtubers-for-news.md
+++ b/_posts/2025-07-31-youtubers-for-news.md
@@ -20,10 +20,10 @@ Like many Pakistanis, I’ve found myself turning more and more toward **indepen
 
 For example:
 
-- [Imran Riaz Khan](https://pakstream.com/youtube.html?newsanchor=ImranRiazKhan) talks about judiciary and civil-military issues with courage.  
-- [Sabir Shakir](https://pakstream.com/youtube.html?newsanchor=SabirShakir) often breaks political developments before they even make the headlines.  
-- [Sami Abraham](https://pakstream.com/youtube.html?newsanchor=SamiAbraham), [Mansoor Ali Khan](https://pakstream.com/youtube.html?newsanchor=MansoorAliKhan), [Moeed Pirzada](https://pakstream.com/youtube.html?newsanchor=MoeedPirzada), each of them brings their own style and credibility.  
-- And then there are rising voices like [Syed Ali Haider](https://pakstream.com/youtube.html?newsanchor=AliHaider), [Siddique Jaan](https://pakstream.com/youtube.html?newsanchor=SiddiqueJaan), and [Usama Ghazi](https://pakstream.com/youtube.html?newsanchor=UsamaGhazi), who cover ground realities that mainstream channels often ignore.
+- [Imran Riaz Khan](https://pakstream.com/freepress.html?newsanchor=ImranRiazKhan) talks about judiciary and civil-military issues with courage.  
+- [Sabir Shakir](https://pakstream.com/freepress.html?newsanchor=SabirShakir) often breaks political developments before they even make the headlines.  
+- [Sami Abraham](https://pakstream.com/freepress.html?newsanchor=SamiAbraham), [Mansoor Ali Khan](https://pakstream.com/freepress.html?newsanchor=MansoorAliKhan), [Moeed Pirzada](https://pakstream.com/freepress.html?newsanchor=MoeedPirzada), each of them brings their own style and credibility.  
+- And then there are rising voices like [Syed Ali Haider](https://pakstream.com/freepress.html?newsanchor=AliHaider), [Siddique Jaan](https://pakstream.com/freepress.html?newsanchor=SiddiqueJaan), and [Usama Ghazi](https://pakstream.com/freepress.html?newsanchor=UsamaGhazi), who cover ground realities that mainstream channels often ignore.
 
 These journalists are not just sources of information, they’ve become part of our daily lives.
 
@@ -42,37 +42,37 @@ I had already built PakStream to organize my favorite Pakistani radio stations. 
 So I created a new page on [PakStream](https://www.pakstream.com) where I can access all the YouTube channels I follow, all in one place. Just one clean interface with links to all the journalists I care about. No algorithm. No ads. No noise.
 
 You can access it here:  
-👉 [https://pakstream.com/youtube.html](https://pakstream.com/youtube.html)
+👉 [https://pakstream.com/freepress.html](https://pakstream.com/freepress.html)
 
 And if you want to jump straight to a specific journalist’s section, you can use a direct link like:  
-👉 [https://pakstream.com/youtube.html?newsanchor=ImranRiazKhan](https://pakstream.com/youtube.html?newsanchor=ImranRiazKhan)
+👉 [https://pakstream.com/freepress.html?newsanchor=ImranRiazKhan](https://pakstream.com/freepress.html?newsanchor=ImranRiazKhan)
 
 It’s super simple, fast, and organized.
 
 Here’s a list of some of the anchors and analysts featured, each one linked to their section:
 
-- [Imran Riaz Khan](https://pakstream.com/youtube.html?newsanchor=ImranRiazKhan)  
-- [Sabir Shakir](https://pakstream.com/youtube.html?newsanchor=SabirShakir)  
-- [Sami Abraham](https://pakstream.com/youtube.html?newsanchor=SamiAbraham)  
-- [Mansoor Ali Khan](https://pakstream.com/youtube.html?newsanchor=MansoorAliKhan)  
-- [Dr. Moeed Pirzada](https://pakstream.com/youtube.html?newsanchor=MoeedPirzada)  
-- [Mubasher Lucman](https://pakstream.com/youtube.html?newsanchor=MubasherLucman)  
-- [Faisal Warraich](https://pakstream.com/youtube.html?newsanchor=FaisalWarraich)  
-- [Abdul Qadir](https://pakstream.com/youtube.html?newsanchor=AbdulQadir)  
-- [Ansar Abbasi](https://pakstream.com/youtube.html?newsanchor=AnsarAbbasi)  
-- [Asma Shirazi](https://pakstream.com/youtube.html?newsanchor=AsmaShirazi)  
-- [Arshad Sharif](https://pakstream.com/youtube.html?newsanchor=ArshadSharif) (may Allah bless his soul)  
-- [Nasim Zehra](https://pakstream.com/youtube.html?newsanchor=NasimZehra)  
-- [Rauf Klasra](https://pakstream.com/youtube.html?newsanchor=RaufKlasra)  
-- [Syed Zaid Zaman Hamid](https://pakstream.com/youtube.html?newsanchor=ZaidHamid)  
-- [Taimur Rahman (Laal)](https://pakstream.com/youtube.html?newsanchor=TaimurRahman)  
-- [Syed Ali Haider](https://pakstream.com/youtube.html?newsanchor=AliHaider)  
-- [Siddique Jaan](https://pakstream.com/youtube.html?newsanchor=SiddiqueJaan)  
-- [Usama Ghazi](https://pakstream.com/youtube.html?newsanchor=UsamaGhazi)  
-- [Jameel Farooqui](https://pakstream.com/youtube.html?newsanchor=JameelFarooqui)  
-- [Waqar Malik](https://pakstream.com/youtube.html?newsanchor=WaqarMalik)  
-- [Syed Muzammil](https://pakstream.com/youtube.html?newsanchor=Muzammil)  
-- [Naya Daur TV](https://pakstream.com/youtube.html?newsanchor=NayaDaurTV)  
+- [Imran Riaz Khan](https://pakstream.com/freepress.html?newsanchor=ImranRiazKhan)  
+- [Sabir Shakir](https://pakstream.com/freepress.html?newsanchor=SabirShakir)  
+- [Sami Abraham](https://pakstream.com/freepress.html?newsanchor=SamiAbraham)  
+- [Mansoor Ali Khan](https://pakstream.com/freepress.html?newsanchor=MansoorAliKhan)  
+- [Dr. Moeed Pirzada](https://pakstream.com/freepress.html?newsanchor=MoeedPirzada)  
+- [Mubasher Lucman](https://pakstream.com/freepress.html?newsanchor=MubasherLucman)  
+- [Faisal Warraich](https://pakstream.com/freepress.html?newsanchor=FaisalWarraich)  
+- [Abdul Qadir](https://pakstream.com/freepress.html?newsanchor=AbdulQadir)  
+- [Ansar Abbasi](https://pakstream.com/freepress.html?newsanchor=AnsarAbbasi)  
+- [Asma Shirazi](https://pakstream.com/freepress.html?newsanchor=AsmaShirazi)  
+- [Arshad Sharif](https://pakstream.com/freepress.html?newsanchor=ArshadSharif) (may Allah bless his soul)  
+- [Nasim Zehra](https://pakstream.com/freepress.html?newsanchor=NasimZehra)  
+- [Rauf Klasra](https://pakstream.com/freepress.html?newsanchor=RaufKlasra)  
+- [Syed Zaid Zaman Hamid](https://pakstream.com/freepress.html?newsanchor=ZaidHamid)  
+- [Taimur Rahman (Laal)](https://pakstream.com/freepress.html?newsanchor=TaimurRahman)  
+- [Syed Ali Haider](https://pakstream.com/freepress.html?newsanchor=AliHaider)  
+- [Siddique Jaan](https://pakstream.com/freepress.html?newsanchor=SiddiqueJaan)  
+- [Usama Ghazi](https://pakstream.com/freepress.html?newsanchor=UsamaGhazi)  
+- [Jameel Farooqui](https://pakstream.com/freepress.html?newsanchor=JameelFarooqui)  
+- [Waqar Malik](https://pakstream.com/freepress.html?newsanchor=WaqarMalik)  
+- [Syed Muzammil](https://pakstream.com/freepress.html?newsanchor=Muzammil)  
+- [Naya Daur TV](https://pakstream.com/freepress.html?newsanchor=NayaDaurTV)  
 
 Each name links to the latest videos, so you can just open the page and watch what’s new, no searching, no subscriptions required.
 
@@ -94,9 +94,9 @@ PakStream isn’t backed by sponsors or companies. It’s a labor of love. A sma
 
 In a world full of misinformation and political noise, finding real, honest reporting is not easy. That’s why I made this tool, for myself and for every Pakistani living far from home but still deeply connected to it.
 
-Visit [PakStream](https://www.pakstream.com), explore the YouTube section, and see if it makes your daily news experience smoother and smarter. And if it does, share it with your friends abroad. Let’s help each other stay informed and connected.
+Visit [PakStream](https://www.pakstream.com), explore the Free Press section, and see if it makes your daily news experience smoother and smarter. And if it does, share it with your friends abroad. Let’s help each other stay informed and connected.
 
-If you're looking to [watch Pakistani TV channels live](/tv.html), check out our TV section where you can stream Urdu news and dramas online. We’ve also shared why we added [Pakistani live TV channels to PakStream](/blog/2025/08/01/pakistani-live-tv.html).
+If you're looking to [watch Pakistani TV channels live](/livetv.html), check out our TV section where you can stream Urdu news and dramas online. We’ve also shared why we added [Pakistani live TV channels to PakStream](/blog/2025/08/01/pakistani-live-tv.html).
 
 ---
 

--- a/_posts/2025-08-01-pakistani-live-tv.md
+++ b/_posts/2025-08-01-pakistani-live-tv.md
@@ -27,7 +27,7 @@ It’s frustrating, especially when all you want is to quickly catch up on what�
 
 Since I was already building [PakStream](https://www.pakstream.com) to stream Pakistani FM radio and curate reliable YouTube journalists, I figured, why not add **live TV channels** too?
 
-Just like the radio and YouTube sections, I wanted this to be:
+Just like the radio and Free Press sections, I wanted this to be:
 
 - **Clean**  
 - **One-click easy**  
@@ -55,7 +55,7 @@ Each one opens in a separate, mobile-friendly player, so whether you’re at wor
 👉 **Explore the TV section now:**
 [https://www.pakstream.com](https://www.pakstream.com)
 
-Looking for commentary beyond TV? Visit our [YouTube news section](/youtube.html) or read about [Pakistani YouTubers for news that every expat should follow](/blog/2025/07/31/youtubers-for-news.html).
+Looking for commentary beyond TV? Visit our [Free Press news section](/freepress.html) or read about [Pakistani YouTubers for news that every expat should follow](/blog/2025/07/31/youtubers-for-news.html).
 
 ## Built for People Like Us
 

--- a/about.html
+++ b/about.html
@@ -61,8 +61,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/contact.html
+++ b/contact.html
@@ -62,8 +62,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/freepress.html
+++ b/freepress.html
@@ -2,29 +2,29 @@
 <html lang="en">
 <head>
   <!-- Standard Meta -->
-  <title>PakStream YouTube - Watch Independent Pakistani News YouTubers</title>
+  <title>PakStream Free Press - Watch Independent Pakistani News YouTubers</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <meta name="title" content="PakStream YouTube - Watch Independent Pakistani News YouTubers">
+  <meta name="title" content="PakStream Free Press - Watch Independent Pakistani News YouTubers">
   <meta name="description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://pakstream.com/youtube.html" />
+  <link rel="canonical" href="https://pakstream.com/freepress.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://pakstream.com/youtube.html">
-  <meta property="og:title" content="PakStream YouTube - Watch Independent Pakistani News YouTubers">
+  <meta property="og:url" content="https://pakstream.com/freepress.html">
+  <meta property="og:title" content="PakStream Free Press - Watch Independent Pakistani News YouTubers">
   <meta property="og:description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta property="og:site_name" content="PakStream">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="https://pakstream.com/youtube.html">
-  <meta name="twitter:title" content="PakStream YouTube - Watch Independent Pakistani News YouTubers">
+  <meta name="twitter:url" content="https://pakstream.com/freepress.html">
+  <meta name="twitter:title" content="PakStream Free Press - Watch Independent Pakistani News YouTubers">
   <meta name="twitter:description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta name="twitter:site" content="@PakStream">
@@ -61,8 +61,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>
@@ -74,7 +74,7 @@
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
-  <!-- YouTube section with channel list and video player -->
+  <!-- Free Press section with channel list and video player -->
   <section class="youtube-section">
     <div class="channel-list">
       <div class="channel-card active" data-channel-id="UCaszgR2TH3qNw_CxLHAd2SQ">Imran&nbsp;Riaz&nbsp;Khan</div>

--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>
@@ -147,14 +147,14 @@
       <li>Drama serials and morning shows</li>
       <li>Works on any browser – no app required</li>
     </ul>
-    <p><a href="/tv.html">Watch live Pakistani channels</a></p>
+    <p><a href="/livetv.html">Watch live Pakistani channels</a></p>
   </section>
 
   <section class="youtube-home">
     <h3>Independent YouTube Voices from Pakistan</h3>
     <p>We bring you hand-picked YouTube channels from across Pakistan — from journalists and commentators to vloggers and analysts.</p>
     <p>Whether you want political insight, comedy, or cultural commentary — our YouTubers keep you informed and entertained.</p>
-    <p><a href="/youtube.html">Explore Pakistani YouTubers</a></p>
+    <p><a href="/freepress.html">Explore Pakistani YouTubers</a></p>
   </section>
 
   <section class="blog-section">

--- a/livetv.html
+++ b/livetv.html
@@ -2,29 +2,29 @@
 <html lang="en">
 <head>
   <!-- Standard Meta -->
-  <title>PakStream TV - Watch Pakistani TV Channels Live</title>
+  <title>PakStream Live TV - Watch Pakistani TV Channels Live</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-  <meta name="title" content="PakStream TV - Watch Pakistani TV Channels Live" />
+  <meta name="title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
   <meta name="description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
   <meta name="author" content="PakStream by Chatdroid AB" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://pakstream.com/tv.html" />
+  <link rel="canonical" href="https://pakstream.com/livetv.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://pakstream.com/tv.html" />
-  <meta property="og:title" content="PakStream TV - Watch Pakistani TV Channels Live" />
+  <meta property="og:url" content="https://pakstream.com/livetv.html" />
+  <meta property="og:title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
   <meta property="og:description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg" />
   <meta property="og:site_name" content="PakStream" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="https://pakstream.com/tv.html" />
-  <meta name="twitter:title" content="PakStream TV - Watch Pakistani TV Channels Live" />
+  <meta name="twitter:url" content="https://pakstream.com/livetv.html" />
+  <meta name="twitter:title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
   <meta name="twitter:description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg" />
   <meta name="twitter:site" content="@PakStream" />
@@ -60,8 +60,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -60,8 +60,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/nav.html
+++ b/nav.html
@@ -13,8 +13,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/privacy.html
+++ b/privacy.html
@@ -62,8 +62,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/radio.html
+++ b/radio.html
@@ -61,8 +61,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,13 +10,13 @@
     <loc>https://pakstream.com/ads.txt</loc>
   </url>
   <url>
-    <loc>https://pakstream.com/youtube.html</loc>
+    <loc>https://pakstream.com/freepress.html</loc>
   </url>
   <url>
     <loc>https://pakstream.com/radio.html</loc>
   </url>
   <url>
-    <loc>https://pakstream.com/tv.html</loc>
+    <loc>https://pakstream.com/livetv.html</loc>
   </url>
   <url>
     <loc>https://pakstream.com/about.html</loc>

--- a/terms.html
+++ b/terms.html
@@ -62,8 +62,8 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
         <a href="/">Home</a>
-        <a href="/youtube.html">YouTube</a>
-        <a href="/tv.html">TV</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>


### PR DESCRIPTION
## Summary
- Rename TV page and navigation tab to **Live TV** and update canonical metadata
- Rebrand YouTube tab as **Free Press**, renaming page and internal references
- Refresh sitemap and site-wide links to point to the new pages

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689bb8cc5b7c8320bfc0f0ce2b624b25