### PR TITLE
Unify channel and details toggles for desktop/mobile

### DIFF
--- a/freepress.html
+++ b/freepress.html
@@ -86,7 +86,7 @@
   <!-- Free Press section with channel list and video player -->
   <section class="youtube-section">
     <div class="channel-list">
-      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelCollapse()" aria-label="Collapse channel list">chevron_left</button>
+      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelList()" aria-label="Collapse channel list">chevron_left</button>
     </div>
     <!-- Video display area: a player for the selected video and a list of recent videos -->
     <div class="video-section">
@@ -100,7 +100,7 @@
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
     <div class="details-container">
-      <button class="collapse-btn collapse-right material-symbols-outlined" onclick="toggleDetailsCollapse()" aria-label="Collapse details list">chevron_right</button>
+      <button class="collapse-btn collapse-right material-symbols-outlined" onclick="toggleDetailsList()" aria-label="Collapse details list">chevron_right</button>
       <div class="details-list" style="display: none;"></div>
     </div>
   </section>
@@ -311,7 +311,7 @@
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
       list.classList.remove('open');
-      document.getElementById('toggle-channels').textContent = 'Channels';
+      document.getElementById('toggle-channels').textContent = channelToggleDefaultText;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   
@@ -438,12 +438,25 @@
       }
     });
 
+  const channelToggleDefaultText = document.getElementById('toggle-channels')?.textContent || '';
+
   function toggleChannelList() {
     const list = document.querySelector('.channel-list');
-    const btn = document.getElementById('toggle-channels');
-    list.classList.toggle('open');
-    btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
-    if (typeof updateScrollLock === 'function') updateScrollLock();
+    const toggleBtn = document.getElementById('toggle-channels');
+    const collapseBtn = document.querySelector('.collapse-left');
+
+    if (window.innerWidth <= 768) {
+      list.classList.toggle('open');
+      if (toggleBtn) {
+        toggleBtn.textContent = list.classList.contains('open') ? `Close ${channelToggleDefaultText}` : channelToggleDefaultText;
+      }
+      if (typeof updateScrollLock === 'function') updateScrollLock();
+    } else {
+      list.classList.toggle('collapsed');
+      const collapsed = list.classList.contains('collapsed');
+      if (collapseBtn) collapseBtn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
+      localStorage.setItem('channelListCollapsed', collapsed);
+    }
   }
 
   document.addEventListener('click', function(e) {
@@ -451,7 +464,7 @@
     const btn = document.getElementById('toggle-channels');
     if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
       list.classList.remove('open');
-      btn.textContent = 'Channels';
+      btn.textContent = channelToggleDefaultText;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   });
@@ -468,7 +481,7 @@
     const touchEndX = e.changedTouches[0].clientX;
     if (touchStartX - touchEndX > 50) {
       channelList.classList.remove('open');
-      document.getElementById('toggle-channels').textContent = 'Channels';
+      document.getElementById('toggle-channels').textContent = channelToggleDefaultText;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     touchStartX = null;
@@ -493,19 +506,33 @@
     const touchEndX = e.changedTouches[0].clientX;
     if (touchEndX - openStartX > 50 && openStartX < 50) {
       channelList.classList.add('open');
-      document.getElementById('toggle-channels').textContent = 'Close Channels';
+      document.getElementById('toggle-channels').textContent = `Close ${channelToggleDefaultText}`;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     openStartX = null;
   });
 
+  const detailsToggleDefaultText = document.getElementById('toggle-details')?.textContent || 'About';
+
   function toggleDetailsList() {
+    const container = document.querySelector('.details-container');
     const list = document.querySelector('.details-list');
-    const btn = document.getElementById('toggle-details');
-    if (btn.style.display === 'none') return;
-    list.classList.toggle('open');
-    btn.textContent = list.classList.contains('open') ? 'Close About' : 'About';
-    if (typeof updateScrollLock === 'function') updateScrollLock();
+    const toggleBtn = document.getElementById('toggle-details');
+    const collapseBtn = document.querySelector('.collapse-right');
+
+    if (window.innerWidth <= 768) {
+      if (toggleBtn.style.display === 'none') return;
+      list.classList.toggle('open');
+      if (toggleBtn) {
+        toggleBtn.textContent = list.classList.contains('open') ? `Close ${detailsToggleDefaultText}` : detailsToggleDefaultText;
+      }
+      if (typeof updateScrollLock === 'function') updateScrollLock();
+    } else {
+      container.classList.toggle('collapsed');
+      const collapsed = container.classList.contains('collapsed');
+      if (collapseBtn) collapseBtn.textContent = collapsed ? 'chevron_left' : 'chevron_right';
+      localStorage.setItem('detailsListCollapsed', collapsed);
+    }
   }
 
   document.addEventListener('click', function(e) {
@@ -513,7 +540,7 @@
     const btn = document.getElementById('toggle-details');
     if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
       list.classList.remove('open');
-      btn.textContent = 'About';
+      btn.textContent = detailsToggleDefaultText;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
   });
