### PR TITLE
feat: improve radio station list UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -252,10 +252,15 @@ section {
   display: flex;
   align-items: center;
   gap: 8px;
+  overflow: hidden;
 }
 
 .youtube-section .channel-card .channel-name {
   flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 
@@ -267,6 +272,7 @@ section {
   color: inherit;
   padding: 0;
   font-size: 20px;
+  flex-shrink: 0;
 }
 
 .youtube-section .channel-card .play-btn {
@@ -573,6 +579,10 @@ table tbody tr.favorite {
   object-fit: contain;
   border-radius: 4px;
   flex-shrink: 0;
+}
+
+.station-row-logo.missing {
+  background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2040%2040%27%3E%3Crect%20width%3D%2740%27%20height%3D%2740%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%275%27%20y%3D%2714%27%20width%3D%2730%27%20height%3D%2718%27%20rx%3D%272%27%20ry%3D%272%27%20fill%3D%27%23888888%27/%3E%3Ccircle%20cx%3D%2714%27%20cy%3D%2723%27%20r%3D%274%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%2722%27%20y%3D%2719%27%20width%3D%2710%27%20height%3D%278%27%20fill%3D%27%23BDBDBD%27/%3E%3C/svg%3E") center/cover no-repeat;
 }
 
 /* Post layout */

--- a/css/theme.css
+++ b/css/theme.css
@@ -29,7 +29,7 @@
   --accent-link: #1E88E5;
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
-  --favorite-row: #2E7D32;
+  --favorite-row: #00796B;
   --hover-primary: #00695C;
   --hover-link: #1565C0;
 }
@@ -63,7 +63,7 @@
   --accent-link: #1565C0;
   --accent-success: #66BB6A;
   --accent-info: #81D4FA;
-  --favorite-row: #2E7D32;
+  --favorite-row: #00796B;
   --hover-primary: #00695C;
   --hover-link: #64B5F6;
 }

--- a/radio.html
+++ b/radio.html
@@ -304,7 +304,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const mainPlayer = document.getElementById('radio-player');
   const currentLabel = document.getElementById('current-station');
   const stationLogo = document.getElementById('station-logo');
-  const defaultLogo = '/images/default_radio.png';
+  const defaultLogo = 'data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2040%2040%27%3E%3Crect%20width%3D%2740%27%20height%3D%2740%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%275%27%20y%3D%2714%27%20width%3D%2730%27%20height%3D%2718%27%20rx%3D%272%27%20ry%3D%272%27%20fill%3D%27%23888888%27/%3E%3Ccircle%20cx%3D%2714%27%20cy%3D%2723%27%20r%3D%274%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%2722%27%20y%3D%2719%27%20width%3D%2710%27%20height%3D%278%27%20fill%3D%27%23BDBDBD%27/%3E%3C/svg%3E';
   const liveBadge = document.getElementById('live-badge');
   const notLiveBadge = document.getElementById('not-live-badge');
   const playButtons = Array.from(document.querySelectorAll('.play-btn'));
@@ -362,19 +362,49 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // Insert station logos into each row
+  // Insert station logos and favorite buttons into each row
   document.querySelectorAll('audio[data-logo]').forEach(audio => {
     const card = audio.closest('.channel-card');
     const name = card.querySelector('.channel-name');
+
     const img = document.createElement('img');
-    img.src = audio.dataset.logo || defaultLogo;
     img.alt = '';
     img.className = 'station-row-logo';
     img.width = 40;
     img.height = 40;
     img.loading = 'lazy';
+    const logo = audio.dataset.logo;
+    if (logo && !logo.includes('default_radio.png')) {
+      img.src = logo;
+      img.onerror = () => { img.classList.add('missing'); img.removeAttribute('src'); };
+    } else {
+      img.classList.add('missing');
+    }
     card.insertBefore(img, name);
+
+    const fav = document.createElement('button');
+    fav.className = 'fav-btn material-icons';
+    fav.type = 'button';
+    fav.textContent = 'favorite_border';
+    fav.setAttribute('aria-label', 'Toggle favorite');
+    fav.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const id = audio.id;
+      const idx = favorites.indexOf(id);
+      if (idx >= 0) favorites.splice(idx, 1); else favorites.push(id);
+      localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+      updateFavoritesUI();
+    });
+    card.insertBefore(fav, audio);
+    fitName(name);
   });
+  function fitName(el) {
+    let size = parseFloat(getComputedStyle(el).fontSize);
+    while (el.scrollWidth > el.clientWidth && size > 10) {
+      size -= 1;
+      el.style.fontSize = size + 'px';
+    }
+  }
   let currentBtn = null;
   let pendingBtn = null;
   let resumeHandler = null;
@@ -393,6 +423,8 @@ document.addEventListener('DOMContentLoaded', function() {
       if (!id) return;
       const isFav = favorites.includes(id);
       card.classList.toggle('favorite', isFav);
+      const btn = card.querySelector('.fav-btn');
+      if (btn) btn.textContent = isFav ? 'favorite' : 'favorite_border';
       (isFav ? favFragment : otherFragment).appendChild(card);
     });
 
@@ -466,7 +498,7 @@ document.addEventListener('DOMContentLoaded', function() {
       stationLogo.onerror = null;
       stationLogo.src = defaultLogo;
     };
-    const logoSrc = audio.dataset.logo || defaultLogo;
+    const logoSrc = (audio.dataset.logo && !audio.dataset.logo.includes('default_radio.png')) ? audio.dataset.logo : defaultLogo;
     stationLogo.src = logoSrc;
     stationLogo.hidden = false;
     liveBadge.hidden = true;


### PR DESCRIPTION
## Summary
- Show station logo or SVG placeholder before station name
- Add per-station favorite buttons and use teal highlight for favorites
- Use inline SVG placeholder when station logos are missing
- Prevent long station names from pushing icons out of view by shrinking text and truncating overflow

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb2b944483209d51f942f6d2c301