### PR TITLE
Style live stream list like YouTube

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -802,3 +802,34 @@ footer nav a:hover {
   margin: 20px 0;
   text-align: center;
 }
+
+#stream-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.stream-card a {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.stream-card img {
+  width: 100%;
+  border-radius: 8px;
+  display: block;
+}
+
+.stream-title {
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
+.stream-viewers {
+  font-size: 0.875rem;
+  color: var(--on-surface-variant);
+}

--- a/livetv.html
+++ b/livetv.html
@@ -286,25 +286,64 @@
         .then(res => res.json())
         .then(data => {
           if (data.items && data.items.length > 0) {
-            data.items.forEach(item => {
-              const li = document.createElement('li');
-              const a = document.createElement('a');
-              a.href = '#';
-              a.textContent = item.snippet.title;
-              a.onclick = (e) => {
-                e.preventDefault();
-                const playerId = `${id}-player`;
-                const player = players[playerId];
-                if (player && player.loadVideoById) {
-                  player.loadVideoById(item.id.videoId);
-                } else {
-                  const iframe = document.getElementById(playerId);
-                  iframe.src = `https://www.youtube.com/embed/${item.id.videoId}?${YT_PARAMS}`;
-                }
+            const info = {};
+            const ids = data.items.map(item => {
+              info[item.id.videoId] = {
+                title: item.snippet.title,
+                thumb: (item.snippet.thumbnails.medium && item.snippet.thumbnails.medium.url) || item.snippet.thumbnails.default.url
               };
-              li.appendChild(a);
-              streamList.appendChild(li);
+              return item.id.videoId;
             });
+            const videosUrl = `https://www.googleapis.com/youtube/v3/videos?part=liveStreamingDetails&id=${ids.join(',')}&key=${API_KEY}`;
+            fetch(videosUrl)
+              .then(res => res.json())
+              .then(vData => {
+                ids.forEach(videoId => {
+                  const details = info[videoId];
+                  const v = vData.items.find(i => i.id === videoId) || {};
+                  const viewers = v.liveStreamingDetails && v.liveStreamingDetails.concurrentViewers;
+
+                  const li = document.createElement('li');
+                  li.className = 'stream-card';
+                  const a = document.createElement('a');
+                  a.href = '#';
+
+                  const img = document.createElement('img');
+                  img.src = details.thumb;
+                  img.alt = details.title;
+                  a.appendChild(img);
+
+                  const titleDiv = document.createElement('div');
+                  titleDiv.className = 'stream-title';
+                  titleDiv.textContent = details.title;
+                  a.appendChild(titleDiv);
+
+                  const viewerDiv = document.createElement('div');
+                  viewerDiv.className = 'stream-viewers';
+                  viewerDiv.textContent = viewers ? `${Number(viewers).toLocaleString()} watching` : 'Live';
+                  a.appendChild(viewerDiv);
+
+                  a.onclick = (e) => {
+                    e.preventDefault();
+                    const playerId = `${id}-player`;
+                    const player = players[playerId];
+                    if (player && player.loadVideoById) {
+                      player.loadVideoById(videoId);
+                    } else {
+                      const iframe = document.getElementById(playerId);
+                      iframe.src = `https://www.youtube.com/embed/${videoId}?${YT_PARAMS}`;
+                    }
+                  };
+
+                  li.appendChild(a);
+                  streamList.appendChild(li);
+                });
+              })
+              .catch(() => {
+                const li = document.createElement('li');
+                li.textContent = 'Error fetching stream details.';
+                streamList.appendChild(li);
+              });
           } else {
             const li = document.createElement('li');
             li.textContent = 'No live streams found.';


### PR DESCRIPTION
## Summary
- Fetch YouTube video details to build live stream cards with thumbnails, titles and viewer counts
- Add CSS grid styling so stream list resembles YouTube's live section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cde5b52e08320a612267d90ab976b