### PR TITLE
Add swipe-to-close gesture for channel menus on mobile

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -405,6 +405,23 @@
     }
   });
 
+  // Allow swipe left to close the channel list on touch devices
+  let touchStartX = null;
+  const channelList = document.querySelector('.channel-list');
+  channelList.addEventListener('touchstart', (e) => {
+    if (!channelList.classList.contains('open')) return;
+    touchStartX = e.touches[0].clientX;
+  });
+  channelList.addEventListener('touchend', (e) => {
+    if (touchStartX === null) return;
+    const touchEndX = e.changedTouches[0].clientX;
+    if (touchStartX - touchEndX > 50) {
+      channelList.classList.remove('open');
+      document.getElementById('toggle-channels').textContent = 'Channels';
+    }
+    touchStartX = null;
+  });
+
   // Read anchor from URL
   const urlParams = new URLSearchParams(window.location.search);
   const anchorKey = urlParams.get('newsanchor');

--- a/livetv.html
+++ b/livetv.html
@@ -537,6 +537,23 @@
         btn.textContent = 'Channels';
       }
     });
+
+    // Allow swipe left to close the channel list on touch devices
+    let touchStartX = null;
+    const channelList = document.querySelector('.channel-list');
+    channelList.addEventListener('touchstart', (e) => {
+      if (!channelList.classList.contains('open')) return;
+      touchStartX = e.touches[0].clientX;
+    });
+    channelList.addEventListener('touchend', (e) => {
+      if (touchStartX === null) return;
+      const touchEndX = e.changedTouches[0].clientX;
+      if (touchStartX - touchEndX > 50) {
+        channelList.classList.remove('open');
+        document.getElementById('toggle-channels').textContent = 'Channels';
+      }
+      touchStartX = null;
+    });
   </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/main.js"></script>


### PR DESCRIPTION
## Summary
- enable left-swipe gesture to close channel list on mobile for Free Press page
- enable left-swipe gesture to close channel list on mobile for Live TV page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbe749b2083209a9e77cdfe16c079