### PR TITLE
Switch to Material Symbols and unify Free Press branding

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <!-- Standard Meta -->
-  <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}</title>
+  <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}">
-  <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}">
+  <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
@@ -16,16 +16,16 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ page.url | absolute_url }}">
-  <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}">
-  <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}">
+  <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}">
+  <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta property="og:site_name" content="PakStream">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="{{ page.url | absolute_url }}">
-  <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}">
-  <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}">
+  <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}">
+  <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta name="twitter:site" content="@PakStream">
   <meta name="twitter:creator" content="@PakStream">
@@ -49,7 +49,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <!-- Standard Meta -->
-  <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}</title>
+  <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}</title>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-  <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}" />
-  <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}" />
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
+  <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
+  <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
   <meta name="author" content="PakStream by Chatdroid AB" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
@@ -16,16 +16,16 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ page.url | absolute_url }}" />
-  <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}" />
-  <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}" />
+  <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
+  <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
   <meta property="og:image" content="/assets/pakstream-banner.jpg" />
   <meta property="og:site_name" content="PakStream" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="{{ page.url | absolute_url }}" />
-  <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube' }}" />
-  <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.' }}" />
+  <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
+  <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
   <meta name="twitter:image" content="/assets/pakstream-banner.jpg" />
   <meta name="twitter:site" content="@PakStream" />
   <meta name="twitter:creator" content="@PakStream" />
@@ -49,7 +49,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/about.html
+++ b/about.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Basic Meta Tags -->
   <title>PakStream - About</title>
-  <meta name="description" content="Stream Pakistani TV channels, radio stations, YouTube news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
@@ -12,7 +12,7 @@
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
+  <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
@@ -20,7 +20,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
+  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
@@ -34,7 +34,7 @@
     "name": "PakStream",
     "url": "https://pakstream.com",
     "logo": "/favicon.ico",
-    "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
+    "description": "PakStream aggregates Pakistani radio, TV, and independent news content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
     ],
@@ -50,7 +50,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/contact.html
+++ b/contact.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Basic Meta Tags -->
   <title>PakStream - Contact</title>
-  <meta name="description" content="Stream Pakistani TV channels, radio stations, YouTube news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
@@ -12,7 +12,7 @@
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
+  <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
@@ -20,7 +20,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
+  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
@@ -34,7 +34,7 @@
     "name": "PakStream",
     "url": "https://pakstream.com",
     "logo": "/favicon.ico",
-    "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
+    "description": "PakStream aggregates Pakistani radio, TV, and independent news content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
     ],
@@ -50,7 +50,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/css/style.css
+++ b/css/style.css
@@ -71,10 +71,11 @@ body {
   color: var(--on-primary);
   text-decoration: none;
   font-weight: 500;
+  padding: 12px 14px;
+  border-radius: 10px;
 }
 
 .top-bar nav a:hover,
