### PR TITLE
refactor: separate freepress profiles

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -120,6 +120,7 @@
 <script>
     const anchorMap = {};
     let detailsMap = {};
+    let profilesMap = {};
     const favorites = JSON.parse(localStorage.getItem('ytFavorites') || '[]');
     const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
     const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
@@ -141,6 +142,31 @@
           return thumb;
         })
         .catch(() => '');
+    }
+
+    function renderProfiles(list) {
+      if (!list.length) return '';
+      const icons = {
+        youtube: { url: 'https://img.icons8.com/color/48/000000/youtube-play.png', label: 'YouTube' },
+        instagram: { url: 'https://img.icons8.com/color/48/000000/instagram-new.png', label: 'Instagram' },
+        twitter: { url: 'https://img.icons8.com/color/48/000000/twitter--v1.png', label: 'X (Twitter)' },
+        facebook: { url: 'https://img.icons8.com/color/48/000000/facebook-new.png', label: 'Facebook' },
+        linkedin: { url: 'https://img.icons8.com/color/48/000000/linkedin.png', label: 'LinkedIn' },
+        tiktok: { url: 'https://img.icons8.com/color/48/000000/tiktok--v1.png', label: 'TikTok' }
+      };
+      const items = list.map(url => {
+        let type = 'website';
+        if (/youtu/.test(url)) type = 'youtube';
+        else if (/instagram/.test(url)) type = 'instagram';
+        else if (/twitter|x\.com/.test(url)) type = 'twitter';
+        else if (/facebook/.test(url)) type = 'facebook';
+        else if (/linkedin/.test(url)) type = 'linkedin';
+        else if (/tiktok/.test(url)) type = 'tiktok';
+        const { url: icon, label } = icons[type] || { url: '', label: type.charAt(0).toUpperCase() + type.slice(1) };
+        const img = icon ? `<img src='${icon}' alt='${label}'>` : '';
+        return `<a class='profile' href='${url}' target='_blank' rel='noopener'>${img}<span>${label}</span></a>`;
+      }).join('');
+      return `<h3>Profiles</h3><div class='profiles'>${items}</div>`;
     }
 
     function updateFavoritesUI() {
@@ -254,9 +280,14 @@
     const detailsList = document.querySelector('.details-list');
     const detailsBtn = document.getElementById('toggle-details');
     const aboutContent = detailsMap[anchorKey];
+    const profileUrls = profilesMap[anchorKey] || [];
     if (detailsList && detailsBtn) {
-      if (aboutContent) {
-        detailsList.innerHTML = aboutContent;
+      if (aboutContent || profileUrls.length) {
+        detailsList.innerHTML = aboutContent || '';
+        if (profileUrls.length) {
+          const container = detailsList.querySelector('.details-content') || detailsList;
+          container.insertAdjacentHTML('beforeend', renderProfiles(profileUrls));
+        }
         detailsList.style.display = '';
         detailsBtn.style.display = '';
         detailsBtn.textContent = 'About';
@@ -343,6 +374,7 @@
       channels.forEach(ch => {
         anchorMap[ch.key] = ch.id;
         detailsMap[ch.key] = ch.about || '';
+        profilesMap[ch.key] = ch.profiles || [];
 
         const card = document.createElement('div');
         card.className = 'channel-card';

--- a/freepress_channels.json
+++ b/freepress_channels.json
@@ -1,38 +1,367 @@
 {
   "channels": [
-    {"key":"ImranRiazKhan","name":"Imran Riaz Khan","id":"UCaszgR2TH3qNw_CxLHAd2SQ", "about": "<div class='details-content'><h3>About</h3><p>Imran Riaz Khan is a Pakistani journalist and TV anchor. On 11 May 2023, Khan was reported to have been arrested by police while travelling in Pakistan. Media reports suggested that Imran's abduction may have been connected to him speaking out against the government and military. <a href='https://en.wikipedia.org/wiki/Imran_Riaz_Khan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> August 14, 1975 (age 50 years), Faisalabad, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Imran Riaz Khan</div><div><strong>Views:</strong> 1.58 billion</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/c/ImranRiazKhan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://www.instagram.com/imrankhanjrnlist' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a><a class='profile' href='https://twitter.com/ImranRiazKhan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/ImranRiazKhanOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"SabirShakir","name":"Sabir Shakir","id":"UCY7eFg5TEMsk_aTqM0pVB4w","about":"<div class='details-content'><h3>About</h3><p>Sabir Shakir is a prominent Pakistani journalist, TV anchor, political commentator and former ARY News bureau chief, known for hosting the talk show The Reporters and running a YouTube channel featuring in-depth political analysis. He launched his channel in 2019 and has amassed a large following. <a href='https://en.everybodywiki.com/Sabir_Shakir' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> November 8, 1982 (age 42 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Sabir Shakir</div><div><strong>Views:</strong> 1.23 billion</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCY7eFg5TEMsk_aTqM0pVB4w' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/ARYSabirShakir' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/SabirShakirARY' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"SamiAbraham","name":"Sami Abraham","id":"UCFCzDl-XQq1TCo_fvBzCoyw","about":"<div class='details-content'><h3>About</h3><p>Sami Abraham is a Pakistani journalist and TV anchor known for his incisive political commentary and news analysis. Hosting shows like “LIVE With Sami Abraham” on platforms including 66 News, he provides in-depth coverage of current affairs. <a href='https://en.wikipedia.org/wiki/Sami_Abraham' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Sami Abraham</div><div><strong>Views:</strong> —</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCFCzDl-XQq1TCo_fvBzCoyw' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a></div></div>"},
-    {"key":"MansoorAliKhan","name":"Mansoor Ali Khan","id":"UClDtMswg3muouH60XTKlVEw","about":"<div class='details-content'><h3>About</h3><p>Mansoor Ali Khan is a Pakistani journalist, television anchor, podcaster and vlogger born on 22 April 1976 in Lahore. With a career spanning top networks including Geo News, Express News and Hum News, he hosts current-affairs shows and contributes political analysis via his YouTube channel, which has over 2.5 million subscribers. <a href='https://en.wikipedia.org/wiki/Mansoor_Ali_Khan_(journalist)' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 22 April 1976 (age 49 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Mansoor Ali Khan</div><div><strong>Views:</strong> 208 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UClDtMswg3muouH60XTKlVEw' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/_mansoor_ali' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"MoeedPirzada","name":"Dr Moeed Pirzada","id":"UCnkYymEbl1qZ0VhGrzH9guw","about":"<div class='details-content'><h3>About</h3><p>Dr Moeed Pirzada is a British-Pakistani geostrategic analyst, journalist, TV anchor, columnist and editor based in Washington, DC. He hosts “Tonight with Moeed Pirzada,” founded Global Village Space, and has interviewed global figures including Hillary Clinton and David Cameron. <a href='https://en.wikipedia.org/wiki/Moeed_Pirzada' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 27 July 1966 (age 59 years), Rawalpindi, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Dr. Moeed Pirzada Official</div><div><strong>Views:</strong> 157 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/@DrMoeedPirzadaOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/moeednj' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/MoeedPirzada' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a><a class='profile' href='https://www.instagram.com/moeed.pirzada' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a></div></div>"},
-    {"key":"MubasherLucman","name":"Mubasher Lucman","id":"UCslugpmYWJiZK5rbvtcaV7Q","about":"<div class='details-content'><h3>About</h3><p>Mubasher Lucman is a Pakistani anchorperson, columnist and former caretaker provincial minister of Punjab (2007–08), who launched ARY Digital as its first CEO. Known for his investigative journalism and hit current-affairs shows like “Khara Sach,” he transitioned to YouTube (channel launched 2018) and hosts in-depth political talk shows. <a href='https://en.wikipedia.org/wiki/Mubashir_Lucman' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 11 January 1963 (age 62 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Mubasher Lucman Official</div><div><strong>Views:</strong> 429 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCslugpmYWJiZK5rbvtcaV7Q' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/mubasherlucman' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.instagram.com/lucman.mubasher' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a><a class='profile' href='https://www.facebook.com/Mubashir.Luqman.Official' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"FaisalWarraich","name":"Faisal Warraich","id":"UChOzmkBxTHbZNZdiiYolWoA","about":"<div class='details-content'><h3>About</h3><p>Faisal Warraich is a Pakistani researcher, historian, storyteller and YouTuber best known for producing documentary-style videos on history, geopolitics and biography through his channels “Faisal Warraich” and “Dekho Suno Jano.” He captivates audiences with deep dives into empires, wars, and civilisations. <a href='https://en.wikipedia.org/wiki/Suhail_Warraich' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Faisal Warraich</div><div><strong>Views:</strong> 116 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/@Faisal.Warraich' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/fswarraich' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"AbdulQadir","name":"Abdul Qadir","id":"UCYdLgIyZnHVwlDkF3Y0G_cQ","about":"<div class='details-content'><h3>About</h3><p>Abdul Qadir is a Pakistani ARY News reporter and political vlogger known for his YouTube channel “Abdul Qadir,” where he covers updates related to Imran Khan, the PTI, and Pakistan’s political landscape in a concise daily format. <a href='https://en.wikipedia.org/wiki/Abdul_Qadir_(cricketer)' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Abdul Qadir</div><div><strong>Views:</strong> 312 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCYdLgIyZnHVwlDkF3Y0G_cQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://twitter.com/AbdulQadirARY' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/abdulqadir.ary' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a><a class='profile' href='https://www.instagram.com/abdulqadir_ary/' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a></div></div>"},
-    {"key":"AnsarAbbasi","name":"Ansar Abbasi","id":"UCw6Gt_4bm-n4yLNUaqon_qA","about":"<div class='details-content'><h3>About</h3><p>Ansar Abbasi is a Pakistani investigative journalist and columnist, serving as a senior editor at The News International. Known for his incisive political commentary and investigative reporting, he holds master’s degrees from Balochistan University and Goldsmiths, University of London. He shares in-depth analysis via his YouTube channel. <a href='https://en.wikipedia.org/wiki/Ansar_Abbasi' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> June 12, 1965 (age 60 years), Murree, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Ansar Abbasi</div><div><strong>Views:</strong> —</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/@InvestigativeJournalist' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/AnsarAAbbasi' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"AsmaShirazi","name":"Asma Shirazi","id":"UCYAIiV0G2ups3CyiFcPeBlg","about":"<div class='details-content'><h3>About</h3><p>Asma Shirazi is a senior Pakistani journalist, political commentator and TV anchor, known for her courageous frontline reporting and current-affairs shows. She earned the prestigious Peter Mackler Award for Courageous and Ethical Journalism in 2014. <a href='https://en.wikipedia.org/wiki/Asma_Shirazi' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 1976 (age 49 years), Islamabad, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Asma Shirazi</div><div><strong>Views:</strong> —</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCYAIiV0G2ups3CyiFcPeBlg' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/asmashirazi' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/AsmaShiraziOffice' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a><a class='profile' href='https://www.instagram.com/asmashiraziofficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a></div></div>"},
-    {"key":"ArshadSharif","name":"Arshad Sharif","id":"UC0UiDwKaevYAOTmVzXkrHSQ","about":"<div class='details-content'><h3>About</h3><p>Arshad Sharif (1973–2022) was a Pakistani investigative journalist, news anchor and author, famed for hosting **Power Play** on ARY News and his fearless political reporting. He received the Pride of Performance award in 2019. Sharif was tragically assassinated in Kenya in October 2022. <a href='https://en.wikipedia.org/wiki/Arshad_Sharif' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 22 February 1973 (age 49 years), Karachi, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Arshad Sharif Official</div><div><strong>Views:</strong> 12.3 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/ArshadSharifOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a></div></div>"},
-    {"key":"NasimZehra","name":"Nasim Zehra","id":"UCKtRaClqV6naRHzuxrsDPnA","about":"<div class='details-content'><h3>About</h3><p>Nasim Zehra (born 8 January 1959) is a Pakistani journalist, writer and TV anchor from Lahore. A Fletcher School alumnus, she hosts a primetime current affairs talk show on Channel 24 and authored the book *From Kargil to the Coup: Events That Shook Pakistan* (2018). She received the Agahi Award in 2016. <a href='https://en.wikipedia.org/wiki/Nasim_Zehra' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 8 January 1959 (age 66 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Nasim Zehra</div><div><strong>Views:</strong> —</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/@NasimZehraOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/nasimzehra' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"RaufKlasra","name":"Rauf Klasra","id":"UCreAj2r67xRSmf3EQxM5KuQ","about":"<div class='details-content'><h3>About</h3><p>Rauf Klasra (born 14 August 1975, age 49) is a Pakistani investigative journalist and Urdu-language columnist known for exposing political and financial scandals. Educated at Bahauddin Zakariya University and Goldsmiths, he also hosts TV shows and writes multiple books. <a href='https://en.wikipedia.org/wiki/Rauf_Klasra' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 14 August 1975 (age 49 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Rauf Klasra</div><div><strong>Views:</strong> 64.9 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCreAj2r67xRSmf3EQxM5KuQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/KlasraRauf' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/RaufKlasra1' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a><a class='profile' href='https://www.instagram.com/RaufKlasra' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a></div></div>"},
-    {"key":"ZaidHamid","name":"Syed Zaid Zaman Hamid","id":"UCpjldgul1pMZJpiL09j8JxA","about":"<div class='details-content'><h3>About</h3><p>Syed Zaid Zaman Hamid (born 14 March 1964) is a Pakistani far-right Islamist political commentator, security consultant and conspiracy theorist, known for hosting the TV series “Brass Tacks” and featuring in The Muslim 500 list of influential Muslims. <a href='https://en.wikipedia.org/wiki/Zaid_Hamid' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 14 March 1964 (age 61 years), Karachi, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Zaid Zaman Hamid Official</div><div><strong>Views:</strong> 2.94 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCpjldgul1pMZJpiL09j8JxA' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='http://www.zaidhamid.pk' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/internet-web-browser.png' alt='Website'><span>Website</span></a></div></div>"},
-    {"key":"TaimurRahman","name":"Taimur Rahman (laal)","id":"UCIyAy8lIQwnj-2CGt9e-N3g","about":"<div class='details-content'><h3>About</h3><p>Taimur Rahman is a Pakistani academic, musician, and leftist political activist, serving as the general secretary of the Mazdoor Kisan Party and lead guitarist of the band Laal. He teaches political science at LUMS and uses his YouTube channel to discuss politics, history, and economics. <a href='https://en.wikipedia.org/wiki/Taimur_Rahman' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Taimur Rahman</div><div><strong>Views:</strong> 12.4 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCIyAy8lIQwnj-2CGt9e-N3g' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/Taimur_Laal' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/LaalPakistan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"AliHaider","name":"Syed Ali Haider","id":"UCep38ldld-DjkOJt9Oh0gOA","about":"<div class='details-content'><h3>About</h3><p>Syed Ali Haider is a Pakistani journalist and news anchor who gained popularity via his YouTube channel “Syed Ali Haider Official,” where he posts rapid breaking news updates and political commentary. His channel has amassed over 2.2 million subscribers. <a href='https://www.famousbirthdays.com/people/syed-ali-haider.html' target='_blank' rel='noopener'>FamousBirthdays</a></p><div class='meta'><div><strong>Born:</strong> 2 April 1985 (age 40 years), India</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Syed Ali Haider Official</div><div><strong>Views:</strong> —</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCep38ldld-DjkOJt9Oh0gOA' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/syedalihaider13' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.instagram.com/syed.ali.haider5' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/instagram-new.png' alt='Instagram'><span>Instagram</span></a><a class='profile' href='https://www.facebook.com/syedalihaider112/' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"SiddiqueJaan","name":"Siddique Jaan","id":"UC-PoCqWxInxzN-9r9FxXJGg","about":"<div class='details-content'><h3>About</h3><p>Siddique Jaan is a Pakistani political commentator and Supreme Court reporter, serving as Bureau Chief Islamabad at BOL News and known for his sharp analysis on current affairs via his YouTube channel. He began his career as a social media coordinator and rose through journalistic ranks covering landmark legal cases. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Siddique Jaan</div><div><strong>Views:</strong> 373 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UC-PoCqWxInxzN-9r9FxXJGg' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/sdqjaan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"UsamaGhazi","name":"Usama Ghazi","id":"UCAO1utA5OhesHBHWjXd1wMw","about":"<div class='details-content'><h3>About</h3><p>Usama Ghazi is a Pakistani journalist, anchor and YouTuber known for his political commentary and news analysis, often focusing on governance, economy, and Pakistan’s socio-political landscape. A former TV news presenter, he now runs the channel “Usama Ghazi” with millions of views. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Usama Ghazi</div><div><strong>Views:</strong> 392 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCAO1utA5OhesHBHWjXd1wMw' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/usamaghazi786' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/usamaghaziofficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"JameelFarooqui","name":"Jameel Farooqui","id":"UCeqdeoG3nRSkkbBKT9u3wQQ","about":"<div class='details-content'><h3>About</h3><p>Jameel Farooqui is a Pakistani journalist and news anchor known for his outspoken political commentary and investigative reporting. Through his YouTube channel, he covers current affairs, governance issues, and human rights topics. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Jameel Farooqui</div><div><strong>Views:</strong> 91.7 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCeqdeoG3nRSkkbBKT9u3wQQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/jameelfarooqui_' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/jameelfarooqui786' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"WaqarMalik","name":"Waqar Malik","id":"UCFqjOGv7tON3rY9kHPLa-OQ","about":"<div class='details-content'><h3>About</h3><p>Waqar Malik is a Pakistani political commentator and digital content creator who uses his YouTube platform to discuss governance, politics, and current affairs. Known for his candid style, he has built a significant online following among politically engaged audiences. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Waqar Malik</div><div><strong>Views:</strong> 44.2 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCFqjOGv7tON3rY9kHPLa-OQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/WaqarMalikPK' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/WaqarMalikOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"Muzammil","name":"Syed Muzammil","id":"UCAyd8kYxON-KM0UuRuK_sIg","about":"<div class='details-content'><h3>About</h3><p>Syed Muzammil is a Pakistani political analyst and YouTuber who produces commentary on governance, legal affairs, and political developments. His direct style and frequent updates have earned him a growing audience on YouTube. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Syed Muzammil</div><div><strong>Views:</strong> 85.6 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCAyd8kYxON-KM0UuRuK_sIg' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/MuzammilViews' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"NayaDaurTV","name":"Naya Daur TV","id":"UCzVdIJeAwQfBZbG_8AOXgBw","about":"<div class='details-content'><h3>About</h3><p>Naya Daur TV is a Pakistani digital news and commentary platform that produces independent journalism, political analysis, and socio-cultural discussions. Its YouTube channel features talk shows, interviews, and explainer videos in Urdu and English. <a href='https://nayadaur.tv' target='_blank' rel='noopener'>Website</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Naya Daur TV</div><div><strong>Views:</strong> 55.8 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCzVdIJeAwQfBZbG_8AOXgBw' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/nayadaurpk' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/NayaDaurPk' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"AsadAliToor","name":"Asad Ali Toor","id":"UCXORDenrw6IHFUvg0PH-3hg","about":"<div class='details-content'><h3>About</h3><p>Asad Ali Toor is a Pakistani journalist and YouTuber known for his outspoken political commentary and coverage of civil liberties and press freedom issues. He frequently critiques state policies and champions free expression through his digital platform. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Asad Ali Toor</div><div><strong>Views:</strong> 54.3 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCXORDenrw6IHFUvg0PH-3hg' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/AsadAToor' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/AsadAliToorJournalist' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"MatiullahJan","name":"Matiullah Jan","id":"UC-hJ0cobUiWlBFTHgLwt8sQ","about":"<div class='details-content'><h3>About</h3><p>Matiullah Jan is a veteran Pakistani journalist and YouTuber known for his critical stance on government policies, judicial matters, and press freedom. He has worked with leading news outlets and survived an abduction in 2020, widely condemned as an attack on free speech. <a href='https://en.wikipedia.org/wiki/Matiullah_Jan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Matiullah Jan</div><div><strong>Views:</strong> 61.2 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UC-hJ0cobUiWlBFTHgLwt8sQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/Matiullahjan919' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/matiullah.jan.395' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"AftabIqbal","name":"Aftab Iqbal","id":"UCFqEO3bSGcp5I8HVgXYdYRQ","about":"<div class='details-content'><h3>About</h3><p>Aftab Iqbal is a Pakistani television host, journalist, and satirist, best known for creating and hosting popular comedy-current affairs shows like *Hasb-e-Haal*, *Khabarnaak*, and *Khabarzar*. He is the founder of Aap Media Network and runs his own digital channels. <a href='https://en.wikipedia.org/wiki/Aftab_Iqbal_(journalist)' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 9 September 1961 (age 63 years), Okara, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Aftab Iqbal</div><div><strong>Views:</strong> 546 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCFqEO3bSGcp5I8HVgXYdYRQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/aftab_iqbal1' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/AftabIqbalOfficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"AminHafeez","name":"Amin Hafeez","id":"UCfL1eqnP_EYuE5gt9OrFHuA","about":"<div class='details-content'><h3>About</h3><p>Amin Hafeez is a Pakistani journalist and reporter celebrated for his humorous and unconventional news reporting style, especially during his tenure at Geo News. His lighthearted yet insightful coverage has made him a popular media personality. <a href='https://en.wikipedia.org/wiki/Amin_Hafeez' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Amin Hafeez</div><div><strong>Views:</strong> 12.1 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCfL1eqnP_EYuE5gt9OrFHuA' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/AminHafeezGeo' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"MuneebFarooq","name":"Muneeb Farooq","id":"UC57P3Cnt2Lq2W310oJxe7sA","about":"<div class='details-content'><h3>About</h3><p>Muneeb Farooq is a Pakistani lawyer, journalist, and TV host known for moderating talk shows such as *Aapas Ki Baat* on Geo News and *Ikhtilaf-e-Rai* on Public News. His YouTube channel features political analysis and interviews. <a href='https://en.wikipedia.org/wiki/Muneeb_Farooq' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 26 January 1983 (age 42 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Muneeb Farooq</div><div><strong>Views:</strong> 14.8 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UC57P3Cnt2Lq2W310oJxe7sA' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/muneebfaruqpak' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/muneebfarooqofficial' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"AhmadNoorani","name":"Ahmad Noorani","id":"UCokfj4SqQZsdjRoG4mUci4A","about":"<div class='details-content'><h3>About</h3><p>Ahmad Noorani is a Pakistani investigative journalist and co-founder of FactFocus, known for exposing high-profile corruption and publishing detailed investigative reports. His work has often led to controversy and government pushback. <a href='https://en.wikipedia.org/wiki/Ahmad_Noorani' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Ahmad Noorani</div><div><strong>Views:</strong> 7.5 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCokfj4SqQZsdjRoG4mUci4A' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/Ahmad_Noorani' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"IndependentUrdu","name":"Independent Urdu","id":"UCAvhohWtYwPdpKVGiMkkKOQ","about":"<div class='details-content'><h3>About</h3><p>Independent Urdu is the Urdu-language service of The Independent, delivering news, features, and analysis on Pakistan and global affairs. Its YouTube channel hosts reports, interviews, and explainers on politics, culture, and current events. <a href='https://www.independenturdu.com' target='_blank' rel='noopener'>Website</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Independent Urdu</div><div><strong>Views:</strong> 506 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCAvhohWtYwPdpKVGiMkkKOQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/indyurdu' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/IndependentUrdu' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"HamidMir","name":"Hamid Mir","id":"UC5N0MlMQopPTGMLUxHISfDg","about":"<div class='details-content'><h3>About</h3><p>Hamid Mir is a veteran Pakistani journalist, news anchor, and author known for hosting *Capital Talk* on Geo News. He has interviewed numerous world leaders and received awards for press freedom, surviving multiple assassination attempts. <a href='https://en.wikipedia.org/wiki/Hamid_Mir' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 23 July 1966 (age 59 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Hamid Mir</div><div><strong>Views:</strong> 14.7 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UC5N0MlMQopPTGMLUxHISfDg' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/HamidMirPAK' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/HamidMirGeo' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"HabibAkram","name":"Habib Akram","id":"UC5kUxR5q8SKtGB-9z7Rr1Iw","about":"<div class='details-content'><h3>About</h3><p>Habib Akram is a Pakistani journalist, analyst, and TV host recognized for his political commentary and current affairs programs. He has been associated with Dunya News and other leading news outlets, offering insights on national politics and governance. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Habib Akram</div><div><strong>Views:</strong> 22.4 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UC5kUxR5q8SKtGB-9z7Rr1Iw' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a></div></div>"},
-    {"key":"AsadToor","name":"Asad Toor","id":"UCXORDenrw6IHFUvg0PH-3hg","about":"<div class='details-content'><h3>About</h3><p>Asad Toor is a Pakistani journalist and vlogger known for his outspoken views on press freedom, human rights, and governance issues. He has faced harassment for his critical reporting on state institutions and political developments. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Asad Toor</div><div><strong>Views:</strong> 54.3 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCXORDenrw6IHFUvg0PH-3hg' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/AsadAToor' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a><a class='profile' href='https://www.facebook.com/AsadAliToorJournalist' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/facebook-new.png' alt='Facebook'><span>Facebook</span></a></div></div>"},
-    {"key":"WajahatSKhan","name":"Wajahat Saeed Khan","id":"UCxaMbYDd4o_zVvfr9_wKAxQ","about":"<div class='details-content'><h3>About</h3><p>Wajahat Saeed Khan is a Pakistani multimedia journalist and war correspondent, having worked with NBC News, Dunya News, and other international outlets. He covers defense, politics, and security, and has reported from conflict zones around the world. <a href='https://en.wikipedia.org/wiki/Wajahat_Saeed_Khan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Wajahat Saeed Khan</div><div><strong>Views:</strong> 1.37 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCxaMbYDd4o_zVvfr9_wKAxQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a><a class='profile' href='https://x.com/WajSKhan' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/twitter--v1.png' alt='X'><span>X (Twitter)</span></a></div></div>"},
-    {"key":"Zaeemleghari","name":"Zaeem leghari","id":"UCfTQGgFP5U53mcbbRRLl1yQ","about":"<div class='details-content'><h3>About</h3><p>Zaeem Leghari is a Pakistani political commentator and YouTuber who discusses current affairs, political developments, and governance issues on his channel. His direct style has attracted an audience interested in political analysis. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Zaeem Leghari</div><div><strong>Views:</strong> 4.21 million</div></div><h3>Profiles</h3><div class='profiles'><a class='profile' href='https://www.youtube.com/channel/UCfTQGgFP5U53mcbbRRLl1yQ' target='_blank' rel='noopener'><img src='https://img.icons8.com/color/48/000000/youtube-play.png' alt='YouTube'><span>YouTube</span></a></div></div>"}
+    {
+      "key": "ImranRiazKhan",
+      "name": "Imran Riaz Khan",
+      "id": "UCaszgR2TH3qNw_CxLHAd2SQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Imran Riaz Khan is a Pakistani journalist and TV anchor. On 11 May 2023, Khan was reported to have been arrested by police while travelling in Pakistan. Media reports suggested that Imran's abduction may have been connected to him speaking out against the government and military. <a href='https://en.wikipedia.org/wiki/Imran_Riaz_Khan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> August 14, 1975 (age 50 years), Faisalabad, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Imran Riaz Khan</div><div><strong>Views:</strong> 1.58 billion</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/c/ImranRiazKhan",
+        "https://www.instagram.com/imrankhanjrnlist",
+        "https://twitter.com/ImranRiazKhan",
+        "https://www.facebook.com/ImranRiazKhanOfficial"
+      ]
+    },
+    {
+      "key": "SabirShakir",
+      "name": "Sabir Shakir",
+      "id": "UCY7eFg5TEMsk_aTqM0pVB4w",
+      "about": "<div class='details-content'><h3>About</h3><p>Sabir Shakir is a prominent Pakistani journalist, TV anchor, political commentator and former ARY News bureau chief, known for hosting the talk show The Reporters and running a YouTube channel featuring in-depth political analysis. He launched his channel in 2019 and has amassed a large following. <a href='https://en.everybodywiki.com/Sabir_Shakir' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> November 8, 1982 (age 42 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Sabir Shakir</div><div><strong>Views:</strong> 1.23 billion</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCY7eFg5TEMsk_aTqM0pVB4w",
+        "https://x.com/ARYSabirShakir",
+        "https://www.facebook.com/SabirShakirARY"
+      ]
+    },
+    {
+      "key": "SamiAbraham",
+      "name": "Sami Abraham",
+      "id": "UCFCzDl-XQq1TCo_fvBzCoyw",
+      "about": "<div class='details-content'><h3>About</h3><p>Sami Abraham is a Pakistani journalist and TV anchor known for his incisive political commentary and news analysis. Hosting shows like “LIVE With Sami Abraham” on platforms including 66 News, he provides in-depth coverage of current affairs. <a href='https://en.wikipedia.org/wiki/Sami_Abraham' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Sami Abraham</div><div><strong>Views:</strong> —</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCFCzDl-XQq1TCo_fvBzCoyw"
+      ]
+    },
+    {
+      "key": "MansoorAliKhan",
+      "name": "Mansoor Ali Khan",
+      "id": "UClDtMswg3muouH60XTKlVEw",
+      "about": "<div class='details-content'><h3>About</h3><p>Mansoor Ali Khan is a Pakistani journalist, television anchor, podcaster and vlogger born on 22 April 1976 in Lahore. With a career spanning top networks including Geo News, Express News and Hum News, he hosts current-affairs shows and contributes political analysis via his YouTube channel, which has over 2.5 million subscribers. <a href='https://en.wikipedia.org/wiki/Mansoor_Ali_Khan_(journalist)' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 22 April 1976 (age 49 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Mansoor Ali Khan</div><div><strong>Views:</strong> 208 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UClDtMswg3muouH60XTKlVEw",
+        "https://x.com/_mansoor_ali"
+      ]
+    },
+    {
+      "key": "MoeedPirzada",
+      "name": "Dr Moeed Pirzada",
+      "id": "UCnkYymEbl1qZ0VhGrzH9guw",
+      "about": "<div class='details-content'><h3>About</h3><p>Dr Moeed Pirzada is a British-Pakistani geostrategic analyst, journalist, TV anchor, columnist and editor based in Washington, DC. He hosts “Tonight with Moeed Pirzada,” founded Global Village Space, and has interviewed global figures including Hillary Clinton and David Cameron. <a href='https://en.wikipedia.org/wiki/Moeed_Pirzada' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 27 July 1966 (age 59 years), Rawalpindi, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Dr. Moeed Pirzada Official</div><div><strong>Views:</strong> 157 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/@DrMoeedPirzadaOfficial",
+        "https://x.com/moeednj",
+        "https://www.facebook.com/MoeedPirzada",
+        "https://www.instagram.com/moeed.pirzada"
+      ]
+    },
+    {
+      "key": "MubasherLucman",
+      "name": "Mubasher Lucman",
+      "id": "UCslugpmYWJiZK5rbvtcaV7Q",
+      "about": "<div class='details-content'><h3>About</h3><p>Mubasher Lucman is a Pakistani anchorperson, columnist and former caretaker provincial minister of Punjab (2007–08), who launched ARY Digital as its first CEO. Known for his investigative journalism and hit current-affairs shows like “Khara Sach,” he transitioned to YouTube (channel launched 2018) and hosts in-depth political talk shows. <a href='https://en.wikipedia.org/wiki/Mubashir_Lucman' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 11 January 1963 (age 62 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Mubasher Lucman Official</div><div><strong>Views:</strong> 429 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCslugpmYWJiZK5rbvtcaV7Q",
+        "https://x.com/mubasherlucman",
+        "https://www.instagram.com/lucman.mubasher",
+        "https://www.facebook.com/Mubashir.Luqman.Official"
+      ]
+    },
+    {
+      "key": "FaisalWarraich",
+      "name": "Faisal Warraich",
+      "id": "UChOzmkBxTHbZNZdiiYolWoA",
+      "about": "<div class='details-content'><h3>About</h3><p>Faisal Warraich is a Pakistani researcher, historian, storyteller and YouTuber best known for producing documentary-style videos on history, geopolitics and biography through his channels “Faisal Warraich” and “Dekho Suno Jano.” He captivates audiences with deep dives into empires, wars, and civilisations. <a href='https://en.wikipedia.org/wiki/Suhail_Warraich' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Faisal Warraich</div><div><strong>Views:</strong> 116 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/@Faisal.Warraich",
+        "https://x.com/fswarraich"
+      ]
+    },
+    {
+      "key": "AbdulQadir",
+      "name": "Abdul Qadir",
+      "id": "UCYdLgIyZnHVwlDkF3Y0G_cQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Abdul Qadir is a Pakistani ARY News reporter and political vlogger known for his YouTube channel “Abdul Qadir,” where he covers updates related to Imran Khan, the PTI, and Pakistan’s political landscape in a concise daily format. <a href='https://en.wikipedia.org/wiki/Abdul_Qadir_(cricketer)' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Abdul Qadir</div><div><strong>Views:</strong> 312 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCYdLgIyZnHVwlDkF3Y0G_cQ",
+        "https://twitter.com/AbdulQadirARY",
+        "https://www.facebook.com/abdulqadir.ary",
+        "https://www.instagram.com/abdulqadir_ary/"
+      ]
+    },
+    {
+      "key": "AnsarAbbasi",
+      "name": "Ansar Abbasi",
+      "id": "UCw6Gt_4bm-n4yLNUaqon_qA",
+      "about": "<div class='details-content'><h3>About</h3><p>Ansar Abbasi is a Pakistani investigative journalist and columnist, serving as a senior editor at The News International. Known for his incisive political commentary and investigative reporting, he holds master’s degrees from Balochistan University and Goldsmiths, University of London. He shares in-depth analysis via his YouTube channel. <a href='https://en.wikipedia.org/wiki/Ansar_Abbasi' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> June 12, 1965 (age 60 years), Murree, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Ansar Abbasi</div><div><strong>Views:</strong> —</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/@InvestigativeJournalist",
+        "https://x.com/AnsarAAbbasi"
+      ]
+    },
+    {
+      "key": "AsmaShirazi",
+      "name": "Asma Shirazi",
+      "id": "UCYAIiV0G2ups3CyiFcPeBlg",
+      "about": "<div class='details-content'><h3>About</h3><p>Asma Shirazi is a senior Pakistani journalist, political commentator and TV anchor, known for her courageous frontline reporting and current-affairs shows. She earned the prestigious Peter Mackler Award for Courageous and Ethical Journalism in 2014. <a href='https://en.wikipedia.org/wiki/Asma_Shirazi' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 1976 (age 49 years), Islamabad, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Asma Shirazi</div><div><strong>Views:</strong> —</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCYAIiV0G2ups3CyiFcPeBlg",
+        "https://x.com/asmashirazi",
+        "https://www.facebook.com/AsmaShiraziOffice",
+        "https://www.instagram.com/asmashiraziofficial"
+      ]
+    },
+    {
+      "key": "ArshadSharif",
+      "name": "Arshad Sharif",
+      "id": "UC0UiDwKaevYAOTmVzXkrHSQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Arshad Sharif (1973–2022) was a Pakistani investigative journalist, news anchor and author, famed for hosting **Power Play** on ARY News and his fearless political reporting. He received the Pride of Performance award in 2019. Sharif was tragically assassinated in Kenya in October 2022. <a href='https://en.wikipedia.org/wiki/Arshad_Sharif' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 22 February 1973 (age 49 years), Karachi, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Arshad Sharif Official</div><div><strong>Views:</strong> 12.3 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/ArshadSharifOfficial"
+      ]
+    },
+    {
+      "key": "NasimZehra",
+      "name": "Nasim Zehra",
+      "id": "UCKtRaClqV6naRHzuxrsDPnA",
+      "about": "<div class='details-content'><h3>About</h3><p>Nasim Zehra (born 8 January 1959) is a Pakistani journalist, writer and TV anchor from Lahore. A Fletcher School alumnus, she hosts a primetime current affairs talk show on Channel 24 and authored the book *From Kargil to the Coup: Events That Shook Pakistan* (2018). She received the Agahi Award in 2016. <a href='https://en.wikipedia.org/wiki/Nasim_Zehra' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 8 January 1959 (age 66 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Nasim Zehra</div><div><strong>Views:</strong> —</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/@NasimZehraOfficial",
+        "https://x.com/nasimzehra"
+      ]
+    },
+    {
+      "key": "RaufKlasra",
+      "name": "Rauf Klasra",
+      "id": "UCreAj2r67xRSmf3EQxM5KuQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Rauf Klasra (born 14 August 1975, age 49) is a Pakistani investigative journalist and Urdu-language columnist known for exposing political and financial scandals. Educated at Bahauddin Zakariya University and Goldsmiths, he also hosts TV shows and writes multiple books. <a href='https://en.wikipedia.org/wiki/Rauf_Klasra' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 14 August 1975 (age 49 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Rauf Klasra</div><div><strong>Views:</strong> 64.9 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCreAj2r67xRSmf3EQxM5KuQ",
+        "https://x.com/KlasraRauf",
+        "https://www.facebook.com/RaufKlasra1",
+        "https://www.instagram.com/RaufKlasra"
+      ]
+    },
+    {
+      "key": "ZaidHamid",
+      "name": "Syed Zaid Zaman Hamid",
+      "id": "UCpjldgul1pMZJpiL09j8JxA",
+      "about": "<div class='details-content'><h3>About</h3><p>Syed Zaid Zaman Hamid (born 14 March 1964) is a Pakistani far-right Islamist political commentator, security consultant and conspiracy theorist, known for hosting the TV series “Brass Tacks” and featuring in The Muslim 500 list of influential Muslims. <a href='https://en.wikipedia.org/wiki/Zaid_Hamid' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 14 March 1964 (age 61 years), Karachi, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Zaid Zaman Hamid Official</div><div><strong>Views:</strong> 2.94 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCpjldgul1pMZJpiL09j8JxA",
+        "http://www.zaidhamid.pk"
+      ]
+    },
+    {
+      "key": "TaimurRahman",
+      "name": "Taimur Rahman (laal)",
+      "id": "UCIyAy8lIQwnj-2CGt9e-N3g",
+      "about": "<div class='details-content'><h3>About</h3><p>Taimur Rahman is a Pakistani academic, musician, and leftist political activist, serving as the general secretary of the Mazdoor Kisan Party and lead guitarist of the band Laal. He teaches political science at LUMS and uses his YouTube channel to discuss politics, history, and economics. <a href='https://en.wikipedia.org/wiki/Taimur_Rahman' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Taimur Rahman</div><div><strong>Views:</strong> 12.4 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCIyAy8lIQwnj-2CGt9e-N3g",
+        "https://x.com/Taimur_Laal",
+        "https://www.facebook.com/LaalPakistan"
+      ]
+    },
+    {
+      "key": "AliHaider",
+      "name": "Syed Ali Haider",
+      "id": "UCep38ldld-DjkOJt9Oh0gOA",
+      "about": "<div class='details-content'><h3>About</h3><p>Syed Ali Haider is a Pakistani journalist and news anchor who gained popularity via his YouTube channel “Syed Ali Haider Official,” where he posts rapid breaking news updates and political commentary. His channel has amassed over 2.2 million subscribers. <a href='https://www.famousbirthdays.com/people/syed-ali-haider.html' target='_blank' rel='noopener'>FamousBirthdays</a></p><div class='meta'><div><strong>Born:</strong> 2 April 1985 (age 40 years), India</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Syed Ali Haider Official</div><div><strong>Views:</strong> —</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCep38ldld-DjkOJt9Oh0gOA",
+        "https://x.com/syedalihaider13",
+        "https://www.instagram.com/syed.ali.haider5",
+        "https://www.facebook.com/syedalihaider112/"
+      ]
+    },
+    {
+      "key": "SiddiqueJaan",
+      "name": "Siddique Jaan",
+      "id": "UC-PoCqWxInxzN-9r9FxXJGg",
+      "about": "<div class='details-content'><h3>About</h3><p>Siddique Jaan is a Pakistani political commentator and Supreme Court reporter, serving as Bureau Chief Islamabad at BOL News and known for his sharp analysis on current affairs via his YouTube channel. He began his career as a social media coordinator and rose through journalistic ranks covering landmark legal cases. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Siddique Jaan</div><div><strong>Views:</strong> 373 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UC-PoCqWxInxzN-9r9FxXJGg",
+        "https://x.com/sdqjaan"
+      ]
+    },
+    {
+      "key": "UsamaGhazi",
+      "name": "Usama Ghazi",
+      "id": "UCAO1utA5OhesHBHWjXd1wMw",
+      "about": "<div class='details-content'><h3>About</h3><p>Usama Ghazi is a Pakistani journalist, anchor and YouTuber known for his political commentary and news analysis, often focusing on governance, economy, and Pakistan’s socio-political landscape. A former TV news presenter, he now runs the channel “Usama Ghazi” with millions of views. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Usama Ghazi</div><div><strong>Views:</strong> 392 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCAO1utA5OhesHBHWjXd1wMw",
+        "https://x.com/usamaghazi786",
+        "https://www.facebook.com/usamaghaziofficial"
+      ]
+    },
+    {
+      "key": "JameelFarooqui",
+      "name": "Jameel Farooqui",
+      "id": "UCeqdeoG3nRSkkbBKT9u3wQQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Jameel Farooqui is a Pakistani journalist and news anchor known for his outspoken political commentary and investigative reporting. Through his YouTube channel, he covers current affairs, governance issues, and human rights topics. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Jameel Farooqui</div><div><strong>Views:</strong> 91.7 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCeqdeoG3nRSkkbBKT9u3wQQ",
+        "https://x.com/jameelfarooqui_",
+        "https://www.facebook.com/jameelfarooqui786"
+      ]
+    },
+    {
+      "key": "WaqarMalik",
+      "name": "Waqar Malik",
+      "id": "UCFqjOGv7tON3rY9kHPLa-OQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Waqar Malik is a Pakistani political commentator and digital content creator who uses his YouTube platform to discuss governance, politics, and current affairs. Known for his candid style, he has built a significant online following among politically engaged audiences. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Waqar Malik</div><div><strong>Views:</strong> 44.2 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCFqjOGv7tON3rY9kHPLa-OQ",
+        "https://x.com/WaqarMalikPK",
+        "https://www.facebook.com/WaqarMalikOfficial"
+      ]
+    },
+    {
+      "key": "Muzammil",
+      "name": "Syed Muzammil",
+      "id": "UCAyd8kYxON-KM0UuRuK_sIg",
+      "about": "<div class='details-content'><h3>About</h3><p>Syed Muzammil is a Pakistani political analyst and YouTuber who produces commentary on governance, legal affairs, and political developments. His direct style and frequent updates have earned him a growing audience on YouTube. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Syed Muzammil</div><div><strong>Views:</strong> 85.6 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCAyd8kYxON-KM0UuRuK_sIg",
+        "https://x.com/MuzammilViews"
+      ]
+    },
+    {
+      "key": "NayaDaurTV",
+      "name": "Naya Daur TV",
+      "id": "UCzVdIJeAwQfBZbG_8AOXgBw",
+      "about": "<div class='details-content'><h3>About</h3><p>Naya Daur TV is a Pakistani digital news and commentary platform that produces independent journalism, political analysis, and socio-cultural discussions. Its YouTube channel features talk shows, interviews, and explainer videos in Urdu and English. <a href='https://nayadaur.tv' target='_blank' rel='noopener'>Website</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Naya Daur TV</div><div><strong>Views:</strong> 55.8 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCzVdIJeAwQfBZbG_8AOXgBw",
+        "https://x.com/nayadaurpk",
+        "https://www.facebook.com/NayaDaurPk"
+      ]
+    },
+    {
+      "key": "AsadAliToor",
+      "name": "Asad Ali Toor",
+      "id": "UCXORDenrw6IHFUvg0PH-3hg",
+      "about": "<div class='details-content'><h3>About</h3><p>Asad Ali Toor is a Pakistani journalist and YouTuber known for his outspoken political commentary and coverage of civil liberties and press freedom issues. He frequently critiques state policies and champions free expression through his digital platform. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Asad Ali Toor</div><div><strong>Views:</strong> 54.3 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCXORDenrw6IHFUvg0PH-3hg",
+        "https://x.com/AsadAToor",
+        "https://www.facebook.com/AsadAliToorJournalist"
+      ]
+    },
+    {
+      "key": "MatiullahJan",
+      "name": "Matiullah Jan",
+      "id": "UC-hJ0cobUiWlBFTHgLwt8sQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Matiullah Jan is a veteran Pakistani journalist and YouTuber known for his critical stance on government policies, judicial matters, and press freedom. He has worked with leading news outlets and survived an abduction in 2020, widely condemned as an attack on free speech. <a href='https://en.wikipedia.org/wiki/Matiullah_Jan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Matiullah Jan</div><div><strong>Views:</strong> 61.2 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UC-hJ0cobUiWlBFTHgLwt8sQ",
+        "https://x.com/Matiullahjan919",
+        "https://www.facebook.com/matiullah.jan.395"
+      ]
+    },
+    {
+      "key": "AftabIqbal",
+      "name": "Aftab Iqbal",
+      "id": "UCFqEO3bSGcp5I8HVgXYdYRQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Aftab Iqbal is a Pakistani television host, journalist, and satirist, best known for creating and hosting popular comedy-current affairs shows like *Hasb-e-Haal*, *Khabarnaak*, and *Khabarzar*. He is the founder of Aap Media Network and runs his own digital channels. <a href='https://en.wikipedia.org/wiki/Aftab_Iqbal_(journalist)' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 9 September 1961 (age 63 years), Okara, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Aftab Iqbal</div><div><strong>Views:</strong> 546 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCFqEO3bSGcp5I8HVgXYdYRQ",
+        "https://x.com/aftab_iqbal1",
+        "https://www.facebook.com/AftabIqbalOfficial"
+      ]
+    },
+    {
+      "key": "AminHafeez",
+      "name": "Amin Hafeez",
+      "id": "UCfL1eqnP_EYuE5gt9OrFHuA",
+      "about": "<div class='details-content'><h3>About</h3><p>Amin Hafeez is a Pakistani journalist and reporter celebrated for his humorous and unconventional news reporting style, especially during his tenure at Geo News. His lighthearted yet insightful coverage has made him a popular media personality. <a href='https://en.wikipedia.org/wiki/Amin_Hafeez' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Amin Hafeez</div><div><strong>Views:</strong> 12.1 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCfL1eqnP_EYuE5gt9OrFHuA",
+        "https://x.com/AminHafeezGeo"
+      ]
+    },
+    {
+      "key": "MuneebFarooq",
+      "name": "Muneeb Farooq",
+      "id": "UC57P3Cnt2Lq2W310oJxe7sA",
+      "about": "<div class='details-content'><h3>About</h3><p>Muneeb Farooq is a Pakistani lawyer, journalist, and TV host known for moderating talk shows such as *Aapas Ki Baat* on Geo News and *Ikhtilaf-e-Rai* on Public News. His YouTube channel features political analysis and interviews. <a href='https://en.wikipedia.org/wiki/Muneeb_Farooq' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 26 January 1983 (age 42 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Muneeb Farooq</div><div><strong>Views:</strong> 14.8 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UC57P3Cnt2Lq2W310oJxe7sA",
+        "https://x.com/muneebfaruqpak",
+        "https://www.facebook.com/muneebfarooqofficial"
+      ]
+    },
+    {
+      "key": "AhmadNoorani",
+      "name": "Ahmad Noorani",
+      "id": "UCokfj4SqQZsdjRoG4mUci4A",
+      "about": "<div class='details-content'><h3>About</h3><p>Ahmad Noorani is a Pakistani investigative journalist and co-founder of FactFocus, known for exposing high-profile corruption and publishing detailed investigative reports. His work has often led to controversy and government pushback. <a href='https://en.wikipedia.org/wiki/Ahmad_Noorani' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Ahmad Noorani</div><div><strong>Views:</strong> 7.5 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCokfj4SqQZsdjRoG4mUci4A",
+        "https://x.com/Ahmad_Noorani"
+      ]
+    },
+    {
+      "key": "IndependentUrdu",
+      "name": "Independent Urdu",
+      "id": "UCAvhohWtYwPdpKVGiMkkKOQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Independent Urdu is the Urdu-language service of The Independent, delivering news, features, and analysis on Pakistan and global affairs. Its YouTube channel hosts reports, interviews, and explainers on politics, culture, and current events. <a href='https://www.independenturdu.com' target='_blank' rel='noopener'>Website</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Independent Urdu</div><div><strong>Views:</strong> 506 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCAvhohWtYwPdpKVGiMkkKOQ",
+        "https://x.com/indyurdu",
+        "https://www.facebook.com/IndependentUrdu"
+      ]
+    },
+    {
+      "key": "HamidMir",
+      "name": "Hamid Mir",
+      "id": "UC5N0MlMQopPTGMLUxHISfDg",
+      "about": "<div class='details-content'><h3>About</h3><p>Hamid Mir is a veteran Pakistani journalist, news anchor, and author known for hosting *Capital Talk* on Geo News. He has interviewed numerous world leaders and received awards for press freedom, surviving multiple assassination attempts. <a href='https://en.wikipedia.org/wiki/Hamid_Mir' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> 23 July 1966 (age 59 years), Lahore, Pakistan</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Hamid Mir</div><div><strong>Views:</strong> 14.7 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UC5N0MlMQopPTGMLUxHISfDg",
+        "https://x.com/HamidMirPAK",
+        "https://www.facebook.com/HamidMirGeo"
+      ]
+    },
+    {
+      "key": "HabibAkram",
+      "name": "Habib Akram",
+      "id": "UC5kUxR5q8SKtGB-9z7Rr1Iw",
+      "about": "<div class='details-content'><h3>About</h3><p>Habib Akram is a Pakistani journalist, analyst, and TV host recognized for his political commentary and current affairs programs. He has been associated with Dunya News and other leading news outlets, offering insights on national politics and governance. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Habib Akram</div><div><strong>Views:</strong> 22.4 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UC5kUxR5q8SKtGB-9z7Rr1Iw"
+      ]
+    },
+    {
+      "key": "AsadToor",
+      "name": "Asad Toor",
+      "id": "UCXORDenrw6IHFUvg0PH-3hg",
+      "about": "<div class='details-content'><h3>About</h3><p>Asad Toor is a Pakistani journalist and vlogger known for his outspoken views on press freedom, human rights, and governance issues. He has faced harassment for his critical reporting on state institutions and political developments. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Asad Toor</div><div><strong>Views:</strong> 54.3 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCXORDenrw6IHFUvg0PH-3hg",
+        "https://x.com/AsadAToor",
+        "https://www.facebook.com/AsadAliToorJournalist"
+      ]
+    },
+    {
+      "key": "WajahatSKhan",
+      "name": "Wajahat Saeed Khan",
+      "id": "UCxaMbYDd4o_zVvfr9_wKAxQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Wajahat Saeed Khan is a Pakistani multimedia journalist and war correspondent, having worked with NBC News, Dunya News, and other international outlets. He covers defense, politics, and security, and has reported from conflict zones around the world. <a href='https://en.wikipedia.org/wiki/Wajahat_Saeed_Khan' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Wajahat Saeed Khan</div><div><strong>Views:</strong> 1.37 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCxaMbYDd4o_zVvfr9_wKAxQ",
+        "https://x.com/WajSKhan"
+      ]
+    },
+    {
+      "key": "Zaeemleghari",
+      "name": "Zaeem leghari",
+      "id": "UCfTQGgFP5U53mcbbRRLl1yQ",
+      "about": "<div class='details-content'><h3>About</h3><p>Zaeem Leghari is a Pakistani political commentator and YouTuber who discusses current affairs, political developments, and governance issues on his channel. His direct style has attracted an audience interested in political analysis. <a href='https://en.wikipedia.org/wiki/List_of_Pakistani_journalists' target='_blank' rel='noopener'>Wikipedia</a></p><div class='meta'><div><strong>Born:</strong> —</div><div><strong>Nationality:</strong> Pakistani</div><div><strong>Channel:</strong> Zaeem Leghari</div><div><strong>Views:</strong> 4.21 million</div></div></div>",
+      "profiles": [
+        "https://www.youtube.com/channel/UCfTQGgFP5U53mcbbRRLl1yQ"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- store social profile URLs in new `profiles` arrays inside `freepress_channels.json`
- render profile links on `freepress.html` using new JSON field and platform icons
- strip embedded profile HTML from channel `about` content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fca659ab08320b4d0a67a4442fac8