### PR TITLE
feat: enable swipe-right gesture to open channel list

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -422,6 +422,30 @@
     touchStartX = null;
   });
 
+  // Allow swipe right from the screen edge to open the channel list on touch devices
+  let openStartX = null;
+  document.addEventListener('touchstart', (e) => {
+    if (channelList.classList.contains('open')) return;
+    openStartX = e.touches[0].clientX;
+  });
+  document.addEventListener('touchmove', (e) => {
+    if (openStartX === null) return;
+    const currentX = e.touches[0].clientX;
+    if (openStartX < 50 && currentX - openStartX > 10) {
+      e.preventDefault();
+    }
+  }, { passive: false });
+  document.addEventListener('touchend', (e) => {
+    if (channelList.classList.contains('open')) return;
+    if (openStartX === null) return;
+    const touchEndX = e.changedTouches[0].clientX;
+    if (touchEndX - openStartX > 50 && openStartX < 50) {
+      channelList.classList.add('open');
+      document.getElementById('toggle-channels').textContent = 'Close Channels';
+    }
+    openStartX = null;
+  });
+
   // Read anchor from URL
   const urlParams = new URLSearchParams(window.location.search);
   const anchorKey = urlParams.get('newsanchor');

--- a/livetv.html
+++ b/livetv.html
@@ -554,6 +554,30 @@
       }
       touchStartX = null;
     });
+
+    // Allow swipe right from the screen edge to open the channel list on touch devices
+    let openStartX = null;
+    document.addEventListener('touchstart', (e) => {
+      if (channelList.classList.contains('open')) return;
+      openStartX = e.touches[0].clientX;
+    });
+    document.addEventListener('touchmove', (e) => {
+      if (openStartX === null) return;
+      const currentX = e.touches[0].clientX;
+      if (openStartX < 50 && currentX - openStartX > 10) {
+        e.preventDefault();
+      }
+    }, { passive: false });
+    document.addEventListener('touchend', (e) => {
+      if (channelList.classList.contains('open')) return;
+      if (openStartX === null) return;
+      const touchEndX = e.changedTouches[0].clientX;
+      if (touchEndX - openStartX > 50 && openStartX < 50) {
+        channelList.classList.add('open');
+        document.getElementById('toggle-channels').textContent = 'Close Channels';
+      }
+      openStartX = null;
+    });
   </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/main.js"></script>


### PR DESCRIPTION
## Summary
- Allow opening channel list with a right swipe from screen edge on Free Press page
- Mirror swipe-right gesture on Live TV page for consistent navigation
- Prevent browser back navigation when performing edge swipe

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbffff95483209913633088b87d2b