### PR TITLE
Fix mobile nav active link contrast

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -684,6 +684,12 @@ table tbody tr.favorite {
     padding: 8px 0;
   }
 
+  .top-bar nav a:hover,
+  .top-bar nav a:focus,
+  .top-bar nav a.active {
+    color: var(--accent-link);
+  }
+
   .nav-overlay {
     position: fixed;
     top: 56px;


### PR DESCRIPTION
## Summary
- Ensure selected navigation links remain visible in the mobile sidebar by using the accent color for hover, focus, and active states.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbf0b91488320a2803691b5c5265f