### PR TITLE
Load about details for Free Press channels

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -251,7 +251,7 @@
     }
     const detailsList = document.querySelector('.details-list');
     if (detailsList) {
-      detailsList.innerHTML = (detailsMap[anchorKey] || detailsMap.default || '');
+      detailsList.innerHTML = detailsMap[anchorKey] || '';
     }
 
     setActiveCard(card);
@@ -325,11 +325,10 @@
     .then(res => res.json())
     .then(data => {
       const channels = data.channels || [];
-      const details = data.details || {};
-      detailsMap = details;
       const list = document.querySelector('.channel-list');
       channels.forEach(ch => {
         anchorMap[ch.key] = ch.id;
+        detailsMap[ch.key] = ch.about || '';
 
         const card = document.createElement('div');
         card.className = 'channel-card';
@@ -361,9 +360,6 @@
         card.appendChild(btn);
         list.appendChild(card);
       });
-
-      const detailsList = document.querySelector('.details-list');
-      detailsList.innerHTML = details.default || '';
 
       document.querySelectorAll('.channel-name').forEach(el => fitText(el));
       updateFavoritesUI();


### PR DESCRIPTION
## Summary
- Populate Free Press details list with channel `about` content from `freepress_channels.json`
- Map each channel key to its `about` info and update details view on selection

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc02619e4832089c6c06e008fc420