### PR TITLE
Lock body scroll when menus open on mobile

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -382,6 +382,7 @@
     const btn = document.getElementById('toggle-channels');
     list.classList.toggle('open');
     btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
+    if (typeof updateScrollLock === 'function') updateScrollLock();
   }
 
   document.addEventListener('click', function(e) {
@@ -390,6 +391,7 @@
     if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
       list.classList.remove('open');
       btn.textContent = 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   });
 
@@ -406,6 +408,7 @@
     if (touchStartX - touchEndX > 50) {
       channelList.classList.remove('open');
       document.getElementById('toggle-channels').textContent = 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     touchStartX = null;
   });
@@ -430,6 +433,7 @@
     if (touchEndX - openStartX > 50 && openStartX < 50) {
       channelList.classList.add('open');
       document.getElementById('toggle-channels').textContent = 'Close Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     openStartX = null;
   });

--- a/css/style.css
+++ b/css/style.css
@@ -24,6 +24,10 @@ body {
   transition: background 0.3s, color 0.3s;
 }
 
+body.no-scroll {
+  overflow: hidden;
+}
+
 /* Top app bar */
 .top-bar {
   background: var(--primary);

--- a/freepress.html
+++ b/freepress.html
@@ -442,6 +442,7 @@
     const btn = document.getElementById('toggle-channels');
     list.classList.toggle('open');
     btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
+    if (typeof updateScrollLock === 'function') updateScrollLock();
   }
 
   document.addEventListener('click', function(e) {
@@ -450,6 +451,7 @@
     if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
       list.classList.remove('open');
       btn.textContent = 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   });
 
@@ -466,6 +468,7 @@
     if (touchStartX - touchEndX > 50) {
       channelList.classList.remove('open');
       document.getElementById('toggle-channels').textContent = 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     touchStartX = null;
   });
@@ -490,6 +493,7 @@
     if (touchEndX - openStartX > 50 && openStartX < 50) {
       channelList.classList.add('open');
       document.getElementById('toggle-channels').textContent = 'Close Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     openStartX = null;
   });
@@ -500,6 +504,7 @@
     if (btn.style.display === 'none') return;
     list.classList.toggle('open');
     btn.textContent = list.classList.contains('open') ? 'Close About' : 'About';
+    if (typeof updateScrollLock === 'function') updateScrollLock();
   }
 
   document.addEventListener('click', function(e) {
@@ -508,6 +513,7 @@
     if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
       list.classList.remove('open');
       btn.textContent = 'About';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   });
 
@@ -524,6 +530,7 @@
     if (touchEndX - detailsTouchStartX > 50) {
       detailsList.classList.remove('open');
       document.getElementById('toggle-details').textContent = 'About';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     detailsTouchStartX = null;
   });
@@ -551,6 +558,7 @@
     if (detailsOpenStartX > window.innerWidth - 50 && detailsOpenStartX - touchEndX > 50) {
       detailsList.classList.add('open');
       document.getElementById('toggle-details').textContent = 'Close About';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     detailsOpenStartX = null;
   });

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,13 @@ document.addEventListener('DOMContentLoaded', function () {
   var touchStartX = null;
   var touchStartY = null;
 
+  function updateScrollLock() {
+    var navOpen = navToggle && navToggle.checked;
+    var sideOpen = document.querySelector('.channel-list.open, .details-list.open');
+    document.body.classList.toggle('no-scroll', navOpen || !!sideOpen);
+  }
+  window.updateScrollLock = updateScrollLock;
+
   var currentPath = window.location.pathname;
   var links = document.querySelectorAll('.nav-links a');
   links.forEach(function (link) {
@@ -115,11 +122,13 @@ document.addEventListener('DOMContentLoaded', function () {
   label.addEventListener('click', function (e) {
     e.preventDefault();
     navToggle.checked = !navToggle.checked;
+    updateScrollLock();
   });
 
   document.addEventListener('click', function (e) {
     if (navToggle.checked && !nav.contains(e.target) && !label.contains(e.target)) {
       navToggle.checked = false;
+      updateScrollLock();
     }
   });
 
@@ -137,6 +146,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var dy = Math.abs(t.clientY - touchStartY);
     if (dx < -50 && dy < 30) {
       navToggle.checked = false;
+      updateScrollLock();
     }
     touchStartX = null;
     touchStartY = null;
@@ -152,6 +162,8 @@ document.addEventListener('DOMContentLoaded', function () {
       localStorage.setItem('theme', next);
     });
   }
+
+  updateScrollLock();
 
   if ('IntersectionObserver' in window) {
     const lazyElements = document.querySelectorAll('img[data-src], iframe[data-src]');

--- a/livetv.html
+++ b/livetv.html
@@ -444,6 +444,7 @@
       const btn = document.getElementById('toggle-channels');
       list.classList.toggle('open');
       btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
 
     document.addEventListener('click', function(e) {
@@ -452,6 +453,7 @@
       if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
         list.classList.remove('open');
         btn.textContent = 'Channels';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
       }
     });
 
@@ -468,6 +470,7 @@
       if (touchStartX - touchEndX > 50) {
         channelList.classList.remove('open');
         document.getElementById('toggle-channels').textContent = 'Channels';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
       }
       touchStartX = null;
     });
@@ -492,6 +495,7 @@
       if (touchEndX - openStartX > 50 && openStartX < 50) {
         channelList.classList.add('open');
         document.getElementById('toggle-channels').textContent = 'Close Channels';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
       }
       openStartX = null;
     });

--- a/radio.html
+++ b/radio.html
@@ -174,6 +174,7 @@ document.addEventListener('DOMContentLoaded', function() {
         channelList.classList.remove('open');
         const btn = document.getElementById('toggle-channels');
         if (btn) btn.textContent = 'Channels';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
       }
       touchStartX = null;
     });
@@ -199,6 +200,7 @@ document.addEventListener('DOMContentLoaded', function() {
         channelList.classList.add('open');
         const btn = document.getElementById('toggle-channels');
         if (btn) btn.textContent = 'Close Channels';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
       }
       openStartX = null;
     });
@@ -573,6 +575,7 @@ function toggleChannelList() {
   const btn = document.getElementById('toggle-channels');
   list.classList.toggle('open');
   btn.textContent = list.classList.contains('open') ? 'Close Stations' : 'Stations';
+  if (typeof updateScrollLock === 'function') updateScrollLock();
 }
 
 document.addEventListener('click', function(e) {
@@ -581,6 +584,7 @@ document.addEventListener('click', function(e) {
   if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
     list.classList.remove('open');
     btn.textContent = 'Stations';
+    if (typeof updateScrollLock === 'function') updateScrollLock();
   }
 });
 
@@ -596,6 +600,7 @@ channelList.addEventListener('touchend', (e) => {
   if (touchStartX - touchEndX > 50) {
     channelList.classList.remove('open');
     document.getElementById('toggle-channels').textContent = 'Stations';
+    if (typeof updateScrollLock === 'function') updateScrollLock();
   }
   touchStartX = null;
 });


### PR DESCRIPTION
## Summary
- add `.no-scroll` CSS and global `updateScrollLock` to disable page scroll when navigation or side menus are open
- invoke scroll locking from channel and details menus on Free Press, Radio, and Live TV pages

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689fd4f976448320882e045bb664e48a