### PR TITLE
Right-align favorite icons in channel lists

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -254,13 +254,16 @@ section {
   gap: 8px;
 }
 
+.youtube-section .channel-card .channel-name {
+  flex: 1;
+}
+
 .youtube-section .channel-card .fav-btn {
   background: none;
   border: none;
   cursor: pointer;
   color: inherit;
   padding: 0;
-  margin-left: 8px;
   font-size: 20px;
 }
 


### PR DESCRIPTION
## Summary
- Ensure favorite icons in Free Press and Live TV channel lists stay at the right edge by growing the channel name to fill available space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c68b6c87c8320a42ff6dd2e433bec