### PR TITLE
Check for existing YouTube channel before generating JSON

### DIFF
--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -76,24 +76,49 @@
   <script>
     const API_KEY = 'AIzaSyDUP58EXeb7RtBBy7QJ3jV46bpXQzfSbIs';
 
-    function parseChannelUrl(url) {
-      try {
-        const u = new URL(url);
-        const path = u.pathname;
-        if (path.startsWith('/@')) {
-          return { type: 'handle', value: path.slice(2) };
-        }
-        const parts = path.split('/').filter(Boolean);
-        if (parts[0] === 'channel' && parts[1]) {
-          return { type: 'id', value: parts[1] };
-        }
-        if (parts[0]) {
-          return { type: 'custom', value: parts[0] };
-        }
-        return { type: null, value: null };
-      } catch (e) {
-        return { type: null, value: null };
+    function parseChannelUrl(input) {
+      input = input.trim();
+      if (!input) {
+        return { type: null, value: null, url: null };
       }
+
+      // Full URL provided
+      if (/^https?:\/\//i.test(input)) {
+        try {
+          const u = new URL(input);
+          const path = u.pathname;
+          if (path.startsWith('/@')) {
+            const handle = path.slice(2);
+            return { type: 'handle', value: handle, url: `https://www.youtube.com/@${handle}` };
+          }
+          const parts = path.split('/').filter(Boolean);
+          if (parts[0] === 'channel' && parts[1]) {
+            const id = parts[1];
+            return { type: 'id', value: id, url: `https://www.youtube.com/channel/${id}` };
+          }
+          if (parts[0]) {
+            const custom = parts[0];
+            return { type: 'custom', value: custom, url: `https://www.youtube.com/${custom}` };
+          }
+          return { type: null, value: null, url: null };
+        } catch (e) {
+          return { type: null, value: null, url: null };
+        }
+      }
+
+      // Handle-only input like "@name"
+      if (input.startsWith('@')) {
+        const handle = input.slice(1);
+        return { type: 'handle', value: handle, url: `https://www.youtube.com/@${handle}` };
+      }
+
+      // Channel ID without URL
+      if (/^UC[0-9A-Za-z_-]{22}$/.test(input)) {
+        return { type: 'id', value: input, url: `https://www.youtube.com/channel/${input}` };
+      }
+
+      // Assume remaining input is a handle
+      return { type: 'handle', value: input, url: `https://www.youtube.com/@${input}` };
     }
 
     document.getElementById('fetch-info').addEventListener('click', async () => {
@@ -108,9 +133,10 @@
 
       const parsed = parseChannelUrl(input);
       if (!parsed.value) {
-        output.textContent = 'Invalid channel URL';
+        output.textContent = 'Invalid channel URL or handle';
         return;
       }
+      const channelUrl = parsed.url;
 
       let apiUrl;
       if (parsed.type === 'handle') {
@@ -134,6 +160,20 @@
         const thumb = item.snippet.thumbnails?.high?.url || item.snippet.thumbnails?.default?.url || '';
         const handle = item.snippet.customUrl ? item.snippet.customUrl.replace(/^@/, '') : parsed.value;
         const key = handle.toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+        // Check for existing channel in all_streams.json
+        try {
+          const existingResp = await fetch('/all_streams.json');
+          const existingData = await existingResp.json();
+          const exists = existingData.items?.some(it => it.ids?.youtube_channel_id === channelId);
+          if (exists) {
+            output.textContent = 'Channel already exists in all_streams.json';
+            return;
+          }
+        } catch (e) {
+          // If we can't fetch the list, continue without the check
+        }
+
         const result = {
           key: key,
           name: name,
@@ -143,7 +183,7 @@
           media: { thumbnail_url: thumb },
           endpoints: [
             { kind: 'embed', provider: 'youtube', url: `https://www.youtube.com/embed/live_stream?channel=${channelId}` },
-            { kind: 'channel', provider: 'youtube', url: input }
+            { kind: 'channel', provider: 'youtube', url: channelUrl }
           ],
           ids: { youtube_channel_id: channelId },
           status: { active: true }


### PR DESCRIPTION
## Summary
- Accept plain handles or IDs and construct full YouTube URLs when onboarding a channel
- Skip JSON generation if the channel's YouTube ID already exists in `all_streams.json`

## Testing
- `npx -y htmlhint onboard-channel.html`
- `python -m json.tool all_streams.json`


------
https://chatgpt.com/codex/tasks/task_e_68a0991333688320b7da57865c204e4e