### PR TITLE
Add test pages consuming unified streams data

### DIFF
--- a/creators-test.html
+++ b/creators-test.html
@@ -1,0 +1,496 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{% include google-tag-manager-head.html %}
+  <!-- Start cookieyes banner -->
+  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
+  <!-- End cookieyes banner -->
+  {% include google-analytics.html %}
+  <!-- Standard Meta -->
+  <title>PakStream Creators - Watch Popular Pakistani YouTubers</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="title" content="PakStream Creators - Watch Popular Pakistani YouTubers">
+  <meta name="description" content="Curated list of Pakistani YouTubers and their latest videos.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Creators, Pakistani YouTubers, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="author" content="PakStream by Chatdroid AB">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pakstream.com/creators.html" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pakstream.com/creators.html">
+  <meta property="og:title" content="PakStream Creators - Watch Popular Pakistani YouTubers">
+  <meta property="og:description" content="Curated list of Pakistani YouTubers and their latest videos.">
+  <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta property="og:site_name" content="PakStream">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://pakstream.com/creators.html">
+  <meta name="twitter:title" content="PakStream Creators - Watch Popular Pakistani YouTubers">
+  <meta name="twitter:description" content="Curated list of Pakistani YouTubers and their latest videos.">
+  <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta name="twitter:site" content="@PakStream">
+  <meta name="twitter:creator" content="@PakStream">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+</head>
+<body>
+{% include google-tag-manager-body.html %}
+  <header class="top-bar">
+    <input type="checkbox" id="nav-toggle">
+    <label for="nav-toggle" class="nav-toggle-label">☰</label>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+      <a href="/">Home</a>
+      <a href="/freepress.html">Free Press</a>
+      <a href="/livetv.html">Live TV</a>
+      <a href="/creators.html">Creators</a>
+      <a href="/radio.html">Radio</a>
+      <a href="/blog.html">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+    <label for="nav-toggle" class="nav-overlay"></label>
+  </header>
+
+  <!-- Creators section with channel list and video player -->
+  <section class="youtube-section">
+    <div class="channel-list"></div>
+
+    <div class="video-section">
+      <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <span class="material-symbols-outlined icon">chevron_left</span>
+        <span class="label" data-default="Channels">Channels</span>
+      </button>
+
+      <div class="live-player">
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      </div>
+      <div id="videoList" class="video-list"><p>Loading videos…</p></div>
+    </div>
+  </section>
+
+  <div class="ad-container"></div>
+
+  <footer>
+    <nav class="footer-nav">
+      <a href="/about.html">About Us</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <p>© 2025 PakStream. All rights reserved.</p>
+  </footer>
+
+<script>
+  // ----- State -----
+  const anchorMap = {};                     // key -> channelId
+  const favorites = JSON.parse(localStorage.getItem('ytFavorites') || '[]');
+
+  // v3 ONLY for thumbnails; use as primary for listing to avoid extension/CORS issues, with cache
+  const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
+  const LIST_CACHE_MS = 30 * 60 * 1000;    // 30 minutes
+
+  // ----- Helpers -----
+  function getChannelThumbnail(id, providedUrl) {
+    const cacheKey = `yt_thumb_${id}`;
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      if (cached.startsWith('data:')) {
+        return Promise.resolve(cached);
+      }
+      try {
+        const parsed = JSON.parse(cached);
+        if (parsed && parsed.url) {
+          return fetchAndCache(parsed.url).catch(() => parsed.url);
+        }
+      } catch {}
+      return Promise.resolve(cached);
+    }
+
+    function fetchAndCache(url) {
+      return fetch(url)
+        .then(res => {
+          if (!res.ok) throw new Error('Network response was not ok');
+          return res.blob();
+        })
+        .then(blob => new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            const dataUrl = reader.result;
+            try { localStorage.setItem(cacheKey, dataUrl); } catch {}
+            resolve(dataUrl);
+          };
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        }));
+    }
+
+    const fallback = () => {
+      const apiUrl = `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${id}&fields=items(snippet/thumbnails/default/url)&key=${API_KEY}`;
+      return fetch(apiUrl)
+        .then(res => res.json())
+        .then(data => data.items?.[0]?.snippet?.thumbnails?.default?.url || '')
+        .then(url => url ? fetchAndCache(url).catch(() => url) : '')
+        .catch(() => '');
+    };
+
+    if (providedUrl) {
+      return fetchAndCache(providedUrl).catch(fallback);
+    }
+    return fallback();
+  }
+
+  function updateFavoritesUI() {
+    const list = document.querySelector('.channel-list');
+    const cards = Array.from(list.querySelectorAll('.channel-card'));
+    const favFragment = document.createDocumentFragment();
+    const otherFragment = document.createDocumentFragment();
+
+    cards.forEach(card => {
+      const id = card.dataset.channelId;
+      const btn = card.querySelector('.fav-btn');
+      const isFav = favorites.includes(id);
+      card.classList.toggle('favorite', isFav);
+      btn.textContent = isFav ? 'favorite' : 'favorite_border';
+      (isFav ? favFragment : otherFragment).appendChild(card);
+    });
+
+    list.appendChild(favFragment);
+    list.appendChild(otherFragment);
+  }
+
+  function toggleFavorite(event) {
+    event.stopPropagation();
+    const card = event.currentTarget.closest('.channel-card');
+    const id = card.dataset.channelId;
+    const idx = favorites.indexOf(id);
+    if (idx >= 0) favorites.splice(idx, 1);
+    else favorites.push(id);
+    localStorage.setItem('ytFavorites', JSON.stringify(favorites));
+    updateFavoritesUI();
+  }
+
+  function fitText(el, maxLines = 2) {
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+    const maxHeight = lineHeight * maxLines;
+    let fontSize = parseFloat(getComputedStyle(el).fontSize);
+    while (el.scrollHeight > maxHeight && fontSize > 10) {
+      fontSize -= 1;
+      el.style.fontSize = fontSize + 'px';
+    }
+  }
+
+  function timeAgo(dateString) {
+    const seconds = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000);
+    const intervals = [
+      { label: 'year', seconds: 31536000 },
+      { label: 'month', seconds: 2592000 },
+      { label: 'day', seconds: 86400 },
+      { label: 'hour', seconds: 3600 },
+      { label: 'minute', seconds: 60 }
+    ];
+    for (const interval of intervals) {
+      const count = Math.floor(seconds / interval.seconds);
+      if (count >= 1) return `${count} ${interval.label}${count > 1 ? 's' : ''} ago`;
+    }
+    return 'Just now';
+  }
+
+  async function fetchVideoDetails(videoId) {
+    const resp = await fetch(`https://noembed.com/embed?url=https://www.youtube.com/watch?v=${videoId}`);
+    if (!resp.ok) throw new Error('Failed to load video details');
+    return resp.json();
+  }
+
+  // Primary: Data API v3 (cached). Fallbacks: RSS direct -> RSS via proxy.
+  async function fetchLatestVideos(channelId) {
+    const cacheKey = `yt_list_${channelId}`;
+    const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+    if (cached && (Date.now() - cached.timestamp) < LIST_CACHE_MS) {
+      return cached.items;
+    }
+
+    // Try v3 first (filters fields to save quota)
+    try {
+      const apiUrl =
+        `https://www.googleapis.com/youtube/v3/search?key=${API_KEY}` +
+        `&channelId=${channelId}&part=snippet,id&order=date&type=video&maxResults=10` +
+        `&fields=items(id/videoId,snippet(title,publishedAt,thumbnails/medium/url))`;
+      const resp = await fetch(apiUrl);
+      if (resp.ok) {
+        const data = await resp.json();
+        const items = (data.items || []).map(item => {
+          const videoId = item.id?.videoId || '';
+          const title = item.snippet?.title || '';
+          const link = videoId ? `https://www.youtube.com/watch?v=${videoId}` : '';
+          const pubDate = item.snippet?.publishedAt || '';
+          const thumbnail = item.snippet?.thumbnails?.medium?.url || (videoId ? `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg` : '');
+          return { title, link, guid: `yt:video:${videoId}`, thumbnail, pubDate, videoId };
+        });
+        if (items.length) {
+          localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), items }));
+          return items;
+        }
+      }
+    } catch (_) { /* continue to RSS */ }
+
+    // RSS (direct)
+    try {
+      const directFeed = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+      const resp = await fetch(directFeed);
+      if (resp.ok) {
+        const xmlText = await resp.text();
+        const items = parseRss(xmlText).slice(0, 10);
+        if (items.length) {
+          localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), items }));
+          return items;
+        }
+      }
+    } catch (_) {}
+
+    // RSS (proxy)
+    try {
+      const directFeed = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+      const proxyFeed  = `https://api.allorigins.win/raw?url=${encodeURIComponent(directFeed)}`;
+      const resp = await fetch(proxyFeed);
+      if (resp.ok) {
+        const xmlText = await resp.text();
+        const items = parseRss(xmlText).slice(0, 10);
+        if (items.length) {
+          localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), items }));
+          return items;
+        }
+      }
+    } catch (_) {}
+
+    throw new Error('Failed to load videos via all methods');
+  }
+
+  function parseRss(xmlText) {
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(xmlText, 'application/xml');
+    const entries = Array.from(xml.getElementsByTagName('entry'));
+    const thumbNs = 'http://search.yahoo.com/mrss/';
+    return entries.map(entry => {
+      let videoId = '';
+      const guid = entry.getElementsByTagName('id')[0]?.textContent || '';
+      if (guid.startsWith('yt:video:')) videoId = guid.split(':').pop();
+      if (!videoId) {
+        const href = entry.getElementsByTagName('link')[0]?.getAttribute('href') || '';
+        const m = href.match(/[?&]v=([^&]+)/);
+        if (m) videoId = m[1];
+      }
+      const title = entry.getElementsByTagName('title')[0]?.textContent || '';
+      const link = entry.getElementsByTagName('link')[0]?.getAttribute('href') || (videoId ? `https://www.youtube.com/watch?v=${videoId}` : '');
+      const pubDate = entry.getElementsByTagName('published')[0]?.textContent || '';
+      const thumbEl = entry.getElementsByTagNameNS(thumbNs, 'thumbnail')[0] || entry.querySelector('media\\:thumbnail');
+      const thumbnail = (thumbEl && thumbEl.getAttribute('url')) || (videoId ? `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg` : '');
+      return { title, link, guid, thumbnail, pubDate, videoId };
+    });
+  }
+
+  // ----- UI wiring -----
+  let cards;
+  const videoListEl = document.getElementById('videoList');
+  const playerFrame = document.getElementById('playerFrame');
+
+  function setActiveCard(clickedCard) {
+    cards.forEach(c => {
+      c.classList.remove('active');
+      const pb = c.querySelector('.play-btn');
+      if (pb) pb.textContent = 'play_arrow';
+    });
+    clickedCard.classList.add('active');
+    const pb = clickedCard.querySelector('.play-btn');
+    if (pb) pb.textContent = 'stop';
+  }
+
+  function setActiveVideo(clickedItem) {
+    document.querySelectorAll('.video-item').forEach(item => item.classList.remove('active'));
+    clickedItem.classList.add('active');
+  }
+
+  function loadVideo(videoId) {
+    if (videoId) {
+      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+    }
+  }
+
+  function toggleChannelList() {
+    const list = document.querySelector('.channel-list');
+    const btn = document.getElementById('toggle-channels');
+    const label = btn?.querySelector('.label');
+    list.classList.toggle('open');
+    if (label) {
+      label.textContent = list.classList.contains('open') ? 'Hide' : (label.dataset.default || 'Channels');
+    }
+  }
+
+  async function handleChannelClick(card) {
+    const channelId = card.dataset.channelId;
+
+    // Update URL with creator key
+    const anchorKey = Object.keys(anchorMap).find(key => anchorMap[key] === channelId);
+    if (anchorKey) {
+      const newUrl = `${window.location.pathname}?creator=${anchorKey}`;
+      history.replaceState(null, '', newUrl);
+    }
+
+    setActiveCard(card);
+    videoListEl.innerHTML = '<p>Loading videos…</p>';
+
+    // Close channel list on small screens
+    if (window.innerWidth <= 768) {
+      const list = document.querySelector('.channel-list');
+      list.classList.remove('open');
+      const label = document.querySelector('#toggle-channels .label');
+      if (label) label.textContent = label.dataset.default || 'Channels';
+    }
+
+    if (!channelId) {
+      videoListEl.innerHTML = '<p>No channel ID provided.</p>';
+      return;
+    }
+
+    try {
+      const videos = await fetchLatestVideos(channelId);
+      if (!videos || videos.length === 0) {
+        videoListEl.innerHTML = '<p>No videos found for this channel.</p>';
+        return;
+      }
+
+      videoListEl.innerHTML = '';
+      videos.forEach((video, index) => {
+        const videoId = video.videoId;
+        if (!videoId) return;
+
+        const itemEl = document.createElement('div');
+        itemEl.className = 'video-item';
+        itemEl.innerHTML = `
+          <img src="${video.thumbnail}" alt="${video.title}" loading="lazy">
+          <div class="video-details">
+            <div class="video-title">${video.title}</div>
+            <div class="video-meta">Loading views… • ${timeAgo(video.pubDate)}</div>
+          </div>
+        `;
+        itemEl.addEventListener('click', () => {
+          loadVideo(videoId);
+          setActiveVideo(itemEl);
+        });
+        videoListEl.appendChild(itemEl);
+
+        if (index === 0) {
+          loadVideo(videoId);
+          setActiveVideo(itemEl);
+        }
+
+        // Non-blocking view count (best effort)
+        fetchVideoDetails(videoId).then(details => {
+          const meta = itemEl.querySelector('.video-meta');
+          const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : 'Views unavailable';
+          meta.textContent = `${viewsText} • ${timeAgo(video.pubDate)}`;
+        }).catch(() => {
+          const meta = itemEl.querySelector('.video-meta');
+          meta.textContent = `Views unavailable • ${timeAgo(video.pubDate)}`;
+        });
+      });
+    } catch (err) {
+      console.error(err);
+      videoListEl.innerHTML = '<p>Error loading videos (all methods failed).</p>';
+    }
+  }
+
+  // ----- Bootstrapping -----
+  fetch('/all_streams.json')
+    .then(res => res.json())
+    .then(data => {
+      const channels = (data.items || [])
+        .filter(item => item.type === 'creator')
+        .map(item => ({
+          key: item.key,
+          id: item.ids?.youtube_channel_id,
+          name: item.name,
+          'thumbnail-url': item.media?.thumbnail_url
+        }));
+      const list = document.querySelector('.channel-list');
+
+      channels.forEach(ch => {
+        anchorMap[ch.key] = ch.id;
+
+        const card = document.createElement('div');
+        card.className = 'channel-card';
+        card.dataset.channelId = ch.id;
+
+        const img = document.createElement('img');
+        img.className = 'channel-thumb';
+        img.alt = `${ch.name} thumbnail`;
+        getChannelThumbnail(ch.id, ch['thumbnail-url']).then(url => { img.src = url || '/assets/avatar-fallback.png'; });
+
+        const span = document.createElement('span');
+        span.className = 'channel-name';
+        span.textContent = ch.name;
+
+        const playBtn = document.createElement('button');
+        playBtn.className = 'play-btn material-symbols-outlined';
+        playBtn.setAttribute('aria-label', 'Play');
+        playBtn.textContent = 'play_arrow';
+        playBtn.addEventListener('click', (e) => { e.stopPropagation(); handleChannelClick(card); });
+
+        const btn = document.createElement('button');
+        btn.className = 'fav-btn material-symbols-outlined';
+        btn.setAttribute('aria-label', 'Toggle favorite');
+        btn.textContent = 'favorite_border';
+        btn.addEventListener('click', toggleFavorite);
+
+        card.appendChild(img);
+        card.appendChild(span);
+        card.appendChild(playBtn);
+        card.appendChild(btn);
+        list.appendChild(card);
+      });
+
+      document.querySelectorAll('.channel-name').forEach(el => fitText(el));
+      updateFavoritesUI();
+
+      cards = document.querySelectorAll('.channel-card');
+      cards.forEach(card => {
+        card.addEventListener('click', () => handleChannelClick(card));
+      });
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const anchorKey = urlParams.get('creator');
+      const defaultCard = document.querySelector('.channel-card');
+
+      if (anchorKey && anchorMap[anchorKey]) {
+        const targetId = anchorMap[anchorKey];
+        const matchedCard = document.querySelector(`.channel-card[data-channel-id="${targetId}"]`);
+        if (matchedCard) {
+          handleChannelClick(matchedCard);
+        } else if (defaultCard) {
+          handleChannelClick(defaultCard);
+        }
+      } else if (defaultCard) {
+        handleChannelClick(defaultCard);
+      }
+    });
+</script>
+
+  <script src="/js/leftmenu.js"></script>
+  <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/main.js"></script>
+</body>
+</html>

