### PR TITLE
Lock background when mobile menus open

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -455,7 +455,7 @@ section {
     box-shadow: 2px 0 5px rgba(0,0,0,0.3);
     overflow-y: auto;
     padding: 16px 8px;
-    z-index: 1001;
+    z-index: 1004;
     flex-direction: column;
     padding: 16px;
     gap: 8px;
@@ -476,7 +476,7 @@ section {
     box-shadow: -2px 0 5px rgba(0,0,0,0.3);
     overflow-y: auto;
     padding: 16px 8px;
-    z-index: 1001;
+    z-index: 1004;
     flex-direction: column;
     padding: 16px;
     gap: 8px;
@@ -899,7 +899,7 @@ table tbody tr.favorite {
     transition: transform 0.3s ease-in-out;
     will-change: transform;
     box-shadow: 2px 0 5px rgba(0,0,0,0.3);
-    z-index: 1001;
+    z-index: 1004;
     flex-direction: column;
     padding: 16px;
     gap: 8px;
@@ -923,16 +923,16 @@ table tbody tr.favorite {
 
   .nav-overlay {
     position: fixed;
-    top: 56px;
+    top: 0;
     left: 0;
     right: 0;
     bottom: 0;
     background: rgba(0,0,0,0.4);
     display: none;
-    z-index: 1000;
+    z-index: 1003;
   }
 
-  #nav-toggle:checked ~ .nav-overlay {
+  .nav-overlay.active {
     display: block;
   }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var label = document.querySelector('.nav-toggle-label');
   var topBar = document.querySelector('.top-bar');
   var themeToggle = document.getElementById('theme-toggle');
+  var overlay = document.querySelector('.nav-overlay');
   if (!navToggle || !nav || !label) return;
   var touchStartX = null;
   var touchStartY = null;
@@ -11,7 +12,9 @@ document.addEventListener('DOMContentLoaded', function () {
   function updateScrollLock() {
     var navOpen = navToggle && navToggle.checked;
     var sideOpen = document.querySelector('.channel-list.open, .details-list.open');
-    document.body.classList.toggle('no-scroll', navOpen || !!sideOpen);
+    var anyOpen = navOpen || !!sideOpen;
+    document.body.classList.toggle('no-scroll', anyOpen);
+    if (overlay) overlay.classList.toggle('active', anyOpen);
   }
   window.updateScrollLock = updateScrollLock;
 
@@ -131,6 +134,14 @@ document.addEventListener('DOMContentLoaded', function () {
       updateScrollLock();
     }
   });
+
+  if (overlay) {
+    overlay.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (navToggle) navToggle.checked = false;
+      updateScrollLock();
+    });
+  }
 
   document.addEventListener('touchstart', function (e) {
     if (!navToggle.checked) return;


### PR DESCRIPTION
## Summary
- Prevent interaction with the page when mobile nav or channel menus are open
- Add overlay handling in JavaScript to lock scrolling and close menus on tap
- Raise menu z-indexes and cover entire screen with overlay for better focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd81d6410832099823b4e8d59595c