### PR TITLE
Unify left menu styling across media pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -258,13 +258,18 @@ section {
   flex: 1;
 }
 
-.youtube-section .channel-card .fav-btn {
+.youtube-section .channel-card .fav-btn,
+.youtube-section .channel-card .play-btn {
   background: none;
   border: none;
   cursor: pointer;
   color: inherit;
   padding: 0;
   font-size: 20px;
+}
+
+.youtube-section .channel-card .play-btn {
+  position: relative;
 }
 
 .youtube-section .channel-card:hover {
@@ -405,10 +410,6 @@ button:hover,
   transform: scale(1.03);
   transition: transform 0.2s ease, background-color 0.2s ease;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
-}
-
-.play-btn {
-  display: none;
 }
 
 .play-pause-btn {

--- a/radio.html
+++ b/radio.html
@@ -79,179 +79,179 @@
     <div class="channel-list">
       
         
-<div class="channel-card"><span class="station-name">Hum FM 106.2</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio35" preload="none" data-logo="/images/stations/hum.png" src="https://server.mediacast4u.stream/8002/stream"></audio>
+<div class="channel-card"><span class="channel-name">Hum FM 106.2</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio35" preload="none" data-logo="/images/stations/hum.png" src="https://server.mediacast4u.stream/8002/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Lahore MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio83" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">Lahore MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio83" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Mirpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio100" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8078/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Mirpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio100" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8078/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Peshawar</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio95" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Peshawar</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio95" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8070/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Mithi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio21" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8052/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Mithi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio21" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8052/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 94.4</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio32" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">FM 94.4</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio32" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">MW 639 Karachi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio90" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/MW639khi?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">MW 639 Karachi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio90" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7000/MW639khi?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Multan MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio42" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Multan MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio42" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8034/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Peshawar MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio96" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8072/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">Peshawar MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio96" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8072/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Quetta MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio93" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8060/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">Quetta MW</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio93" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8060/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Azad Kashmir Radio Mirpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio103" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">Azad Kashmir Radio Mirpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio103" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Khairpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio89" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8054/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Khairpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio89" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8054/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Khuzdar MW 567</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio94" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8062/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Khuzdar MW 567</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio94" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8062/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Bahawalpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio79" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8020/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Bahawalpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio79" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8020/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Saut-ul-Quran</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio67" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Saut-ul-Quran</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio67" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">SOUTUL QURAN PBC FM 93.4 ISLAMABAD</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio61" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">SOUTUL QURAN PBC FM 93.4 ISLAMABAD</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio61" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7002/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Pakistan World Service</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio57" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream"></audio>
+<div class="channel-card"><span class="channel-name">Radio Pakistan World Service</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio57" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Pakistan WS</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio58" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Radio Pakistan WS</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio58" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7005/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Islamabad Station</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio69" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Islamabad Station</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio69" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 92</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio31" preload="none" data-logo="/images/default_radio.png" src="https://s33.myradiostream.com:13872/listen.m4a"></audio>
+<div class="channel-card"><span class="channel-name">FM 92</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio31" preload="none" data-logo="/images/default_radio.png" src="https://s33.myradiostream.com:13872/listen.m4a"></audio>
         </div>
-<div class="channel-card"><span class="station-name">fm...</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio30" preload="none" data-logo="/images/default_radio.png" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio>
+<div class="channel-card"><span class="channel-name">fm...</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio30" preload="none" data-logo="/images/default_radio.png" src="https://n0e.radiojar.com/htnudfgugm8uv?rj-ttl=5&amp;rj-tok=AAABmGW6hMEAMlJqXcyhsglOrw"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Hyderabad MW 1008KHz</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio87" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8042/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Hyderabad MW 1008KHz</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio87" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8042/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Sargodha</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio86" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8040/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Sargodha</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio86" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8040/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Abbotabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio98" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8064/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Abbotabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio98" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8064/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Hyderabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio88" preload="none" data-logo="/images/stations/hyderabad-fm.png" src="https://whmsonic.radio.gov.pk:8044/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Hyderabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio88" preload="none" data-logo="/images/stations/hyderabad-fm.png" src="https://whmsonic.radio.gov.pk:8044/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Multan</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio84" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Multan</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio84" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Love-Islam-Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio39" preload="none" data-logo="/images/default_radio.png" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio>
+<div class="channel-card"><span class="channel-name">Love-Islam-Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio39" preload="none" data-logo="/images/default_radio.png" src="https://stream-179.zeno.fm/f9h69cgbu68uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJmOWg2OWNnYnU2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoidlJJYUZfdGRTemFUNEx4R3hkQTdqQSIsImlhdCI6MTc1NDAyMzc4NiwiZXhwIjoxNzU0MDIzODQ2fQ.UrOJY6xoG5HyvkZCUDw2v_CC9RiZWCNvgWbeAaH3MPs"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Mirpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio45" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">Radio Mirpur</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio45" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8074/?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">All4Masti</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio6" preload="none" data-logo="/images/default_radio.png" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio>
+<div class="channel-card"><span class="channel-name">All4Masti</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio6" preload="none" data-logo="/images/default_radio.png" src="https://stream-158.zeno.fm/bahhkuge5zhvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJiYWhoa3VnZTV6aHZ2IiwiaG9zdCI6InN0cmVhbS0xNTguemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYkhQcHBMQTVRYnlyNGpjdlc1V2NaZyIsImlhdCI6MTc1Mzk5OTI2NiwiZXhwIjoxNzUzOTk5MzI2fQ.HifeijiDD3rrC9SBwW0DkSH-PDSZNITtHh5jwUQlXCc"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Planet FM 87.6</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio68" preload="none" data-logo="/images/stations/planet-87-6.png" src="https://whmsonic.radio.gov.pk:7042/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Planet FM 87.6</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio68" preload="none" data-logo="/images/stations/planet-87-6.png" src="https://whmsonic.radio.gov.pk:7042/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">ILM Radio Renala FM 92</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio36" preload="none" data-logo="/images/default_radio.png" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio>
+<div class="channel-card"><span class="channel-name">ILM Radio Renala FM 92</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio36" preload="none" data-logo="/images/default_radio.png" src="https://stream-176.zeno.fm/7wre21u7xa0uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiI3d3JlMjF1N3hhMHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoibGtRdkI4bkFUTzZGd1VvUjdqN2hHQSIsImlhdCI6MTc1NDAyNjY1MSwiZXhwIjoxNzU0MDI2NzExfQ.F9HyNOL8e9-ALqTf48RhmxMEmXy8QVhifUpD1nlsIqQ"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Pakistan Toronto</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio64" preload="none" data-logo="/images/stations/pakistan-toronto.png" src="https://s3.radio.co/s3b10a57ef/listen"></audio>
+<div class="channel-card"><span class="channel-name">Radio Pakistan Toronto</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio64" preload="none" data-logo="/images/stations/pakistan-toronto.png" src="https://s3.radio.co/s3b10a57ef/listen"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Shopen Anime Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio60" preload="none" data-logo="/images/default_radio.png" src="https://s97.radiolize.com:8040/radio.mp3"></audio>
+<div class="channel-card"><span class="channel-name">Shopen Anime Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio60" preload="none" data-logo="/images/default_radio.png" src="https://s97.radiolize.com:8040/radio.mp3"></audio>
         </div>
-<div class="channel-card"><span class="station-name">NCAC</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio70" preload="none" data-logo="/images/stations/ncac.png" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">NCAC</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio70" preload="none" data-logo="/images/stations/ncac.png" src="https://whmsonic.radio.gov.pk:7004/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">External Service</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio72" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7006/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">External Service</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio72" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7006/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Chalte Chalte</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio75" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7008/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Chalte Chalte</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio75" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7008/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Technology channel</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio74" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8094/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Technology channel</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio74" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8094/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Sports & Health Channel</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio73" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7007/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">Sports & Health Channel</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio73" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7007/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Karachi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio24" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7022/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Karachi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio24" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7022/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Lahore</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio25" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8088/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Lahore</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio25" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8088/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Rawalpindi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio28" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8036/relay"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Rawalpindi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio28" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8036/relay"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Faisalabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio23" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8022/relay"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Faisalabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio23" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8022/relay"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Multan</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio27" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Multan</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio27" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8032/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Mianwali</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio26" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8028/relay"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Mianwali</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio26" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8028/relay"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 93 Chitral</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio22" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8066/relay"></audio>
+<div class="channel-card"><span class="channel-name">FM 93 Chitral</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio22" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8066/relay"></audio>
         </div>
-<div class="channel-card"><span class="station-name">#radio quran</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio1" preload="none" data-logo="/images/default_radio.png" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio>
+<div class="channel-card"><span class="channel-name">#radio quran</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio1" preload="none" data-logo="/images/default_radio.png" src="https://n13.radiojar.com/0tpy1h0kxtzuv?rj-ttl=5&amp;rj-tok=AAABmGWzgMEA_wJ70s6N_TYhlA"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Quetta</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio92" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8058/stream?type=http&amp;nocache=12"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Quetta</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio92" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8058/stream?type=http&amp;nocache=12"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Sialkot</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio85" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8038/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Sialkot</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio85" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8038/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">SAMAA FM Peshawar 107.4</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio65" preload="none" data-logo="/images/default_radio.png" src="https://samaapew107-itelservices.radioca.st/stream"></audio>
+<div class="channel-card"><span class="channel-name">SAMAA FM Peshawar 107.4</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio65" preload="none" data-logo="/images/default_radio.png" src="https://samaapew107-itelservices.radioca.st/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">100 FM (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2001" preload="none" data-logo="/images/stations/100-lahore.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">100 FM (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2001" preload="none" data-logo="/images/stations/100-lahore.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">101 FM (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2002" preload="none" data-logo="/images/stations/101-fm-karachi.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">101 FM (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2002" preload="none" data-logo="/images/stations/101-fm-karachi.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Aladin Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2003" preload="none" data-logo="/images/stations/aladin.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Aladin Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2003" preload="none" data-logo="/images/stations/aladin.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Apna</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2004" preload="none" data-logo="/images/stations/apna-107.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Apna</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2004" preload="none" data-logo="/images/stations/apna-107.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Apna FM (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2005" preload="none" data-logo="/images/stations/apna-karachi.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Apna FM (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2005" preload="none" data-logo="/images/stations/apna-karachi.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Big FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2006" preload="none" data-logo="/images/stations/big.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Big FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2006" preload="none" data-logo="/images/stations/big.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">City (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2007" preload="none" data-logo="/images/stations/city-karachi.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">City (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2007" preload="none" data-logo="/images/stations/city-karachi.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">City (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2008" preload="none" data-logo="/images/stations/city-lahore.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">City (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2008" preload="none" data-logo="/images/stations/city-lahore.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 100</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2009" preload="none" data-logo="/images/stations/fm-100.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">FM 100</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2009" preload="none" data-logo="/images/stations/fm-100.png" src=""></audio>
         </div>
-        <div class="channel-card"><span class="station-name">FM 91 (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2011" preload="none" data-logo="/images/stations/radio-1.png" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio>
+        <div class="channel-card"><span class="channel-name">FM 91 (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2011" preload="none" data-logo="/images/stations/radio-1.png" src="https://cc.vmakerhost.com/proxy/karachi?mp=/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM Karachi Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2013" preload="none" data-logo="/images/stations/karachi-fm-live.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">FM Karachi Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2013" preload="none" data-logo="/images/stations/karachi-fm-live.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM World</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2014" preload="none" data-logo="/images/stations/fm-world.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">FM World</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2014" preload="none" data-logo="/images/stations/fm-world.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">FunCafe Web Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2015" preload="none" data-logo="/images/stations/funcafe.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">FunCafe Web Radio</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2015" preload="none" data-logo="/images/stations/funcafe.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Hot FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2016" preload="none" data-logo="/images/stations/hot-fm.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Hot FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2016" preload="none" data-logo="/images/stations/hot-fm.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Hot FM (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2017" preload="none" data-logo="/images/stations/hot-karachi.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Hot FM (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2017" preload="none" data-logo="/images/stations/hot-karachi.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Mast (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2018" preload="none" data-logo="/images/stations/mast-karachi.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Mast (Karachi)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2018" preload="none" data-logo="/images/stations/mast-karachi.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Mast FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2019" preload="none" data-logo="/images/stations/mast-fm.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Mast FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2019" preload="none" data-logo="/images/stations/mast-fm.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Mast FM (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2020" preload="none" data-logo="/images/stations/mast-lahore.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Mast FM (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2020" preload="none" data-logo="/images/stations/mast-lahore.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Power FM 99</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2022" preload="none" data-logo="/images/stations/power-99.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Power FM 99</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2022" preload="none" data-logo="/images/stations/power-99.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Awaz</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2023" preload="none" data-logo="/images/stations/awaz-106.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Radio Awaz</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2023" preload="none" data-logo="/images/stations/awaz-106.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2024" preload="none" data-logo="/images/stations/radio.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Radio FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2024" preload="none" data-logo="/images/stations/radio.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Jeevay FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2025" preload="none" data-logo="/images/stations/jeevay.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Radio Jeevay FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2025" preload="none" data-logo="/images/stations/jeevay.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Pak Filmi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2027" preload="none" data-logo="/images/stations/pak-filmi.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Radio Pak Filmi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2027" preload="none" data-logo="/images/stations/pak-filmi.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Riphah FM (Islamabad)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2028" preload="none" data-logo="/images/stations/riphah.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Riphah FM (Islamabad)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2028" preload="none" data-logo="/images/stations/riphah.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Spice</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2029" preload="none" data-logo="/images/stations/spice-fm-107.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Spice</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2029" preload="none" data-logo="/images/stations/spice-fm-107.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Suno Urdu Live</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2030" preload="none" data-logo="/images/stations/suno-urdu-live.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Suno Urdu Live</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2030" preload="none" data-logo="/images/stations/suno-urdu-live.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">Sunrise Radio FM (Hasan Abdal)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2031" preload="none" data-logo="/images/stations/sunrise-hasan-abda.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">Sunrise Radio FM (Hasan Abdal)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2031" preload="none" data-logo="/images/stations/sunrise-hasan-abda.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">VOA Deewa</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2032" preload="none" data-logo="/images/stations/voa-deewa.png" src=""></audio>
+<div class="channel-card"><span class="channel-name">VOA Deewa</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio2032" preload="none" data-logo="/images/stations/voa-deewa.png" src=""></audio>
         </div>
-<div class="channel-card"><span class="station-name">City FM 89</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio8" preload="none" data-logo="/images/stations/city-fm.png" src="https://radio.cityfm89.com/stream"></audio>
+<div class="channel-card"><span class="channel-name">City FM 89</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio8" preload="none" data-logo="/images/stations/city-fm.png" src="https://radio.cityfm89.com/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Islamabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio18" preload="none" data-logo="/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:7008/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Islamabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio18" preload="none" data-logo="/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:7008/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Karachi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio19" preload="none" data-logo="/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:8048/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Karachi</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio19" preload="none" data-logo="/images/stations/fm-101.png" src="https://whmsonic.radio.gov.pk:8048/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">PBC (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio51" preload="none" data-logo="/images/stations/pbc-lahore.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio>
+<div class="channel-card"><span class="channel-name">PBC (Lahore)</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio51" preload="none" data-logo="/images/stations/pbc-lahore.png" src="https://whmsonic.radio.gov.pk:8026/relay?type=http&amp;nocache=9"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Pakistan Islamabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio50" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream"></audio>
+<div class="channel-card"><span class="channel-name">Radio Pakistan Islamabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio50" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:7003/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Samaa FM 107.4</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio59" preload="none" data-logo="/images/default_radio.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio>
+<div class="channel-card"><span class="channel-name">Samaa FM 107.4</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio59" preload="none" data-logo="/images/default_radio.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">Radio Mera FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio40" preload="none" data-logo="/images/stations/mera-1074.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio>
+<div class="channel-card"><span class="channel-name">Radio Mera FM</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio40" preload="none" data-logo="/images/stations/mera-1074.png" src="https://samaakhi107-itelservices.radioca.st/stream"></audio>
         </div>
-<div class="channel-card"><span class="station-name">101 lahore</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio41" preload="none" data-logo="/images/default_radio.png" src="http://101.50.87.129:8004/101lahore"></audio>
+<div class="channel-card"><span class="channel-name">101 lahore</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio41" preload="none" data-logo="/images/default_radio.png" src="http://101.50.87.129:8004/101lahore"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Faisalabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio81" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8024/stream?type=http&nocache=14"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Faisalabad</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio81" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8024/stream?type=http&nocache=14"></audio>
         </div>
-<div class="channel-card"><span class="station-name">FM 101 Larkana</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio20" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8050/stream"></audio>
+<div class="channel-card"><span class="channel-name">FM 101 Larkana</span><button class="play-btn" aria-label="Play"><span class="material-icons">play_arrow</span></button><audio id="audio20" preload="none" data-logo="/images/default_radio.png" src="https://whmsonic.radio.gov.pk:8050/stream"></audio>
         </div>
       
     </div>
@@ -365,7 +365,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // Insert station logos into each row
   document.querySelectorAll('audio[data-logo]').forEach(audio => {
     const card = audio.closest('.channel-card');
-    const name = card.querySelector('.station-name');
+    const name = card.querySelector('.channel-name');
     const img = document.createElement('img');
     img.src = audio.dataset.logo || defaultLogo;
     img.alt = '';
@@ -516,7 +516,7 @@ document.addEventListener('DOMContentLoaded', function() {
   playButtons.forEach(btn => {
     const audio = btn.parentElement.querySelector('audio');
     const card = btn.closest('.channel-card');
-      const name = card.querySelector('.station-name').textContent;
+      const name = card.querySelector('.channel-name').textContent;
     btn.classList.remove('material-icons');
     btn.setAttribute('type', 'button');
     btn.setAttribute('aria-label', 'Play');
@@ -558,7 +558,7 @@ document.addEventListener('DOMContentLoaded', function() {
       idx = (idx + offset + audios.length) % audios.length;
     }
     const audio = audios[idx];
-    const name = audio.closest('.channel-card').querySelector('.station-name').textContent;
+    const name = audio.closest('.channel-card').querySelector('.channel-name').textContent;
     const btn = audio.parentElement.querySelector('.play-btn');
     resetButton(currentBtn);
     loadStation(audio, name, btn);
@@ -659,7 +659,7 @@ document.addEventListener('DOMContentLoaded', function() {
   if (initial) {
     const audio = document.getElementById(initial);
     if (audio) {
-      const name = audio.closest('.channel-card').querySelector('.station-name').textContent;
+      const name = audio.closest('.channel-card').querySelector('.channel-name').textContent;
       const btn = audio.parentElement.querySelector('.play-btn');
       resetButton(currentBtn);
       loadStation(audio, name, btn);
@@ -670,7 +670,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const firstCard = cards[0];
       const audio = firstCard.querySelector('audio');
       const btn = firstCard.querySelector('.play-btn');
-      const name = firstCard.querySelector('.station-name').textContent;
+      const name = firstCard.querySelector('.channel-name').textContent;
       resetButton(currentBtn);
       loadStation(audio, name, btn);
     }


### PR DESCRIPTION
## Summary
- Style play buttons the same as favorites and make them visible
- Switch radio station entries to use the shared `channel-name` class for layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c69e59e9483208be12180dd6409c6