--- a/freepress-test.html
+++ b/freepress-test.html
@@ -1,0 +1,576 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{% include google-tag-manager-head.html %}
+  <!-- Start cookieyes banner -->
+  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
+  <!-- End cookieyes banner -->
+  {% include google-analytics.html %}
+  <!-- Standard Meta -->
+  <title>PakStream Free Press - Watch Independent Pakistani News Voices</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
+  <meta name="description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="author" content="PakStream by Chatdroid AB">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pakstream.com/freepress.html" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pakstream.com/freepress.html">
+  <meta property="og:title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
+  <meta property="og:description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
+  <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta property="og:site_name" content="PakStream">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://pakstream.com/freepress.html">
+  <meta name="twitter:title" content="PakStream Free Press - Watch Independent Pakistani News Voices">
+  <meta name="twitter:description" content="Curated list of political and social independent Pakistani news anchors and commentators.">
+  <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta name="twitter:site" content="@PakStream">
+  <meta name="twitter:creator" content="@PakStream">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "name": "PakStream",
+    "url": "https://pakstream.com/",
+    "logo": "https://pakstream.com/assets/logo.png",
+    "sameAs": [
+      "https://facebook.com/PakStream",
+      "https://twitter.com/PakStream"
+    ]
+  }
+  </script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+</head>
+<body>
+{% include google-tag-manager-body.html %}
+  <header class="top-bar">
+    <input type="checkbox" id="nav-toggle">
+    <label for="nav-toggle" class="nav-toggle-label">☰</label>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+      <a href="/">Home</a>
+      <a href="/freepress.html">Free Press</a>
+      <a href="/livetv.html">Live TV</a>
+      <a href="/creators.html">Creators</a>
+      <a href="/radio.html">Radio</a>
+      <a href="/blog.html">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+    <label for="nav-toggle" class="nav-overlay"></label>
+  </header>
+
+  <section class="youtube-section">
+    <div class="channel-list"></div>
+    <div class="video-section">
+      <div class="button-row">
+        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+          <span class="material-symbols-outlined icon">chevron_left</span>
+          <span class="label" data-default="Channels">Channels</span>
+        </button>
+        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
+          <span class="material-symbols-outlined icon">chevron_right</span>
+          <span class="label" data-default="About">About</span>
+        </button>
+      </div>
+      <div class="live-player">
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      </div>
+      <div id="videoList" class="video-list"><p>Loading videos…</p></div>
+    </div>
+    <div class="details-container">
+      <div class="details-list" style="display: none;"></div>
+    </div>
+  </section>
+
+  <div class="ad-container"></div>
+
+  <footer>
+    <nav class="footer-nav">
+      <a href="/about.html">About Us</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <p>© 2025 PakStream. All rights reserved.</p>
+  </footer>
+
+<script>
+  // ----- State -----
+  const anchorMap = {};
+  let detailsMap = {};
+  let profilesMap = {};
+  const favorites = JSON.parse(localStorage.getItem('ytFavorites') || '[]');
+
+  // v3 only for thumbs + (now) primary for listing, with cache
+  const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
+  const LIST_CACHE_MS = 30 * 60 * 1000; // 30 min
+
+  // ----- Helpers -----
+  function getChannelThumbnail(id, providedUrl) {
+    const cacheKey = `yt_thumb_${id}`;
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      if (cached.startsWith('data:')) {
+        return Promise.resolve(cached);
+      }
+      try {
+        const parsed = JSON.parse(cached);
+        if (parsed && parsed.url) {
+          return fetchAndCache(parsed.url).catch(() => parsed.url);
+        }
+      } catch {}
+      return Promise.resolve(cached);
+    }
+
+    function fetchAndCache(url) {
+      return fetch(url)
+        .then(res => {
+          if (!res.ok) throw new Error('Network response was not ok');
+          return res.blob();
+        })
+        .then(blob => new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            const dataUrl = reader.result;
+            try { localStorage.setItem(cacheKey, dataUrl); } catch {}
+            resolve(dataUrl);
+          };
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        }));
+    }
+
+    const fallback = () => {
+      const apiUrl = `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${id}&fields=items(snippet/thumbnails/default/url)&key=${API_KEY}`;
+      return fetch(apiUrl)
+        .then(res => res.json())
+        .then(data => data.items?.[0]?.snippet?.thumbnails?.default?.url || '')
+        .then(url => url ? fetchAndCache(url).catch(() => url) : '')
+        .catch(() => '');
+    };
+
+    if (providedUrl) {
+      return fetchAndCache(providedUrl).catch(fallback);
+    }
+    return fallback();
+  }
+
+  function renderProfiles(list) {
+    if (!list.length) return '';
+    const icons = {
+      youtube:   { url: 'https://img.icons8.com/color/48/000000/youtube-play.png', label: 'YouTube' },
+      instagram: { url: 'https://img.icons8.com/color/48/000000/instagram-new.png', label: 'Instagram' },
+      twitter:   { url: 'https://img.icons8.com/color/48/000000/twitter--v1.png', label: 'X (Twitter)' },
+      facebook:  { url: 'https://img.icons8.com/color/48/000000/facebook-new.png', label: 'Facebook' },
+      linkedin:  { url: 'https://img.icons8.com/color/48/000000/linkedin.png', label: 'LinkedIn' },
+      tiktok:    { url: 'https://img.icons8.com/color/48/000000/tiktok--v1.png', label: 'TikTok' }
+    };
+    const items = list.map(url => {
+      let type = 'website';
+      if (/youtu/.test(url)) type = 'youtube';
+      else if (/instagram/.test(url)) type = 'instagram';
+      else if (/twitter|x\.com/.test(url)) type = 'twitter';
+      else if (/facebook/.test(url)) type = 'facebook';
+      else if (/linkedin/.test(url)) type = 'linkedin';
+      else if (/tiktok/.test(url)) type = 'tiktok';
+      const { url: icon, label } = icons[type] || { url: '', label: type.charAt(0).toUpperCase() + type.slice(1) };
+      const img = icon ? `<img src='${icon}' alt='${label}'>` : '';
+      return `<a class='profile' href='${url}' target='_blank' rel='noopener'><div class='profile-icon'>${img}</div><span>${label}</span></a>`;
+    }).join('');
+    return `<h3>Profiles</h3><div class='profiles'>${items}</div>`;
+  }
+
+  function updateFavoritesUI() {
+    const list = document.querySelector('.channel-list');
+    const cards = Array.from(list.querySelectorAll('.channel-card'));
+    const favFragment = document.createDocumentFragment();
+    const otherFragment = document.createDocumentFragment();
+
+    cards.forEach(card => {
+      const id = card.dataset.channelId;
+      const btn = card.querySelector('.fav-btn');
+      const isFav = favorites.includes(id);
+      card.classList.toggle('favorite', isFav);
+      btn.textContent = isFav ? 'favorite' : 'favorite_border';
+      (isFav ? favFragment : otherFragment).appendChild(card);
+    });
+
+    list.appendChild(favFragment);
+    list.appendChild(otherFragment);
+  }
+
+  function toggleFavorite(event) {
+    event.stopPropagation();
+    const card = event.currentTarget.closest('.channel-card');
+    const id = card.dataset.channelId;
+    const idx = favorites.indexOf(id);
+    if (idx >= 0) favorites.splice(idx, 1);
+    else favorites.push(id);
+    localStorage.setItem('ytFavorites', JSON.stringify(favorites));
+    updateFavoritesUI();
+  }
+
+  function fitText(el, maxLines = 2) {
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+    const maxHeight = lineHeight * maxLines;
+    let fontSize = parseFloat(getComputedStyle(el).fontSize);
+    while (el.scrollHeight > maxHeight && fontSize > 10) {
+      fontSize -= 1;
+      el.style.fontSize = fontSize + 'px';
+    }
+  }
+
+  function timeAgo(dateString) {
+    const seconds = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000);
+    const intervals = [
+      { label: 'year', seconds: 31536000 },
+      { label: 'month', seconds: 2592000 },
+      { label: 'day', seconds: 86400 },
+      { label: 'hour', seconds: 3600 },
+      { label: 'minute', seconds: 60 }
+    ];
+    for (const interval of intervals) {
+      const count = Math.floor(seconds / interval.seconds);
+      if (count >= 1) return `${count} ${interval.label}${count > 1 ? 's' : ''} ago`;
+    }
+    return 'Just now';
+  }
+
+  async function fetchVideoDetails(videoId) {
+    const resp = await fetch(`https://noembed.com/embed?url=https://www.youtube.com/watch?v=${videoId}`);
+    if (!resp.ok) throw new Error('Failed to load video details');
+    return resp.json();
+  }
+
+  // Primary: Data API v3 (cached). Fallbacks: RSS direct -> RSS via proxy.
+  async function fetchLatestVideos(channelId) {
+    const cacheKey = `yt_list_${channelId}`;
+    const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+    if (cached && (Date.now() - cached.timestamp) < LIST_CACHE_MS) {
+      return cached.items;
+    }
+
+    // Try v3 first (usually not blocked by extensions)
+    try {
+      const apiUrl =
+        `https://www.googleapis.com/youtube/v3/search?key=${API_KEY}` +
+        `&channelId=${channelId}&part=snippet,id&order=date&type=video&maxResults=10` +
+        `&fields=items(id/videoId,snippet(title,publishedAt,thumbnails/medium/url))`;
+      const resp = await fetch(apiUrl);
+      if (resp.ok) {
+        const data = await resp.json();
+        const items = (data.items || []).map(item => {
+          const videoId = item.id?.videoId || '';
+          const title = item.snippet?.title || '';
+          const link = videoId ? `https://www.youtube.com/watch?v=${videoId}` : '';
+          const pubDate = item.snippet?.publishedAt || '';
+          const thumbnail = item.snippet?.thumbnails?.medium?.url || (videoId ? `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg` : '');
+          return { title, link, guid: `yt:video:${videoId}`, thumbnail, pubDate, videoId };
+        });
+        if (items.length) {
+          localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), items }));
+          return items;
+        }
+      }
+    } catch (_) {
+      // continue to RSS fallbacks
+    }
+
+    // RSS (direct)
+    try {
+      const directFeed = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+      const resp = await fetch(directFeed);
+      if (resp.ok) {
+        const xmlText = await resp.text();
+        const items = parseRss(xmlText).slice(0, 10);
+        if (items.length) {
+          localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), items }));
+          return items;
+        }
+      }
+    } catch (_) {}
+
+    // RSS (proxy)
+    try {
+      const directFeed = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+      const proxyFeed  = `https://api.allorigins.win/raw?url=${encodeURIComponent(directFeed)}`;
+      const resp = await fetch(proxyFeed);
+      if (resp.ok) {
+        const xmlText = await resp.text();
+        const items = parseRss(xmlText).slice(0, 10);
+        if (items.length) {
+          localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), items }));
+          return items;
+        }
+      }
+    } catch (_) {}
+
+    throw new Error('Failed to load videos via all methods');
+  }
+
+  function parseRss(xmlText) {
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(xmlText, 'application/xml');
+    const entries = Array.from(xml.getElementsByTagName('entry'));
+    const thumbNs = 'http://search.yahoo.com/mrss/';
+    return entries.map(entry => {
+      let videoId = '';
+      const guid = entry.getElementsByTagName('id')[0]?.textContent || '';
+      if (guid.startsWith('yt:video:')) videoId = guid.split(':').pop();
+      if (!videoId) {
+        const href = entry.getElementsByTagName('link')[0]?.getAttribute('href') || '';
+        const m = href.match(/[?&]v=([^&]+)/);
+        if (m) videoId = m[1];
+      }
+      const title = entry.getElementsByTagName('title')[0]?.textContent || '';
+      const link = entry.getElementsByTagName('link')[0]?.getAttribute('href') || (videoId ? `https://www.youtube.com/watch?v=${videoId}` : '');
+      const pubDate = entry.getElementsByTagName('published')[0]?.textContent || '';
+      const thumbEl = entry.getElementsByTagNameNS(thumbNs, 'thumbnail')[0] || entry.querySelector('media\\:thumbnail');
+      const thumbnail = (thumbEl && thumbEl.getAttribute('url')) || (videoId ? `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg` : '');
+      return { title, link, guid, thumbnail, pubDate, videoId };
+    });
+  }
+
+  // ----- UI wiring -----
+  let cards;
+  const videoListEl = document.getElementById('videoList');
+  const playerFrame = document.getElementById('playerFrame');
+
+  function setActiveCard(clickedCard) {
+    cards.forEach(c => {
+      c.classList.remove('active');
+      const pb = c.querySelector('.play-btn');
+      if (pb) pb.textContent = 'play_arrow';
+    });
+    clickedCard.classList.add('active');
+    const pb = clickedCard.querySelector('.play-btn');
+    if (pb) pb.textContent = 'stop';
+  }
+
+  function setActiveVideo(clickedItem) {
+    document.querySelectorAll('.video-item').forEach(item => item.classList.remove('active'));
+    clickedItem.classList.add('active');
+  }
+
+  function loadVideo(videoId) {
+    if (videoId) {
+      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+    }
+  }
+
+  function toggleChannelList() {
+    const list = document.querySelector('.channel-list');
+    const btn = document.getElementById('toggle-channels');
+    const label = btn?.querySelector('.label');
+    list.classList.toggle('open');
+    if (label) {
+      label.textContent = list.classList.contains('open') ? 'Hide' : (label.dataset.default || 'Channels');
+    }
+  }
+
+  function toggleDetailsList() {
+    const details = document.querySelector('.details-list');
+    const btn = document.getElementById('toggle-details');
+    const label = btn?.querySelector('.label');
+    details.classList.toggle('open');
+    details.style.display = details.classList.contains('open') ? '' : 'none';
+    if (label) {
+      label.textContent = details.classList.contains('open') ? 'Hide' : (label.dataset.default || 'About');
+    }
+  }
+
+  async function handleChannelClick(card) {
+    const channelId = card.dataset.channelId;
+
+    const anchorKey = Object.keys(anchorMap).find(key => anchorMap[key] === channelId);
+    if (anchorKey) {
+      const newUrl = `${window.location.pathname}?newsanchor=${anchorKey}`;
+      history.replaceState(null, '', newUrl);
+    }
+
+    const detailsList = document.querySelector('.details-list');
+    const detailsBtn = document.getElementById('toggle-details');
+    const aboutContent = detailsMap[anchorKey];
+    const profileUrls = profilesMap[anchorKey] || [];
+    if (detailsList && detailsBtn) {
+      if (aboutContent || profileUrls.length) {
+        detailsList.innerHTML = aboutContent || '';
+        if (profileUrls.length) {
+          const container = detailsList.querySelector('.details-content') || detailsList;
+          container.insertAdjacentHTML('beforeend', renderProfiles(profileUrls));
+        }
+        detailsList.style.display = '';
+        detailsBtn.style.display = '';
+        detailsBtn.querySelector('.label').textContent = 'About';
+      } else {
+        detailsList.classList.remove('open');
+        detailsList.innerHTML = '';
+        detailsList.style.display = 'none';
+        detailsBtn.style.display = 'none';
+      }
+    }
+
+    setActiveCard(card);
+    videoListEl.innerHTML = '<p>Loading videos…</p>';
+
+    if (window.innerWidth <= 768) {
+      const list = document.querySelector('.channel-list');
+      list.classList.remove('open');
+      const label = document.querySelector('#toggle-channels .label');
+      if (label) label.textContent = label.dataset.default || 'Channels';
+    }
+
+    if (!channelId) {
+      videoListEl.innerHTML = '<p>No channel ID provided.</p>';
+      return;
+    }
+
+    try {
+      const videos = await fetchLatestVideos(channelId);
+      if (!videos || videos.length === 0) {
+        videoListEl.innerHTML = '<p>No videos found for this channel.</p>';
+        return;
+      }
+
+      videoListEl.innerHTML = '';
+      videos.forEach((video, index) => {
+        const videoId = video.videoId;
+        if (!videoId) return;
+
+        const itemEl = document.createElement('div');
+        itemEl.className = 'video-item';
+        itemEl.innerHTML = `
+          <img src="${video.thumbnail}" alt="${video.title}" loading="lazy">
+          <div class="video-details">
+            <div class="video-title">${video.title}</div>
+            <div class="video-meta">Loading views… • ${timeAgo(video.pubDate)}</div>
+          </div>
+        `;
+        itemEl.addEventListener('click', () => {
+          loadVideo(videoId);
+          setActiveVideo(itemEl);
+        });
+        videoListEl.appendChild(itemEl);
+
+        if (index === 0) {
+          loadVideo(videoId);
+          setActiveVideo(itemEl);
+        }
+
+        fetchVideoDetails(videoId).then(details => {
+          const meta = itemEl.querySelector('.video-meta');
+          const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : 'Views unavailable';
+          meta.textContent = `${viewsText} • ${timeAgo(video.pubDate)}`;
+        }).catch(() => {
+          const meta = itemEl.querySelector('.video-meta');
+          meta.textContent = `Views unavailable • ${timeAgo(video.pubDate)}`;
+        });
+      });
+    } catch (err) {
+      console.error(err);
+      videoListEl.innerHTML = '<p>Error loading videos (all methods failed).</p>';
+    }
+  }
+
+  // ----- Bootstrapping -----
+  fetch('/all_streams.json')
+    .then(res => res.json())
+    .then(data => {
+      const channels = (data.items || [])
+        .filter(item => item.type === 'freepress')
+        .map(item => ({
+          key: item.key,
+          id: item.ids?.youtube_channel_id,
+          name: item.name,
+          'thumbnail-url': item.media?.thumbnail_url,
+          about: item.about_html,
+          profiles: item.profiles || []
+        }));
+      const list = document.querySelector('.channel-list');
+
+      channels.forEach(ch => {
+        anchorMap[ch.key] = ch.id;
+        detailsMap[ch.key] = ch.about || '';
+        profilesMap[ch.key] = ch.profiles || [];
+
+        const card = document.createElement('div');
+        card.className = 'channel-card';
+        card.dataset.channelId = ch.id;
+
+        const img = document.createElement('img');
+        img.className = 'channel-thumb';
+        img.alt = `${ch.name} thumbnail`;
+        getChannelThumbnail(ch.id, ch['thumbnail-url']).then(url => { img.src = url || '/assets/avatar-fallback.png'; });
+
+        const span = document.createElement('span');
+        span.className = 'channel-name';
+        span.textContent = ch.name;
+
+        const playBtn = document.createElement('button');
+        playBtn.className = 'play-btn material-symbols-outlined';
+        playBtn.setAttribute('aria-label', 'Play');
+        playBtn.textContent = 'play_arrow';
+        playBtn.addEventListener('click', (e) => { e.stopPropagation(); handleChannelClick(card); });
+
+        const btn = document.createElement('button');
+        btn.className = 'fav-btn material-symbols-outlined';
+        btn.setAttribute('aria-label', 'Toggle favorite');
+        btn.textContent = 'favorite_border';
+        btn.addEventListener('click', toggleFavorite);
+
+        card.appendChild(img);
+        card.appendChild(span);
+        card.appendChild(playBtn);
+        card.appendChild(btn);
+        list.appendChild(card);
+      });
+
+      document.querySelectorAll('.channel-name').forEach(el => fitText(el));
+      updateFavoritesUI();
+
+      cards = document.querySelectorAll('.channel-card');
+      cards.forEach(card => card.addEventListener('click', () => handleChannelClick(card)));
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const anchorKey = urlParams.get('newsanchor');
+      const defaultCard = document.querySelector('.channel-card');
+
+      if (anchorKey && anchorMap[anchorKey]) {
+        const targetId = anchorMap[anchorKey];
+        const matchedCard = document.querySelector(`.channel-card[data-channel-id="${targetId}"]`);
+        if (matchedCard) {
+          handleChannelClick(matchedCard);
+          return;
+        }
+      }
+      if (defaultCard) handleChannelClick(defaultCard);
+    });
+</script>
+
+  <script src="/js/leftmenu.js"></script>
+  <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/main.js"></script>
+</body>
+</html>

