### PR TITLE
Fix mobile search bar overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -96,12 +96,28 @@ footer nav a:hover {
 .search-form {
   margin-left: 16px;
   position: relative;
+  flex: 1;
+  max-width: 300px;
+  min-width: 0;
 }
 
 .search-form input {
+  width: 100%;
+  box-sizing: border-box;
   padding: 6px 8px;
   border-radius: 4px;
   border: 1px solid var(--primary-container);
+}
+
+.search-form.active {
+  max-width: none;
+}
+
+@media (max-width: 600px) {
+  .search-form {
+    margin-left: 8px;
+    max-width: none;
+  }
 }
 
 .search-results {

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (topBar) {
     var themeBtn = themeToggle;
+    var logoTitle = document.querySelector('.logo-title');
     var searchForm = document.createElement('form');
     searchForm.id = 'search-form';
     searchForm.className = 'search-form';
@@ -43,6 +44,16 @@ document.addEventListener('DOMContentLoaded', function () {
     input.placeholder = 'Search...';
     input.setAttribute('aria-label', 'Search');
     searchForm.appendChild(input);
+
+    input.addEventListener('focus', function () {
+      searchForm.classList.add('active');
+      if (logoTitle) logoTitle.setAttribute('hidden', '');
+    });
+
+    input.addEventListener('blur', function () {
+      searchForm.classList.remove('active');
+      if (logoTitle) logoTitle.removeAttribute('hidden');
+    });
 
     var results = document.createElement('div');
     results.id = 'search-results';


### PR DESCRIPTION
## Summary
- Make search bar flexibly fill available space and adjust max-width on small screens
- Hide site title while searching and expand search field for mobile users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689deef145e4832091cd7bfa808427ca