### PR TITLE
Add site-wide live search bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -93,6 +93,44 @@ footer nav a:hover {
   background: color-mix(in oklab, var(--primary) 12%, transparent);
 }
 
+.search-form {
+  margin-left: 16px;
+  position: relative;
+}
+
+.search-form input {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--primary-container);
+}
+
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--surface);
+  color: var(--on-surface);
+  border: 1px solid var(--primary-container);
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  width: 100%;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1003;
+}
+
+.search-results a {
+  display: block;
+  padding: 6px 8px;
+  text-decoration: none;
+  color: var(--on-surface);
+}
+
+.search-results a:hover,
+.search-results a:focus {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+}
+
 /* Keep existing styles untouched below here */
 /* The rest of the existing style.css remains the same... */
 


### PR DESCRIPTION
## Summary
- Replace search page redirect with live results dropdown in the top bar
- Style live-search dropdown to match site theme
- Remove unused search page and script

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de56636e08320ba1defa4e6756f48