### PR TITLE
Add Creators page with curated YouTube list

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -68,6 +68,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -68,6 +68,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/about.html
+++ b/about.html
@@ -73,6 +73,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/contact.html
+++ b/contact.html
@@ -74,6 +74,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/creators.html
+++ b/creators.html
@@ -9,30 +9,30 @@
   <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
-  <title>PakStream Free Press - Watch Independent Pakistani News Voices</title>
+  <title>PakStream Creators - Watch Popular Pakistani YouTubers</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <meta name="title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
-  <meta name="description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="title" content="PakStream Creators - Watch Popular Pakistani YouTubers">
+  <meta name="description" content="Curated list of Pakistani YouTubers and their latest videos.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Creators, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://pakstream.com/freepress.html" />
+  <link rel="canonical" href="https://pakstream.com/creators.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://pakstream.com/freepress.html">
-  <meta property="og:title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
-  <meta property="og:description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
+  <meta property="og:url" content="https://pakstream.com/creators.html">
+  <meta property="og:title" content="PakStream Creators - Watch Popular Pakistani YouTubers">
+  <meta property="og:description" content="Curated list of Pakistani YouTubers and their latest videos.">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta property="og:site_name" content="PakStream">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="https://pakstream.com/freepress.html">
-  <meta name="twitter:title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
-  <meta name="twitter:description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
+  <meta name="twitter:url" content="https://pakstream.com/creators.html">
+  <meta name="twitter:title" content="PakStream Creators - Watch Popular Pakistani YouTubers">
+  <meta name="twitter:description" content="Curated list of Pakistani YouTubers and their latest videos.">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
   <meta name="twitter:site" content="@PakStream">
   <meta name="twitter:creator" content="@PakStream">
@@ -83,7 +83,7 @@
   <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
-  <!-- Free Press section with channel list and video player -->
+  <!-- Creators section with channel list and video player -->
   <section class="youtube-section">
     <div class="channel-list"></div>
     <!-- Video display area: a player for the selected video and a list of recent videos -->
@@ -243,7 +243,7 @@
     // 👇 Update URL
     const anchorKey = Object.keys(anchorMap).find(key => anchorMap[key] === channelId);
     if (anchorKey) {
-      const newUrl = `${window.location.pathname}?newsanchor=${anchorKey}`;
+      const newUrl = `${window.location.pathname}?creator=${anchorKey}`;
       history.replaceState(null, '', newUrl);
     }
   
@@ -314,7 +314,7 @@
     }
 
   }
-  fetch('/freepress_channels.json')
+  fetch('/creators_channels.json')
     .then(res => res.json())
     .then(channels => {
       const list = document.querySelector('.channel-list');
@@ -361,7 +361,7 @@
       });
 
       const urlParams = new URLSearchParams(window.location.search);
-      const anchorKey = urlParams.get('newsanchor');
+      const anchorKey = urlParams.get('creator');
       const defaultCard = document.querySelector('.channel-card');
 
       if (anchorKey && anchorMap[anchorKey]) {

--- a/creators_channels.json
+++ b/creators_channels.json
@@ -1,0 +1,6 @@
+[
+  {"key":"ZeeshanUsmani","name":"Zeeshan Usmani","id":"UCllefjGak7WtAV3sVcRy9xQ"},
+  {"key":"DanishHasan","name":"Danish Hasan","id":"UCjayfyzIgKEYqKQ0OQL4Aiw"},
+  {"key":"Mooroo","name":"Taimoor Salahuddin","id":"UC-rP-oFlxQGpSLYHBlhIWkg"},
+  {"key":"JunaidAkram","name":"Junaid Akram","id":"UCFo9mvW4ythx_tgT3NHaw-Q"}
+]

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/livetv.html
+++ b/livetv.html
@@ -70,6 +70,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/nadraimage.html
+++ b/nadraimage.html
@@ -71,6 +71,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/nav.html
+++ b/nav.html
@@ -23,6 +23,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/privacy.html
+++ b/privacy.html
@@ -74,6 +74,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/radio.html
+++ b/radio.html
@@ -70,6 +70,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,6 +13,9 @@
     <loc>https://pakstream.com/freepress.html</loc>
   </url>
   <url>
+    <loc>https://pakstream.com/creators.html</loc>
+  </url>
+  <url>
     <loc>https://pakstream.com/radio.html</loc>
   </url>
   <url>

--- a/terms.html
+++ b/terms.html
@@ -74,6 +74,7 @@
         <a href="/">Home</a>
         <a href="/freepress.html">Free Press</a>
         <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
         <a href="/radio.html">Radio</a>
         <a href="/blog.html">Blog</a>
         <a href="/about.html">About</a>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -32,6 +32,7 @@
       <a href="/">Home</a>
       <a href="/freepress.html">Free Press</a>
       <a href="/livetv.html">Live TV</a>
+      <a href="/creators.html">Creators</a>
       <a href="/radio.html">Radio</a>
       <a href="/blog.html">Blog</a>
       <a href="/about.html">About</a>


### PR DESCRIPTION
## Summary
- add Creators page mirroring Free Press layout and loading a separate list of YouTube creators
- introduce `creators_channels.json` with initial creator channels
- update navigation and sitemap to include the new Creators section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de336c6448320bbada5a1b039b07a