-.top-bar nav a.active,
 .post-share a:hover,
 footer nav a:hover {
   color: var(--accent-link);
@@ -82,10 +83,14 @@ footer nav a:hover {
 }
 
 .top-bar nav a:hover,
-.top-bar nav a:focus,
-.top-bar nav a.active {
+.top-bar nav a:focus {
   color: var(--on-primary);
   text-decoration: underline;
+}
+
+.top-bar nav a.active,
+.top-bar nav a[aria-current="page"] {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
 }
 
 /* Keep existing styles untouched below here */
@@ -188,7 +193,7 @@ section {
   flex: 1 1 250px;
 }
 
-.feature-card .material-icons {
+.feature-card .material-symbols-outlined {
   font-size: 48px;
   color: var(--primary);
   margin-bottom: 10px;
@@ -683,12 +688,12 @@ table tbody tr.favorite {
   .top-bar nav a {
     color: var(--on-surface);
     display: block;
-    padding: 8px 0;
+    padding: 12px 14px;
+    border-radius: 10px;
   }
 
   .top-bar nav a:hover,
-  .top-bar nav a:focus,
-  .top-bar nav a.active {
+  .top-bar nav a:focus {
     color: var(--accent-link);
   }
 

--- a/freepress.html
+++ b/freepress.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <!-- Standard Meta -->
-  <title>PakStream Free Press - Watch Independent Pakistani News YouTubers</title>
+  <title>PakStream Free Press - Watch Independent Pakistani News Voices</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <meta name="title" content="PakStream Free Press - Watch Independent Pakistani News YouTubers">
-  <meta name="description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
+  <meta name="description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/freepress.html" />
@@ -16,16 +16,16 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://pakstream.com/freepress.html">
-  <meta property="og:title" content="PakStream Free Press - Watch Independent Pakistani News YouTubers">
-  <meta property="og:description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
+  <meta property="og:title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
+  <meta property="og:description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta property="og:site_name" content="PakStream">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://pakstream.com/freepress.html">
-  <meta name="twitter:title" content="PakStream Free Press - Watch Independent Pakistani News YouTubers">
-  <meta name="twitter:description" content="Curated list of political and social Pakistani YouTube journalists and commentators.">
+  <meta name="twitter:title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
+  <meta name="twitter:description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta name="twitter:site" content="@PakStream">
   <meta name="twitter:creator" content="@PakStream">
@@ -50,7 +50,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>
@@ -284,7 +284,7 @@
         span.textContent = ch.name;
 
         const btn = document.createElement('button');
-        btn.className = 'fav-btn material-icons';
+        btn.className = 'fav-btn material-symbols-outlined';
         btn.setAttribute('aria-label', 'Toggle favorite');
         btn.textContent = 'favorite_border';
         btn.addEventListener('click', toggleFavorite);

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <!-- Standard Meta -->
-  <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube</title>
+  <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <meta name="title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube">
-  <meta name="description" content="Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/" />
@@ -22,16 +22,16 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://pakstream.com/">
-  <meta property="og:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube">
-  <meta property="og:description" content="Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.">
+  <meta property="og:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
+  <meta property="og:description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta property="og:site_name" content="PakStream">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://pakstream.com/">
-  <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; YouTube">
-  <meta name="twitter:description" content="Stream Pakistani TV channels, radio stations, and political YouTube talk shows—everything in one place. Stay connected wherever you are.">
+  <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
+  <meta name="twitter:description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta name="twitter:site" content="@PakStream">
   <meta name="twitter:creator" content="@PakStream">
@@ -56,7 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>
@@ -105,17 +105,17 @@
   <!-- Featured cards -->
   <section class="feature-cards">
     <div class="feature-card">
-      <span class="material-icons">article</span>
+      <span class="material-symbols-outlined">article</span>
       <h3>Latest News</h3>
       <p>Stay updated with the latest headlines.</p>
     </div>
     <div class="feature-card">
-      <span class="material-icons">radio</span>
+      <span class="material-symbols-outlined">radio</span>
       <h3>Popular Stations</h3>
       <p>Listen to trending Pakistani radio.</p>
     </div>
     <div class="feature-card">
-      <span class="material-icons">live_tv</span>
+      <span class="material-symbols-outlined">live_tv</span>
       <h3>Top TV Channels</h3>
       <p>Watch the most viewed TV streams.</p>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
   links.forEach(function (link) {
     if (link.getAttribute('href') === currentPath) {
       link.classList.add('active');
+      link.setAttribute('aria-current', 'page');
     }
   });
 

--- a/livetv.html
+++ b/livetv.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <meta name="title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
   <meta name="description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
   <meta name="author" content="PakStream by Chatdroid AB" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://pakstream.com/livetv.html" />
@@ -49,7 +49,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>
@@ -152,7 +152,7 @@
             span.textContent = ch.name;
 
             const btn = document.createElement('button');
-            btn.className = 'fav-btn material-icons';
+            btn.className = 'fav-btn material-symbols-outlined';
             btn.setAttribute('aria-label', 'Toggle favorite');
             btn.textContent = 'favorite_border';
             btn.onclick = (e) => toggleFavorite(e, ch.id);

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Basic Meta Tags -->
   <title>Passport Photo Resizer</title>
-  <meta name="description" content="Stream Pakistani TV channels, radio stations, YouTube news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
@@ -12,7 +12,7 @@
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
+  <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
@@ -20,7 +20,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
+  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
@@ -34,7 +34,7 @@
     "name": "PakStream",
     "url": "https://pakstream.com",
     "logo": "/favicon.ico",
-    "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
+    "description": "PakStream aggregates Pakistani radio, TV, and independent news content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
     ],
@@ -49,7 +49,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/privacy.html
+++ b/privacy.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Basic Meta Tags -->
   <title>PakStream - Privacy Policy</title>
-  <meta name="description" content="Stream Pakistani TV channels, radio stations, YouTube news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
@@ -12,7 +12,7 @@
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
+  <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
@@ -20,7 +20,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
+  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
@@ -34,7 +34,7 @@
     "name": "PakStream",
     "url": "https://pakstream.com",
     "logo": "/favicon.ico",
-    "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
+    "description": "PakStream aggregates Pakistani radio, TV, and independent news content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
     ],
@@ -50,7 +50,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/radio.html
+++ b/radio.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="title" content="PakStream Radio - Listen to Pakistani Radio Stations Online">
   <meta name="description" content="Stream live Pakistani FM, talk, and news radio from anywhere in the world.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/radio.html" />
@@ -50,7 +50,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>
@@ -88,14 +88,14 @@
             <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
           </div>
           <div class="controls">
-            <button id="favorite-btn" class="fav-btn material-icons" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
-            <button id="prev-btn" class="fav-btn material-icons" type="button" aria-label="Previous station" disabled>skip_previous</button>
+            <button id="favorite-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
+            <button id="prev-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Previous station" disabled>skip_previous</button>
             <button id="play-pause-btn" class="play-pause-btn" type="button" aria-label="Play or pause" disabled>
-              <span class="material-icons label">play_arrow</span>
+              <span class="material-symbols-outlined label">play_arrow</span>
               <span class="spinner"></span>
             </button>
-            <button id="next-btn" class="fav-btn material-icons" type="button" aria-label="Next station" disabled>skip_next</button>
-            <button id="mute-btn" class="mute-btn material-icons" type="button" aria-label="Mute" disabled>volume_up</button>
+            <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
+            <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
             <audio id="radio-player" autoplay></audio>
           </div>
         </div>
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const btn = document.createElement('button');
       btn.className = 'play-btn';
       btn.setAttribute('aria-label', 'Play');
-      btn.innerHTML = '<span class="material-icons label">play_arrow</span><span class="spinner"></span>';
+      btn.innerHTML = '<span class="material-symbols-outlined label">play_arrow</span><span class="spinner"></span>';
 
       const audio = document.createElement('audio');
       audio.id = st.id;
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const audio = btn.parentElement.querySelector('audio');
       const card = btn.closest('.channel-card');
       const name = card.querySelector('.channel-name').textContent;
-      btn.classList.remove('material-icons');
+      btn.classList.remove('material-symbols-outlined');
       btn.setAttribute('type', 'button');
       btn.addEventListener('click', (e) => {
         e.preventDefault();

--- a/terms.html
+++ b/terms.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Basic Meta Tags -->
   <title>PakStream - Terms &amp; Conditions</title>
-  <meta name="description" content="Stream Pakistani TV channels, radio stations, YouTube news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
@@ -12,7 +12,7 @@
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta property="og:description" content="Stream TV, radio, and YouTube content from Pakistan. Watch live channels and talk shows anywhere in the world.">
+  <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
   <meta property="og:url" content="https://pakstream.com/">
   <meta property="og:type" content="website">
@@ -20,7 +20,7 @@
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
-  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and YouTube wherever you live.">
+  <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">
 
   <!-- Language Declaration -->
@@ -34,7 +34,7 @@
     "name": "PakStream",
     "url": "https://pakstream.com",
     "logo": "/favicon.ico",
-    "description": "PakStream aggregates Pakistani radio, TV, and YouTube content for Pakistanis living abroad.",
+    "description": "PakStream aggregates Pakistani radio, TV, and independent news content for Pakistanis living abroad.",
     "sameAs": [
       "https://pakstream.com"
     ],
@@ -50,7 +50,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Replace deprecated Material Icons with Material Symbols Outlined for consistent icon rendering.
- Standardize navigation and metadata around "Free Press" branding, updating titles, descriptions, and keywords.
- Add accessible active-state highlighting in top navigation via new CSS and aria-current attributes.

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da41b18a8832088a9008a4b863149