### PR TITLE
Cache live TV stream data for one day

### DIFF
--- a/livetv.html
+++ b/livetv.html
@@ -104,6 +104,7 @@
     const channelMap = {};
     const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
     const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
     function getChannelThumbnail(id) {
       const cacheKey = `yt_thumb_${id}`;
@@ -306,6 +307,66 @@
         streamList.appendChild(li);
         return;
       }
+
+      const cacheKey = `yt_streams_${id}`;
+      const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+
+      const renderEntries = (entries) => {
+        entries.forEach(entry => {
+          const li = document.createElement('li');
+          li.className = 'stream-card';
+          const a = document.createElement('a');
+          a.href = '#';
+
+          const img = document.createElement('img');
+          img.src = entry.thumb;
+          img.alt = entry.title;
+          a.appendChild(img);
+
+          const titleDiv = document.createElement('div');
+          titleDiv.className = 'stream-title';
+          titleDiv.textContent = entry.title;
+          a.appendChild(titleDiv);
+
+          const viewerDiv = document.createElement('div');
+          viewerDiv.className = 'stream-viewers';
+          viewerDiv.textContent = entry.viewers ? `${entry.viewers.toLocaleString()} watching` : 'Live';
+          a.appendChild(viewerDiv);
+
+          a.onclick = (e) => {
+            e.preventDefault();
+            const playerId = `${id}-player`;
+            const player = players[playerId];
+            if (player && player.loadVideoById) {
+              player.loadVideoById(entry.videoId);
+            } else {
+              const iframe = document.getElementById(playerId);
+              iframe.src = `https://www.youtube.com/embed/${entry.videoId}?${YT_PARAMS}`;
+            }
+          };
+
+          li.appendChild(a);
+          streamList.appendChild(li);
+        });
+
+        if (entries.length > 0) {
+          const top = entries[0].videoId;
+          const playerId = `${id}-player`;
+          const player = players[playerId];
+          if (player && player.loadVideoById) {
+            player.loadVideoById(top);
+          } else {
+            const iframe = document.getElementById(playerId);
+            iframe.src = `https://www.youtube.com/embed/${top}?${YT_PARAMS}`;
+          }
+        }
+      };
+
+      if (cached && (Date.now() - cached.timestamp) < ONE_DAY_MS) {
+        renderEntries(cached.entries);
+        return;
+      }
+
       const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${encodeURIComponent(ch['channel-id'])}&eventType=live&type=video&key=${API_KEY}`;
       fetch(url)
         .then(res => res.json())
@@ -331,55 +392,8 @@
                 });
 
                 entries.sort((a, b) => b.viewers - a.viewers);
-
-                entries.forEach(entry => {
-                  const li = document.createElement('li');
-                  li.className = 'stream-card';
-                  const a = document.createElement('a');
-                  a.href = '#';
-
-                  const img = document.createElement('img');
-                  img.src = entry.thumb;
-                  img.alt = entry.title;
-                  a.appendChild(img);
-
-                  const titleDiv = document.createElement('div');
-                  titleDiv.className = 'stream-title';
-                  titleDiv.textContent = entry.title;
-                  a.appendChild(titleDiv);
-
-                  const viewerDiv = document.createElement('div');
-                  viewerDiv.className = 'stream-viewers';
-                  viewerDiv.textContent = entry.viewers ? `${entry.viewers.toLocaleString()} watching` : 'Live';
-                  a.appendChild(viewerDiv);
-
-                  a.onclick = (e) => {
-                    e.preventDefault();
-                    const playerId = `${id}-player`;
-                    const player = players[playerId];
-                    if (player && player.loadVideoById) {
-                      player.loadVideoById(entry.videoId);
-                    } else {
-                      const iframe = document.getElementById(playerId);
-                      iframe.src = `https://www.youtube.com/embed/${entry.videoId}?${YT_PARAMS}`;
-                    }
-                  };
-
-                  li.appendChild(a);
-                  streamList.appendChild(li);
-                });
-
-                if (entries.length > 0) {
-                  const top = entries[0].videoId;
-                  const playerId = `${id}-player`;
-                  const player = players[playerId];
-                  if (player && player.loadVideoById) {
-                    player.loadVideoById(top);
-                  } else {
-                    const iframe = document.getElementById(playerId);
-                    iframe.src = `https://www.youtube.com/embed/${top}?${YT_PARAMS}`;
-                  }
-                }
+                localStorage.setItem(cacheKey, JSON.stringify({ entries, timestamp: Date.now() }));
+                renderEntries(entries);
               })
               .catch(() => {
                 const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- Cache YouTube live stream lists in `livetv.html` for one day using localStorage
- Skip API requests when cached streams are fresh to preserve quota

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689db3025a2c8320868226f51fd92440