### PR TITLE
Fix freepress RSS loading by using YouTube Data API

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -229,12 +229,17 @@
   }
 
   async function fetchLatestVideos(channelId) {
-    const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
-    const apiUrl = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(feedUrl)}`;
+    const apiUrl = `https://www.googleapis.com/youtube/v3/search?key=${API_KEY}&channelId=${channelId}&part=snippet,id&order=date&type=video&maxResults=10`;
     const resp = await fetch(apiUrl);
     const data = await resp.json();
-    if (data.status !== 'ok') throw new Error('Failed to load RSS feed');
-    return data.items;
+    if (!data.items) throw new Error('Failed to load videos');
+    return data.items.map(item => ({
+      title: item.snippet.title,
+      link: `https://www.youtube.com/watch?v=${item.id.videoId}`,
+      guid: `yt:video:${item.id.videoId}`,
+      thumbnail: item.snippet.thumbnails?.medium?.url || '',
+      pubDate: item.snippet.publishedAt
+    }));
   }
 
   async function handleChannelClick(card) {

--- a/freepress.html
+++ b/freepress.html
@@ -265,12 +265,17 @@
   }
 
   async function fetchLatestVideos(channelId) {
-    const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
-    const apiUrl = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(feedUrl)}`;
+    const apiUrl = `https://www.googleapis.com/youtube/v3/search?key=${API_KEY}&channelId=${channelId}&part=snippet,id&order=date&type=video&maxResults=10`;
     const resp = await fetch(apiUrl);
     const data = await resp.json();
-    if (data.status !== 'ok') throw new Error('Failed to load RSS feed');
-    return data.items;
+    if (!data.items) throw new Error('Failed to load videos');
+    return data.items.map(item => ({
+      title: item.snippet.title,
+      link: `https://www.youtube.com/watch?v=${item.id.videoId}`,
+      guid: `yt:video:${item.id.videoId}`,
+      thumbnail: item.snippet.thumbnails?.medium?.url || '',
+      pubDate: item.snippet.publishedAt
+    }));
   }
 
   async function handleChannelClick(card) {


### PR DESCRIPTION
## Summary
- switch latest video retrieval to YouTube Data API
- update freepress and creators pages to parse YouTube API results instead of failing RSS

## Testing
- `pre-commit run --files freepress.html creators.html` *(fails: command not found)*
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a038b4d73483208eb898f0a126e2e0