--- a/livestream-test.html
+++ b/livestream-test.html
@@ -1,0 +1,489 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{% include google-tag-manager-head.html %}
+  <!-- Start cookieyes banner -->
+  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
+  <!-- End cookieyes banner -->
+  {% include google-analytics.html %}
+  <!-- Standard Meta -->
+  <title>PakStream Live TV - Watch Pakistani TV Channels Live</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <meta name="title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
+  <meta name="description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
+  <meta name="author" content="PakStream by Chatdroid AB" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://pakstream.com/livetv.html" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://pakstream.com/livetv.html" />
+  <meta property="og:title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
+  <meta property="og:description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
+  <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg" />
+  <meta property="og:site_name" content="PakStream" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://pakstream.com/livetv.html" />
+  <meta name="twitter:title" content="PakStream Live TV - Watch Pakistani TV Channels Live" />
+  <meta name="twitter:description" content="Your source for live Pakistani news, entertainment, and drama channels abroad." />
+  <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg" />
+  <meta name="twitter:site" content="@PakStream" />
+  <meta name="twitter:creator" content="@PakStream" />
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "name": "PakStream",
+    "url": "https://pakstream.com/",
+    "logo": "https://pakstream.com/assets/logo.png",
+    "sameAs": [
+      "https://facebook.com/PakStream",
+      "https://twitter.com/PakStream"
+    ]
+  }
+  </script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  
+</head>
+<body>
+{% include google-tag-manager-body.html %}
+  <header class="top-bar">
+    <input type="checkbox" id="nav-toggle">
+    <label for="nav-toggle" class="nav-toggle-label">☰</label>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
+  </header>
+
+
+  <!-- TV Livestream section -->
+  <section class="youtube-section">
+    <div class="channel-list"></div>
+    <div class="video-section">
+      <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <span class="material-symbols-outlined icon">chevron_left</span>
+        <span class="label">Channels</span>
+      </button>
+    </div>
+  </section>
+
+  <div class="ad-container">
+    <!-- AdSense area -->
+  </div>
+
+  <footer>
+    <nav class="footer-nav">
+      <a href="/about.html">About Us</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <p>© 2025 PakStream. All rights reserved.</p>
+  </footer>
+
+  <!-- Load YouTube Iframe API -->
+  <script src="https://www.youtube.com/iframe_api"></script>
+  <script>
+    const players = {};
+    const favorites = JSON.parse(localStorage.getItem('tvFavorites') || '[]');
+    const channelMap = {};
+    const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+    function getChannelThumbnail(id, providedUrl) {
+      const cacheKey = `yt_thumb_${id}`;
+      const cached = localStorage.getItem(cacheKey);
+      if (cached) {
+        if (cached.startsWith('data:')) {
+          return Promise.resolve(cached);
+        }
+        try {
+          const parsed = JSON.parse(cached);
+          if (parsed && parsed.url) {
+            return fetchAndCache(parsed.url).catch(() => parsed.url);
+          }
+        } catch {}
+        return Promise.resolve(cached);
+      }
+
+      function fetchAndCache(url) {
+        return fetch(url)
+          .then(res => {
+            if (!res.ok) throw new Error('Network response was not ok');
+            return res.blob();
+          })
+          .then(blob => new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => {
+              const dataUrl = reader.result;
+              try { localStorage.setItem(cacheKey, dataUrl); } catch {}
+              resolve(dataUrl);
+            };
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+          }));
+      }
+
+      const fallback = () => {
+        const apiUrl = `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${id}&fields=items(snippet/thumbnails/default/url)&key=${API_KEY}`;
+        return fetch(apiUrl)
+          .then(res => res.json())
+          .then(data => data.items?.[0]?.snippet?.thumbnails?.default?.url || '')
+          .then(url => url ? fetchAndCache(url).catch(() => url) : '')
+          .catch(() => '');
+      };
+
+      if (providedUrl) {
+        return fetchAndCache(providedUrl).catch(fallback);
+      }
+      return fallback();
+    }
+
+    function updateFavoritesUI() {
+      const list = document.querySelector('.channel-list');
+      const cards = Array.from(list.querySelectorAll('.channel-card'));
+      const favFragment = document.createDocumentFragment();
+      const otherFragment = document.createDocumentFragment();
+
+      cards.forEach(card => {
+        const id = card.dataset.id;
+        const btn = card.querySelector('.fav-btn');
+        const isFav = favorites.includes(id);
+        card.classList.toggle('favorite', isFav);
+        btn.textContent = isFav ? 'favorite' : 'favorite_border';
+        (isFav ? favFragment : otherFragment).appendChild(card);
+      });
+
+      list.appendChild(favFragment);
+      list.appendChild(otherFragment);
+    }
+
+    function fitText(el, maxLines = 2) {
+      const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+      const maxHeight = lineHeight * maxLines;
+      let fontSize = parseFloat(getComputedStyle(el).fontSize);
+      while (el.scrollHeight > maxHeight && fontSize > 10) {
+        fontSize -= 1;
+        el.style.fontSize = fontSize + 'px';
+      }
+    }
+
+      function toggleFavorite(event, id) {
+        event.stopPropagation();
+        const idx = favorites.indexOf(id);
+        if (idx >= 0) favorites.splice(idx, 1);
+        else favorites.push(id);
+        localStorage.setItem('tvFavorites', JSON.stringify(favorites));
+        updateFavoritesUI();
+      }
+
+      let initialChannel = null;
+      const YT_PARAMS = 'enablejsapi=1&origin=https://pakstream.com';
+
+      fetch('/all_streams.json')
+        .then(res => res.json())
+        .then(data => {
+          const channels = (data.items || [])
+            .filter(item => item.type === 'tv')
+            .map(item => ({
+              id: item.key,
+              name: item.name,
+              src: item.endpoints?.find(e => e.kind === 'embed')?.url || '',
+              'channel-id': item.ids?.youtube_channel_id,
+              'thumbnail-url': item.media?.thumbnail_url
+            }));
+          const list = document.querySelector('.channel-list');
+          const videoSection = document.querySelector('.video-section');
+          channels.forEach(ch => {
+            channelMap[ch.id] = ch;
+            const card = document.createElement('div');
+            card.className = 'channel-card';
+            card.dataset.id = ch.id;
+            card.onclick = () => showStream(ch.id, card);
+
+            const img = document.createElement('img');
+            img.className = 'channel-thumb';
+            img.alt = `${ch.name} thumbnail`;
+            getChannelThumbnail(ch['channel-id'], ch['thumbnail-url']).then(url => { img.src = url || '/assets/avatar-fallback.png'; });
+
+            const span = document.createElement('span');
+            span.className = 'channel-name';
+            span.textContent = ch.name;
+
+            const playBtn = document.createElement('button');
+            playBtn.className = 'play-btn material-symbols-outlined';
+            playBtn.setAttribute('aria-label', 'Play');
+            playBtn.textContent = 'play_arrow';
+            playBtn.onclick = (e) => { e.stopPropagation(); showStream(ch.id, card); };
+
+            const btn = document.createElement('button');
+            btn.className = 'fav-btn material-symbols-outlined';
+            btn.setAttribute('aria-label', 'Toggle favorite');
+            btn.textContent = 'favorite_border';
+            btn.onclick = (e) => toggleFavorite(e, ch.id);
+
+            card.appendChild(img);
+            card.appendChild(span);
+            card.appendChild(playBtn);
+            card.appendChild(btn);
+            list.appendChild(card);
+
+            const div = document.createElement('div');
+            div.id = ch.id;
+            div.className = 'live-player';
+            div.style.display = 'none';
+
+            const iframe = document.createElement('iframe');
+            iframe.id = `${ch.id}-player`;
+            iframe.dataset.src = ch.src + (ch.src.includes('?') ? '&' : '?') + YT_PARAMS;
+            iframe.src = '';
+            iframe.loading = 'lazy';
+            iframe.allow = 'autoplay';
+            iframe.allowFullscreen = true;
+            div.appendChild(iframe);
+            videoSection.appendChild(div);
+          });
+          const streamList = document.createElement('div');
+          streamList.id = 'stream-list';
+          streamList.className = 'video-list';
+          videoSection.appendChild(streamList);
+
+          document.querySelectorAll('.channel-name').forEach(el => fitText(el));
+          updateFavoritesUI();
+
+          const urlParams = new URLSearchParams(window.location.search);
+          initialChannel = urlParams.get('tvchannel') || (channels[0] && channels[0].id);
+          if (!urlParams.has('tvchannel') && initialChannel) {
+            history.replaceState(null, '', `${window.location.pathname}?tvchannel=${initialChannel}`);
+          }
+
+          if (window.YT && window.YT.Player) {
+            initPlayer();
+          }
+        });
+
+    function loadPlayer(id, muteOnStart = false) {
+      const iframe = document.getElementById(`${id}-player`);
+      // Use getAttribute to detect an empty src attribute. The `iframe.src`
+      // property returns the page's URL even when `src=""`, which prevented
+      // the first channel from loading its `data-src`.
+      if (iframe.dataset.src && !iframe.getAttribute('src')) {
+        iframe.src = iframe.dataset.src;
+      }
+      players[iframe.id] = new YT.Player(iframe.id, {
+        playerVars: { autoplay: 1 },
+        events: {
+          onReady: event => {
+            //if (muteOnStart) {
+            //  event.target.mute();
+            //}
+            event.target.playVideo();
+          }
+        }
+      });
+    }
+
+      function initPlayer() {
+        const initialCard = document.querySelector(`.channel-card[data-id="${initialChannel}"]`) ||
+          document.querySelector('.channel-card');
+        const channelId = initialCard?.dataset.id;
+        if (channelId) {
+          showStream(channelId, initialCard, true);
+        }
+      }
+
+      window.onYouTubeIframeAPIReady = initPlayer;
+
+    function showStream(id, element, muteOnLoad = false) {
+      // Hide all video divs
+      document.querySelectorAll('.live-player').forEach(div => div.style.display = 'none');
+
+      // Remove active class and reset play icons
+      document.querySelectorAll('.channel-card').forEach(card => card.classList.remove('active'));
+      document.querySelectorAll('.play-btn').forEach(btn => btn.textContent = 'play_arrow');
+
+      // Pause all players
+      for (const key in players) {
+        if (players[key].stopVideo) {
+          players[key].stopVideo();
+        }
+      }
+
+      // Show selected stream
+      document.getElementById(id).style.display = 'block';
+      if (element) {
+        element.classList.add('active');
+        const pb = element.querySelector('.play-btn');
+        if (pb) pb.textContent = 'stop';
+      }
+
+      // Load or play selected stream
+      const playerId = `${id}-player`;
+      if (players[playerId]) {
+        if (players[playerId].unMute) {
+          players[playerId].unMute();
+        }
+        if (players[playerId].playVideo) {
+          players[playerId].playVideo();
+        }
+      } else if (typeof YT !== 'undefined' && YT.Player) {
+        loadPlayer(id, muteOnLoad);
+      }
+
+      // Update URL without reloading
+      const newUrl = `${window.location.pathname}?tvchannel=${id}`;
+      history.replaceState(null, '', newUrl);
+
+      populateStreamList(id);
+
+      // Close channel list on small screens
+      if (window.innerWidth <= 768) {
+        const list = document.querySelector('.channel-list');
+        list.classList.remove('open');
+        const label = document.querySelector('#toggle-channels .label');
+        if (label) label.textContent = label.dataset.default || label.textContent;
+        if (typeof updateScrollLock === 'function') updateScrollLock();
+      }
+    }
+
+    function setActiveStream(el) {
+      document.querySelectorAll('#stream-list .video-item').forEach(item => item.classList.remove('active'));
+      el.classList.add('active');
+    }
+
+    function populateStreamList(id) {
+      const streamList = document.getElementById('stream-list');
+      if (!streamList) return;
+      streamList.innerHTML = '';
+      const ch = channelMap[id];
+      if (!ch || !ch['channel-id']) {
+        const div = document.createElement('div');
+        div.textContent = 'No live streams available.';
+        streamList.appendChild(div);
+        return;
+      }
+
+      const cacheKey = `yt_streams_${id}`;
+      const cached = JSON.parse(localStorage.getItem(cacheKey) || 'null');
+
+      const renderEntries = (entries) => {
+        entries.forEach((entry, index) => {
+          const item = document.createElement('div');
+          item.className = 'video-item';
+          item.innerHTML = `
+            <img src="${entry.thumb}" alt="${entry.title}" loading="lazy">
+            <div class="video-details">
+              <div class="video-title">${entry.title}</div>
+              <div class="video-meta">${entry.viewers ? `${entry.viewers.toLocaleString()} watching` : 'Live'}</div>
+            </div>
+          `;
+          item.addEventListener('click', () => {
+            const playerId = `${id}-player`;
+            const player = players[playerId];
+            if (player && player.loadVideoById) {
+              player.loadVideoById(entry.videoId);
+            } else {
+              const iframe = document.getElementById(playerId);
+              iframe.src = `https://www.youtube.com/embed/${entry.videoId}?${YT_PARAMS}`;
+            }
+            setActiveStream(item);
+          });
+          streamList.appendChild(item);
+          if (index === 0) {
+            const playerId = `${id}-player`;
+            const player = players[playerId];
+            if (player && player.loadVideoById) {
+              player.loadVideoById(entry.videoId);
+            } else {
+              const iframe = document.getElementById(playerId);
+              iframe.src = `https://www.youtube.com/embed/${entry.videoId}?${YT_PARAMS}`;
+            }
+            setActiveStream(item);
+          }
+        });
+      };
+
+      if (cached && (Date.now() - cached.timestamp) < ONE_DAY_MS) {
+        renderEntries(cached.entries);
+        return;
+      }
+
+      const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${encodeURIComponent(ch['channel-id'])}&eventType=live&type=video&key=${API_KEY}`;
+      fetch(url)
+        .then(res => res.json())
+        .then(data => {
+          if (data.items && data.items.length > 0) {
+            const info = {};
+            const ids = data.items.map(item => {
+              info[item.id.videoId] = {
+                title: item.snippet.title,
+                thumb: (item.snippet.thumbnails.medium && item.snippet.thumbnails.medium.url) || item.snippet.thumbnails.default.url
+              };
+              return item.id.videoId;
+            });
+            const videosUrl = `https://www.googleapis.com/youtube/v3/videos?part=liveStreamingDetails&id=${ids.join(',')}&key=${API_KEY}`;
+            fetch(videosUrl)
+              .then(res => res.json())
+              .then(vData => {
+                const entries = ids.map(videoId => {
+                  const details = info[videoId];
+                  const v = vData.items.find(i => i.id === videoId) || {};
+                  const viewers = Number(v.liveStreamingDetails && v.liveStreamingDetails.concurrentViewers || 0);
+                  return { videoId, title: details.title, thumb: details.thumb, viewers };
+                });
+
+                entries.sort((a, b) => b.viewers - a.viewers);
+                localStorage.setItem(cacheKey, JSON.stringify({ entries, timestamp: Date.now() }));
+                renderEntries(entries);
+              })
+              .catch(() => {
+                const div = document.createElement('div');
+                div.textContent = 'Error fetching stream details.';
+                streamList.appendChild(div);
+              });
+          } else {
+            const div = document.createElement('div');
+            div.textContent = 'No live streams found.';
+            streamList.appendChild(div);
+          }
+        })
+        .catch(() => {
+          const div = document.createElement('div');
+          div.textContent = 'Error fetching streams.';
+          streamList.appendChild(div);
+        });
+    }
+
+  </script>
+  <script src="/js/leftmenu.js"></script>
+  <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/main.js"></script>
+</body>
+</html>

