### PR TITLE
Add canonical tags and robot meta controls

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@ layout: default
 title: "Page Not Found"
 permalink: /404.html
 description: "The page you requested could not be found."
+robots: noindex, follow
 ---
 
 <section class="not-found">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
   <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
-  <meta name="robots" content="index, follow">
+  <meta name="robots" content="{{ page.robots | default: 'index, follow' }}">
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@
   <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
   <meta name="author" content="PakStream by Chatdroid AB" />
-  <meta name="robots" content="index, follow" />
+  <meta name="robots" content="{{ page.robots | default: 'index, follow' }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 

--- a/about.html
+++ b/about.html
@@ -13,8 +13,10 @@
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
+  <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <link rel="canonical" href="https://pakstream.com/about.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,10 @@
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
+  <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <link rel="canonical" href="https://pakstream.com/contact.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -13,8 +13,10 @@
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
+  <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <link rel="canonical" href="https://pakstream.com/nadraimage.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/privacy.html
+++ b/privacy.html
@@ -13,8 +13,10 @@
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
+  <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <link rel="canonical" href="https://pakstream.com/privacy.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/terms.html
+++ b/terms.html
@@ -13,8 +13,10 @@
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
+  <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
+  <link rel="canonical" href="https://pakstream.com/terms.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -12,6 +12,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Experiment with YouTube channels to list current live streams.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="canonical" href="https://pakstream.com/youtube-playground.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">


### PR DESCRIPTION
## Summary
- allow per-page robots meta directives in default and post layouts
- add canonical URLs and robots tags to static info pages
- mark 404 and playground pages as noindex to prevent indexing

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689dd813228c83208b5cc4663ea8d738