### PR TITLE
Fix YouTube RSS CORS fetch in media hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -435,8 +435,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     videoList.innerHTML = "";
     if (!channelId) return;
     try {
-      const rssUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
-      const xml = await fetch(rssUrl).then(r => r.text());
+      const directFeed = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+      let xml = "";
+      try {
+        const resp = await fetch(directFeed);
+        if (!resp.ok) throw new Error("Bad status");
+        xml = await resp.text();
+      } catch (_) {
+        const proxyFeed = `https://api.allorigins.win/raw?url=${encodeURIComponent(directFeed)}`;
+        xml = await fetch(proxyFeed).then(r => r.text());
+      }
       const doc = new DOMParser().parseFromString(xml, "text/xml");
       const entries = [...doc.querySelectorAll("entry")].slice(0, 10);
       if (!entries.length) return;


### PR DESCRIPTION
## Summary
- handle CORS errors when loading latest videos
- fall back to allorigins proxy if direct YouTube RSS fetch fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c5daee808320b9e72d01ea4d7f51