### PR TITLE
Add Google Analytics include across layouts and pages

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,8 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G9N0G15W9V"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-G9N0G15W9V');
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}</title>
   <meta charset="UTF-8">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}</title>
   <meta charset="UTF-8" />

--- a/about.html
+++ b/about.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - About</title>
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - Contact</title>
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">

--- a/freepress.html
+++ b/freepress.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Free Press - Watch Independent Pakistani News Voices</title>
   <meta charset="UTF-8">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press</title>
   <meta charset="UTF-8">

--- a/livetv.html
+++ b/livetv.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Live TV - Watch Pakistani TV Channels Live</title>
   <meta charset="UTF-8" />

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>Passport Photo Resizer</title>
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">

--- a/nav.html
+++ b/nav.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <meta charset="UTF-8">
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">

--- a/privacy.html
+++ b/privacy.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - Privacy Policy</title>
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">

--- a/radio.html
+++ b/radio.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Radio - Listen to Pakistani Radio Stations Online</title>
   <meta charset="UTF-8">

--- a/terms.html
+++ b/terms.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - Terms &amp; Conditions</title>
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -1,6 +1,9 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% include google-analytics.html %}
   <title>PakStream - YouTube Playground</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- add reusable Google Analytics snippet include
- load analytics in default and post layouts
- enable analytics on standalone pages such as index, about, contact, privacy, terms, and more

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc0aed040832088a5d2301673c2b2