### PR TITLE
Unify channel list items and favorite styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+:root {
+  --logo-placeholder: url("data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><rect width="40" height="40" rx="20" fill="%23BDBDBD"/></svg>");
+}
+
 /* Refactored style.css with improved readability & polished UI/UX */
 /* Roboto font loaded asynchronously via HTML link tags */
 
@@ -252,6 +256,17 @@ section {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.channel-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-image: var(--logo-placeholder);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  flex-shrink: 0;
 }
 
 .youtube-section .channel-card .channel-name {

--- a/css/theme.css
+++ b/css/theme.css
@@ -29,7 +29,7 @@
   --accent-link: #1E88E5;
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
-  --favorite-row: #2E7D32;
+  --favorite-row: #00796b;
   --hover-primary: #00695C;
   --hover-link: #1565C0;
 }
@@ -63,7 +63,7 @@
   --accent-link: #1565C0;
   --accent-success: #66BB6A;
   --accent-info: #81D4FA;
-  --favorite-row: #2E7D32;
+  --favorite-row: #00796b;
   --hover-primary: #00695C;
   --hover-link: #64B5F6;
 }

--- a/freepress.html
+++ b/freepress.html
@@ -259,8 +259,9 @@
     const playerFrame = document.getElementById('playerFrame');
 
   function setActiveCard(clickedCard) {
-    cards.forEach(c => c.classList.remove('active'));
+    cards.forEach(c => { c.classList.remove('active'); const icon = c.querySelector('.play-btn .material-icons'); if (icon) icon.textContent = 'play_arrow'; });
     clickedCard.classList.add('active');
+    const icon = clickedCard.querySelector('.play-btn .material-icons'); if (icon) icon.textContent = 'stop';
   }
 
   function setActiveVideo(clickedItem) {
@@ -389,6 +390,17 @@
     card.addEventListener('click', () => handleChannelClick(card));
   });
 
+  function toggleFreePress(card) {
+    if (card.classList.contains("active")) {
+      document.getElementById("playerFrame").src = "about:blank";
+      card.classList.remove("active");
+      const icon = card.querySelector(".play-btn .material-icons");
+      if (icon) icon.textContent = "play_arrow";
+    } else {
+      handleChannelClick(card);
+    }
+  }
+
   function toggleChannelList() {
     const list = document.querySelector('.channel-list');
     const btn = document.getElementById('toggle-channels');
@@ -464,6 +476,7 @@
   }
 </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/channel-cards.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/channel-cards.js
+++ b/js/channel-cards.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.channel-list .channel-card').forEach(card => {
+    const name = card.querySelector('.channel-name');
+    const audio = card.querySelector('audio');
+    let fav = card.querySelector('.fav-btn');
+    let play = card.querySelector('.play-btn');
+
+    // Add logo
+    if (!card.querySelector('.channel-logo')) {
+      const logoUrl = card.dataset.logo || audio?.dataset.logo || '';
+      const logo = document.createElement('div');
+      logo.className = 'channel-logo';
+      logo.style.backgroundImage = logoUrl
+        ? `url('${logoUrl}'), var(--logo-placeholder)`
+        : 'var(--logo-placeholder)';
+      card.insertBefore(logo, name);
+    }
+
+    // Add play button if missing
+    if (!play) {
+      play = document.createElement('button');
+      play.className = 'play-btn';
+      play.setAttribute('aria-label', 'Play');
+      const icon = document.createElement('span');
+      icon.className = 'material-icons';
+      icon.textContent = 'play_arrow';
+      play.appendChild(icon);
+      const ref = fav || audio;
+      card.insertBefore(play, ref);
+      if (typeof showStream === 'function' && card.dataset.id) {
+        play.addEventListener('click', e => {
+          e.stopPropagation();
+          toggleChannel(card.dataset.id, play);
+        });
+      } else if (typeof handleChannelClick === 'function' && card.dataset.channelId) {
+        play.addEventListener('click', e => {
+          e.stopPropagation();
+          toggleFreePress(card);
+        });
+      }
+    }
+
+    // Add favorite button if missing
+    if (!fav) {
+      fav = document.createElement('button');
+      fav.className = 'fav-btn material-icons';
+      fav.setAttribute('aria-label', 'Toggle favorite');
+      fav.textContent = 'favorite_border';
+      if (typeof toggleFavorite === 'function') {
+        if (audio) {
+          fav.addEventListener('click', e => toggleFavorite(e, audio.id));
+        } else if (card.dataset.id) {
+          fav.addEventListener('click', e => toggleFavorite(e, card.dataset.id));
+        } else {
+          fav.addEventListener('click', e => toggleFavorite(e));
+        }
+      }
+      card.insertBefore(fav, audio);
+    }
+    if (card.classList.contains('active')) {
+      const icon = card.querySelector('.play-btn .material-icons');
+      if (icon) icon.textContent = 'stop';
+    }
+  });
+  if (typeof updateFavoritesUI === 'function') {
+    updateFavoritesUI();
+  }
+});

