### PR TITLE
Fix missing Material Symbols font on media hub

### DIFF
--- a/media-hub.html
+++ b/media-hub.html
@@ -7,10 +7,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <title>PakStream Media Hub</title>
   <meta name="description" content="PakStream Media Hub - Live TV, Free Press, Radio and Creators in one place." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
 <body>
   <!-- Top bar (same as site) -->


### PR DESCRIPTION
## Summary
- load Google Fonts for Material Symbols and Roboto in media-hub head

## Testing
- `npx htmlhint media-hub.html`

------
https://chatgpt.com/codex/tasks/task_e_68a0c2f822408320b9a626d844e91888