### PR TITLE
Auto-select top channel in Live TV and Free Press

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -408,17 +408,18 @@
   // Read anchor from URL
   const urlParams = new URLSearchParams(window.location.search);
   const anchorKey = urlParams.get('newsanchor');
+  const defaultCard = document.querySelector('.channel-card');
 
   if (anchorKey && anchorMap[anchorKey]) {
     const targetId = anchorMap[anchorKey];
-    const matchedCard = Array.from(cards).find(card => card.dataset.channelId === targetId);
+    const matchedCard = document.querySelector(`.channel-card[data-channel-id="${targetId}"]`);
     if (matchedCard) {
       handleChannelClick(matchedCard);
-    } else {
-      handleChannelClick(cards[0]);
+    } else if (defaultCard) {
+      handleChannelClick(defaultCard);
     }
-  } else {
-  handleChannelClick(cards[0]);
+  } else if (defaultCard) {
+    handleChannelClick(defaultCard);
   }
 </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>

--- a/livetv.html
+++ b/livetv.html
@@ -443,8 +443,9 @@
       vsh: 'vsh'
     };
     const urlParams = new URLSearchParams(window.location.search);
-    const initialChannel = tvAnchorMap[urlParams.get('tvchannel')] || 'geo';
-    if (!urlParams.has('tvchannel')) {
+    const defaultChannel = document.querySelector('.channel-card')?.dataset.id;
+    const initialChannel = tvAnchorMap[urlParams.get('tvchannel')] || defaultChannel;
+    if (!urlParams.has('tvchannel') && initialChannel) {
       history.replaceState(null, '', `${window.location.pathname}?tvchannel=${initialChannel}`);
     }
 
@@ -472,7 +473,10 @@
     window.onYouTubeIframeAPIReady = function() {
       const initialCard = document.querySelector(`.channel-card[data-id="${initialChannel}"]`) ||
         document.querySelector('.channel-card');
-      showStream(initialChannel, initialCard, true);
+      const channelId = initialCard?.dataset.id;
+      if (channelId) {
+        showStream(channelId, initialCard, true);
+      }
     };
 
     function showStream(id, element, muteOnLoad = false) {


### PR DESCRIPTION
## Summary
- Start Live TV with the first channel in the list, respecting favorites
- Ensure Free Press loads the top creator when landing on the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbba28ca4832088b19fd64bc8cd9a