@@ -530,7 +557,7 @@
     const touchEndX = e.changedTouches[0].clientX;
     if (touchEndX - detailsTouchStartX > 50) {
       detailsList.classList.remove('open');
-      document.getElementById('toggle-details').textContent = 'About';
+      document.getElementById('toggle-details').textContent = detailsToggleDefaultText;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     detailsTouchStartX = null;
@@ -558,29 +585,11 @@
     const touchEndX = e.changedTouches[0].clientX;
     if (detailsOpenStartX > window.innerWidth - 50 && detailsOpenStartX - touchEndX > 50) {
       detailsList.classList.add('open');
-      document.getElementById('toggle-details').textContent = 'Close About';
+      document.getElementById('toggle-details').textContent = `Close ${detailsToggleDefaultText}`;
       if (typeof updateScrollLock === 'function') updateScrollLock();
     }
     detailsOpenStartX = null;
   });
-
-  function toggleChannelCollapse() {
-    const list = document.querySelector('.channel-list');
-    const btn = document.querySelector('.collapse-left');
-    list.classList.toggle('collapsed');
-    const collapsed = list.classList.contains('collapsed');
-    btn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
-    localStorage.setItem('channelListCollapsed', collapsed);
-  }
-
-  function toggleDetailsCollapse() {
-    const container = document.querySelector('.details-container');
-    const btn = document.querySelector('.collapse-right');
-    container.classList.toggle('collapsed');
-    const collapsed = container.classList.contains('collapsed');
-    btn.textContent = collapsed ? 'chevron_left' : 'chevron_right';
-    localStorage.setItem('detailsListCollapsed', collapsed);
-  }
 
   // Apply saved collapse state on load
   (function() {

--- a/livetv.html
+++ b/livetv.html
@@ -86,7 +86,7 @@
   <!-- TV Livestream section -->
   <section class="youtube-section">
     <div class="channel-list">
-      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelCollapse()" aria-label="Collapse channel list">chevron_left</button>
+      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelList()" aria-label="Collapse channel list">chevron_left</button>
     </div>
     <div class="video-section">
       <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()">Channels</button>
@@ -327,7 +327,7 @@
       if (window.innerWidth <= 768) {
         const list = document.querySelector('.channel-list');
         list.classList.remove('open');
-        document.getElementById('toggle-channels').textContent = 'Channels';
+        document.getElementById('toggle-channels').textContent = channelToggleDefaultText;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
     }
@@ -440,12 +440,25 @@
         });
     }
 
+    const channelToggleDefaultText = document.getElementById('toggle-channels')?.textContent || '';
+
     function toggleChannelList() {
       const list = document.querySelector('.channel-list');
-      const btn = document.getElementById('toggle-channels');
-      list.classList.toggle('open');
-      btn.textContent = list.classList.contains('open') ? 'Close Channels' : 'Channels';
-      if (typeof updateScrollLock === 'function') updateScrollLock();
+      const toggleBtn = document.getElementById('toggle-channels');
+      const collapseBtn = document.querySelector('.collapse-left');
+
+      if (window.innerWidth <= 768) {
+        list.classList.toggle('open');
+        if (toggleBtn) {
+          toggleBtn.textContent = list.classList.contains('open') ? `Close ${channelToggleDefaultText}` : channelToggleDefaultText;
+        }
+        if (typeof updateScrollLock === 'function') updateScrollLock();
+      } else {
+        list.classList.toggle('collapsed');
+        const collapsed = list.classList.contains('collapsed');
+        if (collapseBtn) collapseBtn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
+        localStorage.setItem('channelListCollapsed', collapsed);
+      }
     }
 
     document.addEventListener('click', function(e) {
@@ -453,7 +466,7 @@
       const btn = document.getElementById('toggle-channels');
       if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
         list.classList.remove('open');
-        btn.textContent = 'Channels';
+        btn.textContent = channelToggleDefaultText;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
     });
