### PR TITLE
Add favorite buttons to radio station list

### DIFF
--- a/radio.html
+++ b/radio.html
@@ -205,8 +205,23 @@ document.addEventListener('DOMContentLoaded', function() {
       audio.dataset.logo = st.logo || defaultLogo;
       if (st.src) audio.src = st.src;
 
+      const favButton = document.createElement('button');
+      favButton.className = 'fav-btn material-symbols-outlined';
+      favButton.setAttribute('aria-label', 'Toggle favorite');
+      favButton.textContent = 'favorite_border';
+      favButton.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const id = audio.id;
+        const idx = favorites.indexOf(id);
+        if (idx >= 0) favorites.splice(idx, 1);
+        else favorites.push(id);
+        localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+        updateFavoritesUI();
+      });
+
       card.appendChild(nameSpan);
       card.appendChild(btn);
+      card.appendChild(favButton);
       card.appendChild(audio);
       list.appendChild(card);
     });


### PR DESCRIPTION
## Summary
- Add per-station favorite buttons in the radio sidebar, matching Live TV's favorite toggle.
- Wire station-level favorite button events to local storage and UI updates.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db54abc748320992464bba3b7fe8d