--- a/radio-test.html
+++ b/radio-test.html
@@ -1,0 +1,622 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{% include google-tag-manager-head.html %}
+  <!-- Start cookieyes banner -->
+  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
+  <!-- End cookieyes banner -->
+  {% include google-analytics.html %}
+  <!-- Standard Meta -->
+  <title>PakStream Radio - Listen to Pakistani Radio Stations Online</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="title" content="PakStream Radio - Listen to Pakistani Radio Stations Online">
+  <meta name="description" content="Stream live Pakistani FM, talk, and news radio from anywhere in the world.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="author" content="PakStream by Chatdroid AB">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pakstream.com/radio.html" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pakstream.com/radio.html">
+  <meta property="og:title" content="PakStream Radio - Listen to Pakistani Radio Stations Online">
+  <meta property="og:description" content="Stream live Pakistani FM, talk, and news radio from anywhere in the world.">
+  <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta property="og:site_name" content="PakStream">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://pakstream.com/radio.html">
+  <meta name="twitter:title" content="PakStream Radio - Listen to Pakistani Radio Stations Online">
+  <meta name="twitter:description" content="Stream live Pakistani FM, talk, and news radio from anywhere in the world.">
+  <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta name="twitter:site" content="@PakStream">
+  <meta name="twitter:creator" content="@PakStream">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "name": "PakStream",
+    "url": "https://pakstream.com/",
+    "logo": "https://pakstream.com/assets/logo.png",
+    "sameAs": [
+      "https://facebook.com/PakStream",
+      "https://twitter.com/PakStream"
+    ]
+  }
+  </script>
+
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  
+</head>
+<body class="radio-list">
+  <header class="top-bar">
+    <input type="checkbox" id="nav-toggle">
+    <label for="nav-toggle" class="nav-toggle-label">☰</label>
+    <h1 class="logo-title">PakStream</h1>
+    <nav class="nav-links">
+        <a href="/">Home</a>
+        <a href="/freepress.html">Free Press</a>
+        <a href="/livetv.html">Live TV</a>
+        <a href="/creators.html">Creators</a>
+        <a href="/radio.html">Radio</a>
+        <a href="/blog.html">Blog</a>
+        <a href="/about.html">About</a>
+        <a href="/contact.html">Contact</a>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+      </nav>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
+  </header>
+
+  <!-- Radio station listing -->
+  <section class="youtube-section">
+    <div class="channel-list"></div>
+    <div class="video-section">
+      <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle station list">
+        <span class="material-symbols-outlined icon">chevron_left</span>
+        <span class="label">Stations</span>
+      </button>
+      <div class="live-player">
+        <div id="player-container" class="radio-player">
+          <div class="station-info">
+            <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
+            <h3 id="current-station" class="station-title">Select a station</h3>
+            <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
+            <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
+          </div>
+          <div class="controls">
+            <button id="favorite-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
+            <button id="prev-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Previous station" disabled>skip_previous</button>
+            <button id="play-pause-btn" class="play-pause-btn" type="button" aria-label="Play or pause" disabled>
+              <span class="material-symbols-outlined label">play_arrow</span>
+              <span class="spinner"></span>
+            </button>
+            <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
+            <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
+            <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
+            <audio id="radio-player" autoplay></audio>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <p class="source-note">Source data from the <a href="https://fi1.api.radio-browser.info/json/stations/bycountry/pakistan">Radio&nbsp;Browser API</a>, the community‑curated service <a href="https://streamurl.link">StreamURL.link</a>, and Radio&nbsp;Pakistan’s <a href="https://radio.gov.pk/live-streaming">live‑streaming page</a>. Streams may be subject to change by broadcasters.</p>
+
+
+  <!-- Placeholder for advertising or extra content -->
+  <div class="ad-container">
+    <!-- Google AdSense: Insert your ad code here -->
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <nav class="footer-nav">
+      <a href="/about.html">About Us</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <p>© 2025 PakStream. All rights reserved.</p>
+  </footer>
+  <script>
+// Central radio player with favorites and deep links
+document.addEventListener('DOMContentLoaded', function() {
+  const mainPlayer = document.getElementById('radio-player');
+  const currentLabel = document.getElementById('current-station');
+  const stationLogo = document.getElementById('station-logo');
+  const defaultLogo = 'data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2040%2040%27%3E%3Crect%20width%3D%2740%27%20height%3D%2740%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%275%27%20y%3D%2714%27%20width%3D%2730%27%20height%3D%2718%27%20rx%3D%272%27%20ry%3D%272%27%20fill%3D%27%23888888%27/%3E%3Ccircle%20cx%3D%2714%27%20cy%3D%2723%27%20r%3D%274%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%2722%27%20y%3D%2719%27%20width%3D%2710%27%20height%3D%278%27%20fill%3D%27%23BDBDBD%27/%3E%3C/svg%3E';
+  const liveBadge = document.getElementById('live-badge');
+  const notLiveBadge = document.getElementById('not-live-badge');
+  let playButtons = [];
+  const favBtn = document.getElementById('favorite-btn');
+  const prevBtn = document.getElementById('prev-btn');
+  const playPauseBtn = document.getElementById('play-pause-btn');
+  const playPauseLabel = playPauseBtn.querySelector('.label');
+  const nextBtn = document.getElementById('next-btn');
+  const muteBtn = document.getElementById('mute-btn');
+  const shareBtn = document.getElementById('share-btn');
+  const favorites = JSON.parse(localStorage.getItem('radioFavorites') || '[]');
+  const API_KEY = 'AIzaSyDYVIpMttgcSxeadCGKBSj1HOt-foiHgOM';
+
+  function getChannelThumbnail(id, providedUrl) {
+    const cacheKey = `yt_thumb_${id}`;
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      if (cached.startsWith('data:')) {
+        return Promise.resolve(cached);
+      }
+      try {
+        const parsed = JSON.parse(cached);
+        if (parsed && parsed.url) {
+          return fetchAndCache(parsed.url).catch(() => parsed.url);
+        }
+      } catch {}
+      return Promise.resolve(cached);
+    }
+
+    function fetchAndCache(url) {
+      return fetch(url)
+        .then(res => {
+          if (!res.ok) throw new Error('Network response was not ok');
+          return res.blob();
+        })
+        .then(blob => new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            const dataUrl = reader.result;
+            try { localStorage.setItem(cacheKey, dataUrl); } catch {}
+            resolve(dataUrl);
+          };
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        }));
+    }
+
+    const fallback = () => {
+      const apiUrl = `https://www.googleapis.com/youtube/v3/channels?part=snippet&id=${id}&fields=items(snippet/thumbnails/default/url)&key=${API_KEY}`;
+      return fetch(apiUrl)
+        .then(res => res.json())
+        .then(data => data.items?.[0]?.snippet?.thumbnails?.default?.url || '')
+        .then(url => url ? fetchAndCache(url).catch(() => url) : '')
+        .catch(() => '');
+    };
+
+    if (providedUrl) {
+      return fetchAndCache(providedUrl).catch(fallback);
+    }
+    return fallback();
+  }
+
+  function fitText(el, maxLines = 2) {
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+    const maxHeight = lineHeight * maxLines;
+    let fontSize = parseFloat(getComputedStyle(el).fontSize);
+    while (el.scrollHeight > maxHeight && fontSize > 10) {
+      fontSize -= 1;
+      el.style.fontSize = fontSize + 'px';
+    }
+  }
+
+  function buildStationList(stations) {
+    const list = document.querySelector('.channel-list');
+    stations.forEach(st => {
+      const card = document.createElement('div');
+      card.className = 'channel-card';
+
+      const img = document.createElement('img');
+      img.alt = '';
+      img.className = 'station-row-logo';
+      img.width = 40;
+      img.height = 40;
+      img.loading = 'lazy';
+      img.src = defaultLogo;
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'channel-name';
+      nameSpan.textContent = st.name;
+
+      const btn = document.createElement('button');
+      btn.className = 'play-btn';
+      btn.setAttribute('aria-label', 'Play');
+      btn.innerHTML = '<span class="material-symbols-outlined label">play_arrow</span><span class="spinner"></span>';
+
+      const audio = document.createElement('audio');
+      audio.id = st.id;
+      audio.preload = 'none';
+      audio.dataset.logo = defaultLogo;
+      if (st.src) audio.src = st.src;
+
+      const favButton = document.createElement('button');
+      favButton.className = 'fav-btn material-symbols-outlined';
+      favButton.setAttribute('aria-label', 'Toggle favorite');
+      favButton.textContent = 'favorite_border';
+      favButton.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const id = audio.id;
+        const idx = favorites.indexOf(id);
+        if (idx >= 0) favorites.splice(idx, 1);
+        else favorites.push(id);
+        localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+        updateFavoritesUI();
+      });
+
+      card.appendChild(img);
+      card.appendChild(nameSpan);
+      card.appendChild(btn);
+      card.appendChild(favButton);
+      card.appendChild(audio);
+      list.appendChild(card);
+
+      getChannelThumbnail(st.id, st.logo).then(url => {
+        const finalLogo = url || defaultLogo;
+        img.src = finalLogo;
+        audio.dataset.logo = finalLogo;
+      });
+    });
+
+    document.querySelectorAll('.channel-name').forEach(el => fitText(el));
+
+    playButtons = Array.from(document.querySelectorAll('.play-btn'));
+    playButtons.forEach(btn => {
+      const audio = btn.parentElement.querySelector('audio');
+      const card = btn.closest('.channel-card');
+      const name = card.querySelector('.channel-name').textContent;
+      btn.classList.remove('material-symbols-outlined');
+      btn.setAttribute('type', 'button');
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (btn === currentBtn) {
+          stopStation();
+        } else {
+          resetButton(currentBtn);
+          loadStation(audio, name, btn);
+        }
+      });
+
+      card.addEventListener('click', (e) => {
+        if (e.target.closest('button')) return;
+        btn.click();
+      });
+    });
+
+    updateFavoritesUI();
+
+    const params = new URLSearchParams(window.location.search);
+    const initial = params.get('station');
+    if (initial) {
+      const audio = document.getElementById(initial);
+      if (audio) {
+        const name = audio.closest('.channel-card').querySelector('.channel-name').textContent;
+        const btn = audio.parentElement.querySelector('.play-btn');
+        resetButton(currentBtn);
+        loadStation(audio, name, btn);
+      }
+    } else {
+      const firstCard = document.querySelector('.channel-list .channel-card');
+      if (firstCard) {
+        const audio = firstCard.querySelector('audio');
+        const btn = firstCard.querySelector('.play-btn');
+        const name = firstCard.querySelector('.channel-name').textContent;
+        resetButton(currentBtn);
+        loadStation(audio, name, btn);
+      }
+    }
+  }
+  let currentBtn = null;
+  let pendingBtn = null;
+  let resumeHandler = null;
+  let currentAudio = null;
+
+  function updateFavoritesUI() {
+    const list = document.querySelector('.channel-list');
+    // Grab all cards so we can batch their reordering
+    const cards = Array.from(list.querySelectorAll('.channel-card'));
+    const favFragment = document.createDocumentFragment();
+    const otherFragment = document.createDocumentFragment();
+
+    cards.forEach(card => {
+      const audio = card.querySelector('audio');
+      const id = audio?.id;
+      if (!id) return;
+      const isFav = favorites.includes(id);
+      card.classList.toggle('favorite', isFav);
+      const btn = card.querySelector('.fav-btn');
+      if (btn) btn.textContent = isFav ? 'favorite' : 'favorite_border';
+      (isFav ? favFragment : otherFragment).appendChild(card);
+    });
+
+    // Re-attach cards in a single pass to minimize layout reflows
+    list.appendChild(favFragment);
+    list.appendChild(otherFragment);
+
+    if (currentAudio) {
+      const isFav = favorites.includes(currentAudio.id);
+      favBtn.textContent = isFav ? 'favorite' : 'favorite_border';
+      favBtn.classList.toggle('favorited', isFav);
+      favBtn.disabled = false;
+      playPauseBtn.disabled = false;
+      muteBtn.disabled = false;
+    } else {
+      favBtn.textContent = 'favorite_border';
+      favBtn.classList.remove('favorited');
+      favBtn.disabled = true;
+      playPauseBtn.disabled = true;
+      muteBtn.disabled = true;
+    }
+
+    const hasStations = playButtons.length > 0;
+    prevBtn.disabled = nextBtn.disabled = !hasStations;
+
+    playPauseLabel.textContent = mainPlayer.paused ? 'play_arrow' : 'pause';
+    playPauseBtn.setAttribute('aria-label', mainPlayer.paused ? 'Play' : 'Pause');
+    muteBtn.textContent = mainPlayer.muted ? 'volume_off' : 'volume_up';
+  }
+
+  function resetButton(btn) {
+    if (!btn) return;
+    btn.classList.remove('loading');
+    const label = btn.querySelector('.label');
+    if (label) label.textContent = 'play_arrow';
+    btn.setAttribute('aria-label', 'Play');
+  }
+
+  function stopStation() {
+    mainPlayer.pause();
+    mainPlayer.removeAttribute('src');
+    mainPlayer.load();
+    currentLabel.textContent = 'Select a station';
+    stationLogo.onerror = null;
+    stationLogo.src = defaultLogo;
+    stationLogo.hidden = false;
+    liveBadge.hidden = true;
+    notLiveBadge.hidden = false;
+    history.replaceState(null, '', window.location.pathname);
+    resetButton(currentBtn);
+    currentBtn = null;
+    pendingBtn = null;
+    currentAudio = null;
+    document.querySelectorAll('.channel-card').forEach(card => card.classList.remove('active'));
+    updateFavoritesUI();
+  }
+
+  function loadStation(audio, name, btn) {
+    // Clean up any previous resume handler
+    if (resumeHandler) {
+      document.removeEventListener('click', resumeHandler);
+      document.removeEventListener('touchstart', resumeHandler);
+      resumeHandler = null;
+    }
+    pendingBtn = btn;
+    document.querySelectorAll('.channel-card').forEach(card => card.classList.remove('active'));
+    btn.closest('.channel-card').classList.add('active');
+    btn.classList.add('loading');
+    playPauseBtn.classList.add('loading');
+    stationLogo.onerror = () => {
+      stationLogo.onerror = null;
+      stationLogo.src = defaultLogo;
+    };
+    const logoSrc = (audio.dataset.logo && !audio.dataset.logo.includes('default_radio.png')) ? audio.dataset.logo : defaultLogo;
+    stationLogo.src = logoSrc;
+    stationLogo.hidden = false;
+    liveBadge.hidden = true;
+    notLiveBadge.hidden = false;
+    mainPlayer.src = audio.src;
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: name,
+        artwork: [{ src: logoSrc }]
+      });
+    }
+    mainPlayer.load();
+    const playPromise = mainPlayer.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => {
+        // Autoplay may be blocked on some devices (e.g. mobile).
+        // Reset the button state and wait for the first user interaction
+        // before trying to play again.
+        resetButton(btn);
+        playPauseBtn.classList.remove('loading');
+
+        resumeHandler = () => {
+          btn.classList.add('loading');
+          playPauseBtn.classList.add('loading');
+          const pp = mainPlayer.play();
+          if (pp !== undefined) {
+            pp.catch(() => {
+              resetButton(btn);
+              pendingBtn = null;
+            });
+          }
+          document.removeEventListener('click', resumeHandler);
+          document.removeEventListener('touchstart', resumeHandler);
+          resumeHandler = null;
+        };
+        document.addEventListener('click', resumeHandler, { once: true });
+        document.addEventListener('touchstart', resumeHandler, { once: true });
+      });
+    }
+      currentAudio = audio;
+      currentLabel.textContent = name;
+      const newUrl = `${window.location.pathname}?station=${audio.id}`;
+      history.replaceState(null, '', newUrl);
+
+      if (window.innerWidth <= 768) {
+        const list = document.querySelector('.channel-list');
+        list.classList.remove('open');
+        const label = document.querySelector('#toggle-channels .label');
+        if (label) label.textContent = label.dataset.default || label.textContent;
+        if (typeof updateScrollLock === 'function') updateScrollLock();
+      }
+
+      updateFavoritesUI();
+    }
+
+  fetch('/all_streams.json')
+    .then(res => res.json())
+    .then(data => {
+      const stations = (data.items || [])
+        .filter(item => item.type === 'radio')
+        .map(item => ({
+          id: item.ids?.internal_id || item.key,
+          name: item.name,
+          logo: item.media?.logo_url,
+          src: item.endpoints?.find(e => e.kind === 'stream')?.url
+        }));
+      buildStationList(stations);
+    });
+
+  favBtn.addEventListener('click', () => {
+    if (!currentAudio) return;
+    const id = currentAudio.id;
+    const idx = favorites.indexOf(id);
+    if (idx >= 0) favorites.splice(idx, 1);
+    else favorites.push(id);
+    localStorage.setItem('radioFavorites', JSON.stringify(favorites));
+    updateFavoritesUI();
+  });
+
+  function playStation(offset) {
+    const audios = Array.from(document.querySelectorAll('.channel-list audio'));
+    if (audios.length === 0) return;
+    const currentId = currentAudio ? currentAudio.id : null;
+    let idx = currentId ? audios.findIndex(a => a.id === currentId) : -1;
+    if (idx === -1) {
+      idx = offset > 0 ? 0 : audios.length - 1;
+    } else {
+      idx = (idx + offset + audios.length) % audios.length;
+    }
+    const audio = audios[idx];
+    const name = audio.closest('.channel-card').querySelector('.channel-name').textContent;
+    const btn = audio.parentElement.querySelector('.play-btn');
+    resetButton(currentBtn);
+    loadStation(audio, name, btn);
+  }
+
+  prevBtn.addEventListener('click', () => playStation(-1));
+  nextBtn.addEventListener('click', () => playStation(1));
+
+  if ('mediaSession' in navigator) {
+    navigator.mediaSession.setActionHandler('previoustrack', () => playStation(-1));
+    navigator.mediaSession.setActionHandler('nexttrack', () => playStation(1));
+  }
+
+  playPauseBtn.addEventListener('click', () => {
+    if (mainPlayer.paused) {
+      const label = currentBtn?.querySelector('.label');
+      if (label) label.textContent = 'stop';
+      currentBtn?.setAttribute('aria-label', 'Stop');
+      playPauseBtn.classList.add('loading');
+      currentBtn?.classList.add('loading');
+      mainPlayer.play();
+    } else {
+      mainPlayer.pause();
+    }
+  });
+
+  muteBtn.addEventListener('click', () => {
+    mainPlayer.muted = !mainPlayer.muted;
+    muteBtn.textContent = mainPlayer.muted ? 'volume_off' : 'volume_up';
+  });
+
+  shareBtn.addEventListener('click', () => {
+    const shareData = {
+      title: document.title,
+      url: window.location.href
+    };
+    if (navigator.share) {
+      navigator.share(shareData).catch(err => console.error('Share failed', err));
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(shareData.url).then(() => {
+        alert('Page URL copied to clipboard');
+      }, () => {
+        window.prompt('Copy this URL', shareData.url);
+      });
+    } else {
+      window.prompt('Copy this URL', shareData.url);
+    }
+  });
+
+  mainPlayer.addEventListener('playing', () => {
+    playPauseLabel.textContent = 'pause';
+    playPauseBtn.classList.remove('loading');
+    playPauseBtn.setAttribute('aria-label', 'Pause');
+    liveBadge.hidden = false;
+    notLiveBadge.hidden = true;
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = 'playing';
+    }
+    if (pendingBtn) {
+      if (currentBtn && currentBtn !== pendingBtn) {
+        resetButton(currentBtn);
+      }
+      pendingBtn.classList.remove('loading');
+      pendingBtn.querySelector('.label').textContent = 'stop';
+      pendingBtn.setAttribute('aria-label', 'Stop');
+      currentBtn = pendingBtn;
+      pendingBtn = null;
+    } else if (currentBtn) {
+      currentBtn.classList.remove('loading');
+      currentBtn.querySelector('.label').textContent = 'stop';
+      currentBtn.setAttribute('aria-label', 'Stop');
+    }
+  });
+
+    mainPlayer.addEventListener('waiting', () => {
+      liveBadge.hidden = true;
+      notLiveBadge.hidden = false;
+      playPauseBtn.classList.add('loading');
+      const targetBtn = pendingBtn || currentBtn;
+      targetBtn?.classList.add('loading');
+    });
+
+  mainPlayer.addEventListener('pause', () => {
+    if (!mainPlayer.src) return;
+    resetButton(currentBtn);
+    playPauseLabel.textContent = 'play_arrow';
+    playPauseBtn.classList.remove('loading');
+    playPauseBtn.setAttribute('aria-label', 'Play');
+    liveBadge.hidden = true;
+    notLiveBadge.hidden = false;
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = 'paused';
+    }
+  });
+
+  mainPlayer.addEventListener('error', () => {
+    resetButton(pendingBtn || currentBtn);
+    playPauseBtn.classList.remove('loading');
+    playPauseLabel.textContent = 'play_arrow';
+    playPauseBtn.setAttribute('aria-label', 'Play');
+    currentBtn = null;
+    pendingBtn = null;
+    currentAudio = null;
+    liveBadge.hidden = true;
+    notLiveBadge.hidden = false;
+    stationLogo.onerror = null;
+    stationLogo.src = defaultLogo;
+    stationLogo.hidden = false;
+    updateFavoritesUI();
+  });
+
+});
+
+  </script>
+  <script src="/js/leftmenu.js"></script>
+  <script defer src="/js/main.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add `livestream-test.html` to load TV channels from `all_streams.json`
- add `freepress-test.html` to read freepress entries from unified data
- add `radio-test.html` and `creators-test.html` using the consolidated streams
- unify thumbnail handling across test pages using cached fetch logic

## Testing
- `npx --yes htmlhint livestream-test.html freepress-test.html radio-test.html creators-test.html`


------
https://chatgpt.com/codex/tasks/task_e_68a090c7ec048320be355657d8f2ad10