### PR TITLE
Align sidebar height with video list

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -526,13 +526,13 @@ section {
   .youtube-section .channel-list {
     position: sticky;
     top: 72px;
-    max-height: calc(100vh - 88px);
+    height: calc(100vh - 120px);
     overflow-y: auto;
   }
   .youtube-section .details-container {
     position: sticky;
     top: 72px;
-    max-height: calc(100vh - 88px);
+    height: calc(100vh - 120px);
   }
   .youtube-section .details-container .details-list {
     overflow-y: auto;


### PR DESCRIPTION
## Summary
- Align channel list and details panel heights with video list so bottoms match

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fd1b315708320b652b238feaa6153