### PR TITLE
Add site-wide search bar and results page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -93,6 +93,25 @@ footer nav a:hover {
   background: color-mix(in oklab, var(--primary) 12%, transparent);
 }
 
+.search-form {
+  margin-left: 16px;
+}
+
+.search-form input {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--primary-container);
+}
+
+#search-results ul {
+  list-style: none;
+  padding: 0;
+}
+
+#search-results li {
+  margin: 8px 0;
+}
+
 /* Keep existing styles untouched below here */
 /* The rest of the existing style.css remains the same... */
 

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,8 @@ document.addEventListener('DOMContentLoaded', function () {
   var navToggle = document.getElementById('nav-toggle');
   var nav = document.querySelector('nav');
   var label = document.querySelector('.nav-toggle-label');
+  var topBar = document.querySelector('.top-bar');
+  var themeToggle = document.getElementById('theme-toggle');
   if (!navToggle || !nav || !label) return;
 
   var currentPath = window.location.pathname;
@@ -13,7 +15,6 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
-  var topBar = document.querySelector('.top-bar');
   var homePaths = ['/', '/'];
   if (topBar && label && homePaths.indexOf(currentPath) === -1) {
     var backBtn = document.createElement('a');
@@ -31,6 +32,31 @@ document.addEventListener('DOMContentLoaded', function () {
     topBar.insertBefore(backBtn, label.nextSibling);
   }
 
+  if (topBar) {
+    var themeBtn = themeToggle;
+    var searchForm = document.createElement('form');
+    searchForm.id = 'search-form';
+    searchForm.className = 'search-form';
+    var input = document.createElement('input');
+    input.type = 'search';
+    input.id = 'search-input';
+    input.placeholder = 'Search...';
+    input.setAttribute('aria-label', 'Search');
+    searchForm.appendChild(input);
+    searchForm.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var q = input.value.trim();
+      if (q) {
+        window.location.href = '/search.html?q=' + encodeURIComponent(q);
+      }
+    });
+    if (themeBtn) {
+      topBar.insertBefore(searchForm, themeBtn);
+    } else {
+      topBar.appendChild(searchForm);
+    }
+  }
+
   label.addEventListener('click', function (e) {
     e.preventDefault();
     navToggle.checked = !navToggle.checked;
@@ -42,7 +68,6 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
-  var themeToggle = document.getElementById('theme-toggle');
   if (themeToggle) {
     var savedTheme = localStorage.getItem('theme') || 'light';
     document.documentElement.setAttribute('data-theme', savedTheme);

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const params = new URLSearchParams(window.location.search);
+  const query = (params.get('q') || '').trim();
+  const container = document.getElementById('search-results');
+  if (!container) return;
+  if (!query) {
+    container.textContent = 'Please enter a search term.';
+    return;
+  }
+  const sources = [
+    { url: '/channels.json', type: 'tv', link: c => `/livetv.html?tvchannel=${c.id}` },
+    { url: '/freepress_channels.json', type: 'freepress', link: c => `/freepress.html?newsanchor=${c.key}` },
+    { url: '/radio_channels.json', type: 'radio', link: c => `/radio.html?station=${c.id}` }
+  ];
+  Promise.all(sources.map(src => fetch(src.url)
+    .then(res => res.json())
+    .then(data => ({ type: src.type, link: src.link, data }))
+  )).then(results => {
+    const term = query.toLowerCase();
+    const matches = [];
+    results.forEach(group => {
+      group.data.forEach(item => {
+        const name = item.name || '';
+        if (name.toLowerCase().includes(term)) {
+          matches.push({ name, url: group.link(item), type: group.type });
+        }
+      });
+    });
+    if (matches.length === 0) {
+      container.textContent = 'No results found.';
+      return;
+    }
+    const ul = document.createElement('ul');
+    matches.forEach(m => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = m.url;
+      a.textContent = `${m.name} (${m.type})`;
+      li.appendChild(a);
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  }).catch(() => {
+    container.textContent = 'Error fetching search data.';
+  });
+});

--- a/search.html
+++ b/search.html
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Search PakStream
+description: Search TV channels, radio stations and Free Press anchors.
+---
+<section class="search-page">
+  <h1>Search Results</h1>
+  <div id="search-results"></div>
+</section>
+<script defer src="/js/search.js"></script>


### PR DESCRIPTION
## Summary
- Inject a search form into the top bar that redirects to a new search page.
- Style the search form and results list to match existing design.
- Add `search.html` and `search.js` to query channels, freepress, and radio JSON sources.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de56636e08320ba1defa4e6756f48