### PR TITLE
Add channel thumbnails with caching

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -261,6 +261,13 @@ section {
   overflow: hidden;
 }
 
+.youtube-section .channel-card .channel-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .youtube-section .channel-card .channel-name {
   flex: 1;
   min-width: 0;

--- a/freepress.html
+++ b/freepress.html
@@ -107,6 +107,27 @@
 <script>
     const anchorMap = {};
     const favorites = JSON.parse(localStorage.getItem('ytFavorites') || '[]');
+    const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
+    const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+    function getChannelThumbnail(id) {
+      const cacheKey = `yt_thumb_${id}`;
+      const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+      if (cached && (Date.now() - cached.timestamp) < ONE_YEAR_MS) {
+        return Promise.resolve(cached.url);
+      }
+      const url = `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${id}&fields=items(snippet/thumbnails/default/url)&key=${API_KEY}`;
+      return fetch(url)
+        .then(res => res.json())
+        .then(data => {
+          const thumb = data.items?.[0]?.snippet?.thumbnails?.default?.url || '';
+          if (thumb) {
+            localStorage.setItem(cacheKey, JSON.stringify({ url: thumb, timestamp: Date.now() }));
+          }
+          return thumb;
+        })
+        .catch(() => '');
+    }
 
     function updateFavoritesUI() {
       const list = document.querySelector('.channel-list');
@@ -279,6 +300,10 @@
         card.className = 'channel-card';
         card.dataset.channelId = ch.id;
 
+        const img = document.createElement('img');
+        img.className = 'channel-thumb';
+        getChannelThumbnail(ch.id).then(url => { img.src = url; });
+
         const span = document.createElement('span');
         span.className = 'channel-name';
         span.textContent = ch.name;
@@ -289,6 +314,7 @@
         btn.textContent = 'favorite_border';
         btn.addEventListener('click', toggleFavorite);
 
+        card.appendChild(img);
         card.appendChild(span);
         card.appendChild(btn);
         list.appendChild(card);

--- a/livetv.html
+++ b/livetv.html
@@ -103,6 +103,26 @@
     const favorites = JSON.parse(localStorage.getItem('tvFavorites') || '[]');
     const channelMap = {};
     const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
+    const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+    function getChannelThumbnail(id) {
+      const cacheKey = `yt_thumb_${id}`;
+      const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+      if (cached && (Date.now() - cached.timestamp) < ONE_YEAR_MS) {
+        return Promise.resolve(cached.url);
+      }
+      const url = `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${id}&fields=items(snippet/thumbnails/default/url)&key=${API_KEY}`;
+      return fetch(url)
+        .then(res => res.json())
+        .then(data => {
+          const thumb = data.items?.[0]?.snippet?.thumbnails?.default?.url || '';
+          if (thumb) {
+            localStorage.setItem(cacheKey, JSON.stringify({ url: thumb, timestamp: Date.now() }));
+          }
+          return thumb;
+        })
+        .catch(() => '');
+    }
 
     function updateFavoritesUI() {
       const list = document.querySelector('.channel-list');
@@ -147,6 +167,10 @@
             card.dataset.id = ch.id;
             card.onclick = () => showStream(ch.id, card);
 
+            const img = document.createElement('img');
+            img.className = 'channel-thumb';
+            getChannelThumbnail(ch['channel-id']).then(url => { img.src = url; });
+
             const span = document.createElement('span');
             span.className = 'channel-name';
             span.textContent = ch.name;
@@ -157,6 +181,7 @@
             btn.textContent = 'favorite_border';
             btn.onclick = (e) => toggleFavorite(e, ch.id);
 
+            card.appendChild(img);
             card.appendChild(span);
             card.appendChild(btn);
             list.appendChild(card);


### PR DESCRIPTION
## Summary
- show YouTube channel thumbnails in Free Press and Live TV menus
- cache thumbnail URLs for a year to avoid repeated API calls
- style thumbnails for new channel card layout

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689daa8f69308320bd8a7cc1322e45bd