--- a/livetv.html
+++ b/livetv.html
@@ -478,13 +478,25 @@
         showStream(channelId, initialCard, true);
       }
     };
+    function toggleChannel(id, btn) {
+      const card = btn.closest(".channel-card");
+      if (card.classList.contains("active")) {
+        const playerId = `${id}-player`;
+        if (players[playerId]?.stopVideo) players[playerId].stopVideo();
+        card.classList.remove("active");
+        btn.querySelector(".material-icons").textContent = "play_arrow";
+        document.getElementById(id).style.display = "none";
+      } else {
+        showStream(id, card);
+      }
+    }
 
     function showStream(id, element, muteOnLoad = false) {
       // Hide all video divs
       document.querySelectorAll('.live-player').forEach(div => div.style.display = 'none');
 
       // Remove active class
-      document.querySelectorAll('.channel-card').forEach(card => card.classList.remove('active'));
+      document.querySelectorAll('.channel-card').forEach(card => { card.classList.remove('active'); const icon = card.querySelector('.play-btn .material-icons'); if (icon) icon.textContent = 'play_arrow'; });
 
       // Pause all players
       for (const key in players) {
@@ -495,7 +507,7 @@
 
       // Show selected stream
       document.getElementById(id).style.display = 'block';
-      if (element) element.classList.add('active');
+      if (element) { element.classList.add('active'); const icon = element.querySelector('.play-btn .material-icons'); if (icon) icon.textContent = 'stop'; }
 
       // Load or play selected stream
       const playerId = `${id}-player`;
@@ -580,6 +592,7 @@
     });
   </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/channel-cards.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -392,7 +392,12 @@ document.addEventListener('DOMContentLoaded', function() {
       const id = audio?.id;
       if (!id) return;
       const isFav = favorites.includes(id);
-      card.classList.toggle('favorite', isFav);
+    card.classList.toggle('favorite', isFav);
+      const favButton = card.querySelector('.fav-btn');
+      if (favButton) {
+        favButton.textContent = isFav ? 'favorite' : 'favorite_border';
+        favButton.classList.toggle('favorited', isFav);
+      }
       (isFav ? favFragment : otherFragment).appendChild(card);
     });
 
@@ -546,6 +551,16 @@ document.addEventListener('DOMContentLoaded', function() {
     localStorage.setItem('radioFavorites', JSON.stringify(favorites));
     updateFavoritesUI();
   });
+  function toggleFavorite(event, id) {
+    event.stopPropagation();
+    const idx = favorites.indexOf(id);
+    if (idx >= 0) favorites.splice(idx, 1);
+    else favorites.push(id);
+    localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+    updateFavoritesUI();
+  }
+  window.toggleFavorite = toggleFavorite;
+
 
   function playStation(offset) {
     const audios = Array.from(document.querySelectorAll('.channel-list audio'));
@@ -709,6 +724,7 @@ channelList.addEventListener('touchend', (e) => {
   touchStartX = null;
 });
   </script>
+  <script defer src="/js/channel-cards.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Standardize channel list entries across Live TV, Free Press, and Radio with shared script for logos, play/stop, and favorite icons
- Replace favorite row highlight with #00796b
- Add SVG placeholder logos and per-item favorite toggling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb24360dc8320993c622f93c5c8fc