### PR TITLE
Animate hero flag with SVG and parallax effect

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -150,10 +150,40 @@ section {
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
 
-.hero-banner img {
+.hero-banner img,
+.hero-banner svg {
   width: 100%;
   height: 300px;
   object-fit: cover;
+  display: block;
+}
+
+.wave {
+  animation: waveMove 10s ease-in-out infinite alternate;
+}
+
+@keyframes waveMove {
+  0% {
+    transform: scale(1) translateX(0px);
+  }
+  100% {
+    transform: scale(1.05) translateX(5px);
+  }
+}
+
+.crescent,
+.star {
+  animation: glow 3s ease-in-out infinite;
+}
+
+@keyframes glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 5px var(--accent-info));
+  }
+  50% {
+    filter: drop-shadow(0 0 15px var(--accent-link));
+  }
 }
 
 .hero-text {

--- a/index.html
+++ b/index.html
@@ -82,20 +82,37 @@
 
   <!-- Hero section with image and tagline -->
   <section class="hero-banner">
-    <picture>
-      <source
-        type="image/webp"
-        srcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
-        sizes="(max-width: 420px) 80vw, 380px" />
-      <img
-        src="/images/pakistan-abstract-380.webp"
-        width="380"
-        height="380"
-        alt="Abstract Pakistan crescent and star"
-        decoding="async"
-        fetchpriority="high"
-        style="aspect-ratio: 1 / 1; object-fit: cover;" />
-    </picture>
+    <svg
+      class="hero-flag"
+      viewBox="0 0 400 300"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Abstract Pakistan crescent and star">
+      <rect width="400" height="300" fill="var(--primary)" />
+      <g class="wave-layer" data-depth="0.02">
+        <path
+          class="wave wave1"
+          d="M0 200 Q100 180 200 200 T400 200 V300 H0Z"
+          fill="var(--primary-container)" />
+      </g>
+      <g class="wave-layer" data-depth="0.04">
+        <path
+          class="wave wave2"
+          d="M0 240 Q100 220 200 240 T400 240 V300 H0Z"
+          fill="var(--accent-success)"
+          opacity="0.3" />
+      </g>
+      <g class="emblem" transform="translate(260 140)" data-depth="0.08">
+        <path
+          class="crescent"
+          d="M0-50a50 50 0 1 0 0 100a35 35 0 1 1 0-100"
+          fill="var(--on-primary)" />
+        <polygon
+          class="star"
+          points="0,-15 4,-5 15,-5 6,2 9,12 0,6 -9,12 -6,2 -15,-5 -4,-5"
+          fill="var(--on-primary)" />
+      </g>
+    </svg>
     <div class="hero-text">
       <h2>Your Gateway to Pakistani Media</h2>
       <p>Stay Connected to Pakistan — News, Radio &amp; More</p>

--- a/js/main.js
+++ b/js/main.js
@@ -73,6 +73,25 @@ document.addEventListener('DOMContentLoaded', function () {
       el.removeAttribute('data-src');
     });
   }
+
+  var banner = document.querySelector('.hero-banner');
+  if (banner) {
+    var layers = banner.querySelectorAll('[data-depth]');
+    banner.addEventListener('mousemove', function (e) {
+      var rect = banner.getBoundingClientRect();
+      var x = e.clientX - rect.left - rect.width / 2;
+      var y = e.clientY - rect.top - rect.height / 2;
+      layers.forEach(function (layer) {
+        var depth = parseFloat(layer.dataset.depth) || 0;
+        layer.style.transform = 'translate(' + x * depth + 'px,' + y * depth + 'px)';
+      });
+    });
+    banner.addEventListener('mouseleave', function () {
+      layers.forEach(function (layer) {
+        layer.style.transform = '';
+      });
+    });
+  }
 });
 
 (function(){


### PR DESCRIPTION
## Summary
- Replace static hero image with inline SVG using theme colors
- Animate flag waves with subtle glow on crescent and star
- Add mouse-driven parallax interactions for layered elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dac0504fc8320a3b5a528fe9e9e8a