### PR TITLE
Preserve channel card height during menu collapse

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -553,8 +553,8 @@ section {
   .youtube-section .channel-list.collapsed .channel-card {
     padding: 8px;
     justify-content: center;
-    width: 56px;
-    height: 56px;
+    width: var(--collapsed-size, 56px);
+    height: var(--collapsed-size, 56px);
     border-radius: 50%;
     box-sizing: border-box;
   }

--- a/freepress.html
+++ b/freepress.html
@@ -566,6 +566,16 @@
   function toggleChannelCollapse() {
     const list = document.querySelector('.channel-list');
     const btn = document.querySelector('.collapse-left');
+    const cards = list.querySelectorAll('.channel-card');
+    if (!list.classList.contains('collapsed')) {
+      cards.forEach(card => {
+        card.style.setProperty('--collapsed-size', card.offsetHeight + 'px');
+      });
+    } else {
+      cards.forEach(card => {
+        card.style.removeProperty('--collapsed-size');
+      });
+    }
     list.classList.toggle('collapsed');
     btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
   }

--- a/livetv.html
+++ b/livetv.html
@@ -503,6 +503,16 @@
     function toggleChannelCollapse() {
       const list = document.querySelector('.channel-list');
       const btn = document.querySelector('.collapse-left');
+      const cards = list.querySelectorAll('.channel-card');
+      if (!list.classList.contains('collapsed')) {
+        cards.forEach(card => {
+          card.style.setProperty('--collapsed-size', card.offsetHeight + 'px');
+        });
+      } else {
+        cards.forEach(card => {
+          card.style.removeProperty('--collapsed-size');
+        });
+      }
       list.classList.toggle('collapsed');
       btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
     }

--- a/radio.html
+++ b/radio.html
@@ -608,6 +608,16 @@ channelList.addEventListener('touchend', (e) => {
 function toggleChannelCollapse() {
   const list = document.querySelector('.channel-list');
   const btn = document.querySelector('.collapse-left');
+  const cards = list.querySelectorAll('.channel-card');
+  if (!list.classList.contains('collapsed')) {
+    cards.forEach(card => {
+      card.style.setProperty('--collapsed-size', card.offsetHeight + 'px');
+    });
+  } else {
+    cards.forEach(card => {
+      card.style.removeProperty('--collapsed-size');
+    });
+  }
   list.classList.toggle('collapsed');
   btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
 }


### PR DESCRIPTION
## Summary
- Use CSS variable for collapsed channel-card size to avoid shrinking height
- Set variable in collapse toggle to maintain card height when left menu collapses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd6f224fc832081adb428bb48c412