### PR TITLE
Add Google Tag Manager

### DIFF
--- a/_includes/google-tag-manager-body.html
+++ b/_includes/google-tag-manager-body.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T63RDQDK"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/_includes/google-tag-manager-head.html
+++ b/_includes/google-tag-manager-head.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-T63RDQDK');</script>
+<!-- End Google Tag Manager -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -58,6 +59,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -58,6 +59,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -61,6 +62,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -61,6 +62,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <!-- Header with navigation -->
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">

--- a/freepress.html
+++ b/freepress.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -61,6 +62,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -67,6 +68,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/livetv.html
+++ b/livetv.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -60,6 +61,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->

--- a/nav.html
+++ b/nav.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -13,6 +14,7 @@
   <link rel="stylesheet" href="/css/theme.css">
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -61,6 +62,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <!-- Header with navigation -->
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">

--- a/radio.html
+++ b/radio.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->

--- a/terms.html
+++ b/terms.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -61,6 +62,7 @@
   
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <!-- Header with navigation -->
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
@@ -20,6 +21,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
 <body>
+{% include google-tag-manager-body.html %}
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
     <label for="nav-toggle" class="nav-toggle-label">☰</label>


### PR DESCRIPTION
## Summary
- add Google Tag Manager snippets for head and body
- include GTM on all site pages and layouts

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6f0ab788320b13bd09727ba1a1c