### PR TITLE
Unify favorite button classes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -258,7 +258,8 @@ section {
   flex: 1;
 }
 
-.youtube-section .channel-card .fav-btn,
+
+.fav-btn,
 .youtube-section .channel-card .play-btn {
   background: none;
   border: none;
@@ -286,7 +287,7 @@ section {
   color: var(--on-primary);
 }
 
-.youtube-section .channel-card.favorite .fav-btn {
+.channel-card.favorite .fav-btn {
   color: var(--on-primary);
 }
 

--- a/radio.html
+++ b/radio.html
@@ -266,13 +266,13 @@
             <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
           </div>
           <div class="controls">
-            <button id="favorite-btn" class="favorite-btn material-icons" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
-            <button id="prev-btn" class="fav-nav-btn material-icons" type="button" aria-label="Previous station" disabled>skip_previous</button>
+            <button id="favorite-btn" class="fav-btn material-icons" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
+            <button id="prev-btn" class="fav-btn material-icons" type="button" aria-label="Previous station" disabled>skip_previous</button>
             <button id="play-pause-btn" class="play-pause-btn" type="button" aria-label="Play or pause" disabled>
               <span class="material-icons label">play_arrow</span>
               <span class="spinner"></span>
             </button>
-            <button id="next-btn" class="fav-nav-btn material-icons" type="button" aria-label="Next station" disabled>skip_next</button>
+            <button id="next-btn" class="fav-btn material-icons" type="button" aria-label="Next station" disabled>skip_next</button>
             <button id="mute-btn" class="mute-btn material-icons" type="button" aria-label="Mute" disabled>volume_up</button>
             <audio id="radio-player" autoplay></audio>
           </div>


### PR DESCRIPTION
## Summary
- Consolidate favorite-related buttons under a single `fav-btn` class across pages
- Introduce global `.fav-btn` rule and streamline channel-card favorite styling

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c1efd188320b477ad70a9ccface