### PR TITLE
feat: add desktop menu collapse controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -294,14 +294,19 @@ section {
 }
 
 .youtube-section .channel-list,
-.youtube-section .details-list {
+.youtube-section .details-container {
   display: flex;
   flex-direction: column;
   gap: 8px;
   width: 220px;
 }
-.youtube-section .details-list {
+.youtube-section .details-container {
   width: 300px;
+}
+.youtube-section .details-container .details-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .youtube-section .button-row {
@@ -451,6 +456,9 @@ section {
     padding: 16px;
     gap: 8px;
   }
+  .youtube-section .details-container {
+    width: auto;
+  }
   .youtube-section .details-list {
     position: fixed;
     top: 56px;
@@ -489,6 +497,24 @@ section {
   }
 }
 
+/* Collapse buttons */
+.collapse-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  font-size: 20px;
+  align-self: flex-end;
+}
+.channel-list .collapse-left {
+  align-self: flex-start;
+}
+@media (max-width: 768px) {
+  .collapse-btn {
+    display: none;
+  }
+}
+
 @media (min-width: 769px) {
   .youtube-section .channel-toggle,
   .youtube-section .details-toggle {
@@ -497,12 +523,38 @@ section {
   .youtube-section .button-row {
     display: none;
   }
-  .youtube-section .channel-list,
-  .youtube-section .details-list {
+  .youtube-section .channel-list {
     position: sticky;
     top: 72px;
     max-height: calc(100vh - 88px);
     overflow-y: auto;
+  }
+  .youtube-section .details-container {
+    position: sticky;
+    top: 72px;
+    max-height: calc(100vh - 88px);
+  }
+  .youtube-section .details-container .details-list {
+    overflow-y: auto;
+    flex: 1;
+  }
+  .youtube-section .channel-list.collapsed {
+    width: 72px;
+  }
+  .youtube-section .channel-list.collapsed .channel-card {
+    padding: 8px;
+    justify-content: center;
+  }
+  .youtube-section .channel-list.collapsed .channel-name,
+  .youtube-section .channel-list.collapsed .play-btn,
+  .youtube-section .channel-list.collapsed .fav-btn {
+    display: none;
+  }
+  .youtube-section .details-container.collapsed {
+    width: 24px;
+  }
+  .youtube-section .details-container.collapsed .details-list {
+    display: none;
   }
 }
 

--- a/freepress.html
+++ b/freepress.html
@@ -85,7 +85,9 @@
 
   <!-- Free Press section with channel list and video player -->
   <section class="youtube-section">
-    <div class="channel-list"></div>
+    <div class="channel-list">
+      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelCollapse()" aria-label="Collapse channel list">chevron_left</button>
+    </div>
     <!-- Video display area: a player for the selected video and a list of recent videos -->
     <div class="video-section">
       <div class="button-row">
@@ -97,7 +99,10 @@
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
-    <div class="details-list" style="display: none;"></div>
+    <div class="details-container">
+      <button class="collapse-btn collapse-right material-symbols-outlined" onclick="toggleDetailsCollapse()" aria-label="Collapse details list">chevron_right</button>
+      <div class="details-list" style="display: none;"></div>
+    </div>
   </section>
 
   <!-- Placeholder for advertising or extra content -->
@@ -549,6 +554,20 @@
     }
     detailsOpenStartX = null;
   });
+
+  function toggleChannelCollapse() {
+    const list = document.querySelector('.channel-list');
+    const btn = document.querySelector('.collapse-left');
+    list.classList.toggle('collapsed');
+    btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
+  }
+
+  function toggleDetailsCollapse() {
+    const container = document.querySelector('.details-container');
+    const btn = document.querySelector('.collapse-right');
+    container.classList.toggle('collapsed');
+    btn.textContent = container.classList.contains('collapsed') ? 'chevron_left' : 'chevron_right';
+  }
 </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/main.js"></script>

--- a/livetv.html
+++ b/livetv.html
@@ -85,7 +85,9 @@
 
   <!-- TV Livestream section -->
   <section class="youtube-section">
-    <div class="channel-list"></div>
+    <div class="channel-list">
+      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelCollapse()" aria-label="Collapse channel list">chevron_left</button>
+    </div>
     <div class="video-section">
       <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()">Channels</button>
     </div>
@@ -493,6 +495,13 @@
       }
       openStartX = null;
     });
+
+    function toggleChannelCollapse() {
+      const list = document.querySelector('.channel-list');
+      const btn = document.querySelector('.collapse-left');
+      list.classList.toggle('collapsed');
+      btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
+    }
   </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/main.js"></script>

--- a/radio.html
+++ b/radio.html
@@ -84,7 +84,9 @@
 
   <!-- Radio station listing -->
   <section class="youtube-section">
-    <div class="channel-list"></div>
+    <div class="channel-list">
+      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelCollapse()" aria-label="Collapse channel list">chevron_left</button>
+    </div>
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()">Stations</button>
       <div class="live-player">
@@ -597,6 +599,13 @@ channelList.addEventListener('touchend', (e) => {
   }
   touchStartX = null;
 });
+
+function toggleChannelCollapse() {
+  const list = document.querySelector('.channel-list');
+  const btn = document.querySelector('.collapse-left');
+  list.classList.toggle('collapsed');
+  btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
+}
   </script>
   <script defer src="/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow laptop users to collapse side menus on Free Press, Live TV, and Radio pages
- left menu reduces to thumbnails; Free Press right menu can hide entirely
- desktop-only collapse buttons with responsive CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fcf9f90a08320944111c5a588460e