### PR TITLE
Restyle freepress profile section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -528,17 +528,28 @@ section {
 }
 
 .details-content .profile {
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-decoration: none;
   color: inherit;
   font-size: 0.8rem;
 }
 
-.details-content .profile img {
-  width: 40px;
-  height: 40px;
+.details-content .profile-icon {
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
+  background: var(--surface-variant);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-bottom: 4px;
+}
+
+.details-content .profile-icon img {
+  width: 24px;
+  height: 24px;
 }
 
 /* Buttons */

--- a/freepress.html
+++ b/freepress.html
@@ -164,7 +164,7 @@
         else if (/tiktok/.test(url)) type = 'tiktok';
         const { url: icon, label } = icons[type] || { url: '', label: type.charAt(0).toUpperCase() + type.slice(1) };
         const img = icon ? `<img src='${icon}' alt='${label}'>` : '';
-        return `<a class='profile' href='${url}' target='_blank' rel='noopener'>${img}<span>${label}</span></a>`;
+        return `<a class='profile' href='${url}' target='_blank' rel='noopener'><div class='profile-icon'>${img}</div><span>${label}</span></a>`;
       }).join('');
       return `<h3>Profiles</h3><div class='profiles'>${items}</div>`;
     }


### PR DESCRIPTION
## Summary
- Use a dedicated wrapper to render social profile icons with labels on the freepress page
- Style profile icons with a circular background and centered image for a more polished layout

## Testing
- `npx prettier --check freepress.html css/style.css` (fails: code style issues found)
- `npm test` (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_689fcd6403848320add49f76e436ca1b