@@ -470,7 +483,7 @@
       const touchEndX = e.changedTouches[0].clientX;
       if (touchStartX - touchEndX > 50) {
         channelList.classList.remove('open');
-        document.getElementById('toggle-channels').textContent = 'Channels';
+        document.getElementById('toggle-channels').textContent = channelToggleDefaultText;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
       touchStartX = null;
@@ -495,20 +508,11 @@
       const touchEndX = e.changedTouches[0].clientX;
       if (touchEndX - openStartX > 50 && openStartX < 50) {
         channelList.classList.add('open');
-        document.getElementById('toggle-channels').textContent = 'Close Channels';
+        document.getElementById('toggle-channels').textContent = `Close ${channelToggleDefaultText}`;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
       openStartX = null;
     });
-
-    function toggleChannelCollapse() {
-      const list = document.querySelector('.channel-list');
-      const btn = document.querySelector('.collapse-left');
-      list.classList.toggle('collapsed');
-      const collapsed = list.classList.contains('collapsed');
-      btn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
-      localStorage.setItem('channelListCollapsed', collapsed);
-    }
 
     // Apply saved collapse state on load
     (function() {

--- a/radio.html
+++ b/radio.html
@@ -85,7 +85,7 @@
   <!-- Radio station listing -->
   <section class="youtube-section">
     <div class="channel-list">
-      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelCollapse()" aria-label="Collapse channel list">chevron_left</button>
+      <button class="collapse-btn collapse-left material-symbols-outlined" onclick="toggleChannelList()" aria-label="Collapse channel list">chevron_left</button>
     </div>
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()">Stations</button>
@@ -453,7 +453,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const list = document.querySelector('.channel-list');
         list.classList.remove('open');
         const btn = document.getElementById('toggle-channels');
-        if (btn) btn.textContent = 'Stations';
+        if (btn) btn.textContent = channelToggleDefaultText;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
 
@@ -599,12 +599,25 @@ document.addEventListener('DOMContentLoaded', function() {
 
 });
 
+const channelToggleDefaultText = document.getElementById('toggle-channels')?.textContent || '';
+
 function toggleChannelList() {
   const list = document.querySelector('.channel-list');
-  const btn = document.getElementById('toggle-channels');
-  list.classList.toggle('open');
-  btn.textContent = list.classList.contains('open') ? 'Close Stations' : 'Stations';
-  if (typeof updateScrollLock === 'function') updateScrollLock();
+  const toggleBtn = document.getElementById('toggle-channels');
+  const collapseBtn = document.querySelector('.collapse-left');
+
+  if (window.innerWidth <= 768) {
+    list.classList.toggle('open');
+    if (toggleBtn) {
+      toggleBtn.textContent = list.classList.contains('open') ? `Close ${channelToggleDefaultText}` : channelToggleDefaultText;
+    }
+    if (typeof updateScrollLock === 'function') updateScrollLock();
+  } else {
+    list.classList.toggle('collapsed');
+    const collapsed = list.classList.contains('collapsed');
+    if (collapseBtn) collapseBtn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
+    localStorage.setItem('channelListCollapsed', collapsed);
+  }
 }
 
 document.addEventListener('click', function(e) {
@@ -612,7 +625,7 @@ document.addEventListener('click', function(e) {
   const btn = document.getElementById('toggle-channels');
   if (list.classList.contains('open') && !list.contains(e.target) && !btn.contains(e.target)) {
     list.classList.remove('open');
-    btn.textContent = 'Stations';
+    btn.textContent = channelToggleDefaultText;
     if (typeof updateScrollLock === 'function') updateScrollLock();
   }
 });
@@ -628,20 +641,11 @@ channelList.addEventListener('touchend', (e) => {
   const touchEndX = e.changedTouches[0].clientX;
   if (touchStartX - touchEndX > 50) {
     channelList.classList.remove('open');
-    document.getElementById('toggle-channels').textContent = 'Stations';
+    document.getElementById('toggle-channels').textContent = channelToggleDefaultText;
     if (typeof updateScrollLock === 'function') updateScrollLock();
   }
   touchStartX = null;
 });
-
-function toggleChannelCollapse() {
-  const list = document.querySelector('.channel-list');
-  const btn = document.querySelector('.collapse-left');
-  list.classList.toggle('collapsed');
-  const collapsed = list.classList.contains('collapsed');
-  btn.textContent = collapsed ? 'chevron_right' : 'chevron_left';
-  localStorage.setItem('channelListCollapsed', collapsed);
-}
 
 // Apply saved collapse state on load
 (function() {


### PR DESCRIPTION
## Summary
- Consolidate channel list controls so desktop collapse and mobile toggle buttons both use `toggleChannelList`
- Merge details pane collapse and mobile toggle into a single `toggleDetailsList` handler on the Free Press page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes htmlhint freepress.html radio.html livetv.html` *(fails: Doctype must be declared before any non-comment content)*

------
https://chatgpt.com/codex/tasks/task_e_68a0397c26a08320807afab3741942e3