### PR TITLE
Add detailed profile panel for news anchors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -300,6 +300,9 @@ section {
   gap: 8px;
   width: 220px;
 }
+.youtube-section .details-list {
+  width: 300px;
+}
 
 .youtube-section .channel-card,
 .youtube-section .detail-item {
@@ -490,6 +493,41 @@ section {
     max-height: calc(100vh - 88px);
     overflow-y: auto;
   }
+}
+
+.details-content h3 {
+  margin: 8px 0;
+  font-size: 1.1rem;
+}
+
+.details-content p {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+}
+
+.details-content .meta div {
+  margin-bottom: 4px;
+  font-size: 0.9rem;
+}
+
+.details-content .profiles {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+}
+
+.details-content .profile {
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.8rem;
+}
+
+.details-content .profile img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  margin-bottom: 4px;
 }
 
 /* Buttons */

--- a/freepress.html
+++ b/freepress.html
@@ -117,6 +117,7 @@
   <!-- JavaScript for dynamically loading latest videos from the selected channel -->
 <script>
     const anchorMap = {};
+    let detailsMap = {};
     const favorites = JSON.parse(localStorage.getItem('ytFavorites') || '[]');
     const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
     const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
@@ -248,7 +249,11 @@
       const newUrl = `${window.location.pathname}?newsanchor=${anchorKey}`;
       history.replaceState(null, '', newUrl);
     }
-  
+    const detailsList = document.querySelector('.details-list');
+    if (detailsList) {
+      detailsList.innerHTML = (detailsMap[anchorKey] || detailsMap.default || '');
+    }
+
     setActiveCard(card);
     videoListEl.innerHTML = '<p>Loading videos…</p>';
 
@@ -320,7 +325,8 @@
     .then(res => res.json())
     .then(data => {
       const channels = data.channels || [];
-      const details = data.details || [];
+      const details = data.details || {};
+      detailsMap = details;
       const list = document.querySelector('.channel-list');
       channels.forEach(ch => {
         anchorMap[ch.key] = ch.id;
@@ -357,12 +363,7 @@
       });
 
       const detailsList = document.querySelector('.details-list');
-      details.forEach(text => {
-        const item = document.createElement('div');
-        item.className = 'detail-item';
-        item.textContent = text;
-        detailsList.appendChild(item);
-      });
+      detailsList.innerHTML = details.default || '';
 
       document.querySelectorAll('.channel-name').forEach(el => fitText(el));
       updateFavoritesUI();

--- a/freepress_channels.json
+++ b/freepress_channels.json
@@ -35,9 +35,8 @@
     {"key":"WajahatSKhan","name":"Wajahat Saeed Khan","id":"UCxaMbYDd4o_zVvfr9_wKAxQ"},
     {"key":"Zaeemleghari","name":"Zaeem leghari","id":"UCfTQGgFP5U53mcbbRRLl1yQ"}
   ],
-  "details": [
-    "PakStream curates independent Pakistani news voices.",
-    "Opinions belong to their creators.",
-    "Contact us at contact@pakstream.com"
-  ]
+  "details": {
+    "default": "<div class='detail-item'>PakStream curates independent Pakistani news voices.</div><div class='detail-item'>Opinions belong to their creators.</div><div class='detail-item'>Contact us at contact@pakstream.com</div>",
+    "ImranRiazKhan": "<div class='details-content'><h3>About</h3><p>Imran Riaz Khan is a Pakistani journalist and TV anchor. On 11 May 2023, Khan was reported to have been arrested by police while travelling in Pakistan. Media reports suggested that Imran's abduction may have been connected to him speaking out against the government and military. <a href='https://en.wikipedia.org/wiki/Imran_Riaz_Khan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> August 14, 1975 (age 50 years), Faisalabad, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Imran Riaz Khan</div><div><strong>Views:</strong> 1.58 billion</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/c/ImranRiazKhan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://www.instagram.com/imrankhanjrnlist' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a><a class='profile' href='https://twitter.com/ImranRiazKhan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/ImranRiazKhanOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"
+  }
 }


### PR DESCRIPTION
## Summary
- Load anchor-specific profile HTML from `freepress_channels.json`
- Replace basic detail list with rich 'About' panel and social profile links
- Style details sidebar for biography, metadata, and profile icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb85e4c9c832092e9bd3b20215e27