### PR TITLE
Release scroll lock after selecting channel

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -255,6 +255,7 @@
       const list = document.querySelector('.channel-list');
       list.classList.remove('open');
       document.getElementById('toggle-channels').textContent = 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   
     if (!channelId) {

--- a/freepress.html
+++ b/freepress.html
@@ -312,6 +312,7 @@
       const list = document.querySelector('.channel-list');
       list.classList.remove('open');
       document.getElementById('toggle-channels').textContent = 'Channels';
+      if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   
     if (!channelId) {

--- a/livetv.html
+++ b/livetv.html
@@ -328,6 +328,7 @@
         const list = document.querySelector('.channel-list');
         list.classList.remove('open');
         document.getElementById('toggle-channels').textContent = 'Channels';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
       }
     }
 

--- a/radio.html
+++ b/radio.html
@@ -442,12 +442,21 @@ document.addEventListener('DOMContentLoaded', function() {
         document.addEventListener('touchstart', resumeHandler, { once: true });
       });
     }
-    currentAudio = audio;
-    currentLabel.textContent = name;
-    const newUrl = `${window.location.pathname}?station=${audio.id}`;
-    history.replaceState(null, '', newUrl);
-    updateFavoritesUI();
-  }
+      currentAudio = audio;
+      currentLabel.textContent = name;
+      const newUrl = `${window.location.pathname}?station=${audio.id}`;
+      history.replaceState(null, '', newUrl);
+
+      if (window.innerWidth <= 768) {
+        const list = document.querySelector('.channel-list');
+        list.classList.remove('open');
+        const btn = document.getElementById('toggle-channels');
+        if (btn) btn.textContent = 'Stations';
+        if (typeof updateScrollLock === 'function') updateScrollLock();
+      }
+
+      updateFavoritesUI();
+    }
 
   fetch('/radio_channels.json')
     .then(res => res.json())


### PR DESCRIPTION
## Summary
- unlock page scroll after choosing a channel on small screens
- apply same fix for free press, creators, and radio menus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fdbfe31848320a26d983d89161f21