### PR TITLE
feat: unify left menu controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -271,9 +271,10 @@ section {
 .youtube-section .channel-card .channel-name {
   flex: 1;
   min-width: 0;
-  white-space: nowrap;
+  line-height: 1.2;
+  max-height: 2.4em;
   overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
 }
 
 
@@ -590,7 +591,7 @@ table tbody tr.favorite {
   width: 40px;
   height: 40px;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: 50%;
   flex-shrink: 0;
 }
 

--- a/freepress.html
+++ b/freepress.html
@@ -159,13 +159,29 @@
       updateFavoritesUI();
     }
 
+    function fitText(el, maxLines = 2) {
+      const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+      const maxHeight = lineHeight * maxLines;
+      let fontSize = parseFloat(getComputedStyle(el).fontSize);
+      while (el.scrollHeight > maxHeight && fontSize > 10) {
+        fontSize -= 1;
+        el.style.fontSize = fontSize + 'px';
+      }
+    }
+
     let cards;
     const videoListEl = document.getElementById('videoList');
     const playerFrame = document.getElementById('playerFrame');
 
   function setActiveCard(clickedCard) {
-    cards.forEach(c => c.classList.remove('active'));
+    cards.forEach(c => {
+      c.classList.remove('active');
+      const pb = c.querySelector('.play-btn');
+      if (pb) pb.textContent = 'play_arrow';
+    });
     clickedCard.classList.add('active');
+    const pb = clickedCard.querySelector('.play-btn');
+    if (pb) pb.textContent = 'stop';
   }
 
   function setActiveVideo(clickedItem) {
@@ -308,6 +324,12 @@
         span.className = 'channel-name';
         span.textContent = ch.name;
 
+        const playBtn = document.createElement('button');
+        playBtn.className = 'play-btn material-symbols-outlined';
+        playBtn.setAttribute('aria-label', 'Play');
+        playBtn.textContent = 'play_arrow';
+        playBtn.addEventListener('click', (e) => { e.stopPropagation(); handleChannelClick(card); });
+
         const btn = document.createElement('button');
         btn.className = 'fav-btn material-symbols-outlined';
         btn.setAttribute('aria-label', 'Toggle favorite');
@@ -316,10 +338,12 @@
 
         card.appendChild(img);
         card.appendChild(span);
+        card.appendChild(playBtn);
         card.appendChild(btn);
         list.appendChild(card);
       });
 
+      document.querySelectorAll('.channel-name').forEach(el => fitText(el));
       updateFavoritesUI();
 
       cards = document.querySelectorAll('.channel-card');

--- a/livetv.html
+++ b/livetv.html
@@ -144,6 +144,16 @@
       list.appendChild(otherFragment);
     }
 
+    function fitText(el, maxLines = 2) {
+      const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+      const maxHeight = lineHeight * maxLines;
+      let fontSize = parseFloat(getComputedStyle(el).fontSize);
+      while (el.scrollHeight > maxHeight && fontSize > 10) {
+        fontSize -= 1;
+        el.style.fontSize = fontSize + 'px';
+      }
+    }
+
       function toggleFavorite(event, id) {
         event.stopPropagation();
         const idx = favorites.indexOf(id);
@@ -176,6 +186,12 @@
             span.className = 'channel-name';
             span.textContent = ch.name;
 
+            const playBtn = document.createElement('button');
+            playBtn.className = 'play-btn material-symbols-outlined';
+            playBtn.setAttribute('aria-label', 'Play');
+            playBtn.textContent = 'play_arrow';
+            playBtn.onclick = (e) => { e.stopPropagation(); showStream(ch.id, card); };
+
             const btn = document.createElement('button');
             btn.className = 'fav-btn material-symbols-outlined';
             btn.setAttribute('aria-label', 'Toggle favorite');
@@ -184,6 +200,7 @@
 
             card.appendChild(img);
             card.appendChild(span);
+            card.appendChild(playBtn);
             card.appendChild(btn);
             list.appendChild(card);
 
@@ -206,6 +223,7 @@
           streamList.id = 'stream-list';
           videoSection.appendChild(streamList);
 
+          document.querySelectorAll('.channel-name').forEach(el => fitText(el));
           updateFavoritesUI();
 
           const urlParams = new URLSearchParams(window.location.search);
@@ -255,8 +273,9 @@
       // Hide all video divs
       document.querySelectorAll('.live-player').forEach(div => div.style.display = 'none');
 
-      // Remove active class
+      // Remove active class and reset play icons
       document.querySelectorAll('.channel-card').forEach(card => card.classList.remove('active'));
+      document.querySelectorAll('.play-btn').forEach(btn => btn.textContent = 'play_arrow');
 
       // Pause all players
       for (const key in players) {
@@ -267,7 +286,11 @@
 
       // Show selected stream
       document.getElementById(id).style.display = 'block';
-      if (element) element.classList.add('active');
+      if (element) {
+        element.classList.add('active');
+        const pb = element.querySelector('.play-btn');
+        if (pb) pb.textContent = 'stop';
+      }
 
       // Load or play selected stream
       const playerId = `${id}-player`;

--- a/radio.html
+++ b/radio.html
@@ -138,6 +138,16 @@ document.addEventListener('DOMContentLoaded', function() {
   const muteBtn = document.getElementById('mute-btn');
   const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
 
+  function fitText(el, maxLines = 2) {
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+    const maxHeight = lineHeight * maxLines;
+    let fontSize = parseFloat(getComputedStyle(el).fontSize);
+    while (el.scrollHeight > maxHeight && fontSize > 10) {
+      fontSize -= 1;
+      el.style.fontSize = fontSize + 'px';
+    }
+  }
+
   // Allow swipe gestures to toggle the channel list on touch devices
   const channelList = document.querySelector('.channel-list');
   if (channelList) {
@@ -238,6 +248,8 @@ document.addEventListener('DOMContentLoaded', function() {
       img.loading = 'lazy';
       card.insertBefore(img, name);
     });
+
+    document.querySelectorAll('.channel-name').forEach(el => fitText(el));
 
     playButtons = Array.from(document.querySelectorAll('.play-btn'));
     playButtons.forEach(btn => {


### PR DESCRIPTION
## Summary
- Allow channel names to wrap on two lines with dynamic font sizing for consistency
- Add play/stop buttons to Live TV and Free Press listings
- Make radio station thumbnails round to match other sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db8f3d418832098925b291ed7c176