### PR TITLE
Remember menu collapse preferences

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -567,15 +567,35 @@
     const list = document.querySelector('.channel-list');
     const btn = document.querySelector('.collapse-left');
     list.classList.toggle('collapsed');
-    btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
+    const collapsed = list.classList.contains('collapsed');
+    btn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
+    localStorage.setItem('channelListCollapsed', collapsed);
   }
 
   function toggleDetailsCollapse() {
     const container = document.querySelector('.details-container');
     const btn = document.querySelector('.collapse-right');
     container.classList.toggle('collapsed');
-    btn.textContent = container.classList.contains('collapsed') ? 'chevron_left' : 'chevron_right';
+    const collapsed = container.classList.contains('collapsed');
+    btn.textContent = collapsed ? 'chevron_left' : 'chevron_right';
+    localStorage.setItem('detailsListCollapsed', collapsed);
   }
+
+  // Apply saved collapse state on load
+  (function() {
+    const list = document.querySelector('.channel-list');
+    const leftBtn = document.querySelector('.collapse-left');
+    if (localStorage.getItem('channelListCollapsed') === 'true') {
+      list.classList.add('collapsed');
+      if (leftBtn) leftBtn.textContent = 'chevron_right';
+    }
+    const container = document.querySelector('.details-container');
+    const rightBtn = document.querySelector('.collapse-right');
+    if (localStorage.getItem('detailsListCollapsed') === 'true') {
+      container.classList.add('collapsed');
+      if (rightBtn) rightBtn.textContent = 'chevron_left';
+    }
+  })();
 </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/main.js"></script>

--- a/livetv.html
+++ b/livetv.html
@@ -504,8 +504,20 @@
       const list = document.querySelector('.channel-list');
       const btn = document.querySelector('.collapse-left');
       list.classList.toggle('collapsed');
-      btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
+      const collapsed = list.classList.contains('collapsed');
+      btn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
+      localStorage.setItem('channelListCollapsed', collapsed);
     }
+
+    // Apply saved collapse state on load
+    (function() {
+      const list = document.querySelector('.channel-list');
+      const btn = document.querySelector('.collapse-left');
+      if (localStorage.getItem('channelListCollapsed') === 'true') {
+        list.classList.add('collapsed');
+        if (btn) btn.textContent = 'chevron_right';
+      }
+    })();
   </script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/main.js"></script>

--- a/radio.html
+++ b/radio.html
@@ -609,8 +609,20 @@ function toggleChannelCollapse() {
   const list = document.querySelector('.channel-list');
   const btn = document.querySelector('.collapse-left');
   list.classList.toggle('collapsed');
-  btn.textContent = list.classList.contains('collapsed') ? 'chevron_right' : 'chevron_left';
+  const collapsed = list.classList.contains('collapsed');
+  btn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
+  localStorage.setItem('channelListCollapsed', collapsed);
 }
+
+// Apply saved collapse state on load
+(function() {
+  const list = document.querySelector('.channel-list');
+  const btn = document.querySelector('.collapse-left');
+  if (localStorage.getItem('channelListCollapsed') === 'true') {
+    list.classList.add('collapsed');
+    if (btn) btn.textContent = 'chevron_right';
+  }
+})();
   </script>
   <script defer src="/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Store left and right menu collapse state in localStorage for persistence
- Apply saved collapse state on page load across Live TV, Radio, and Free Press pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd759bc148320b316ad80b151d5bf