### PR TITLE
Style collapsed sidebar channel cards as circles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -549,6 +549,16 @@ section {
   .youtube-section .channel-list.collapsed .channel-card {
     padding: 8px;
     justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    box-sizing: border-box;
+  }
+  .youtube-section .channel-list.collapsed .channel-card .channel-thumb {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
   }
   .youtube-section .channel-list.collapsed .channel-name,
   .youtube-section .channel-list.collapsed .play-btn,


### PR DESCRIPTION
## Summary
- Restyle collapsed sidebar channel cards as perfect circles with centered circular thumbnails.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd3aaa648832098ca2e51991f64e1