### PR TITLE
Fix missing favorites in media hub left menu

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -80,9 +80,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       playBtn.setAttribute("type","button");
 
       const favButton = document.createElement("button");
-      favButton.className = "fav-btn material-symbols-outlined";
+      favButton.className = "fav-btn";
       favButton.setAttribute("aria-label","Toggle favorite");
-      favButton.textContent = "favorite_border";
+      const favIcon = document.createElement("span");
+      favIcon.className = "material-symbols-outlined";
+      favIcon.textContent = "favorite_border";
+      favButton.appendChild(favIcon);
 
       const audio = document.createElement("audio");
       audio.id = it.ids?.internal_id || it.key;
@@ -116,9 +119,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       card.appendChild(audio);
     } else {
       const favButton = document.createElement("button");
-      favButton.className = "fav-btn material-symbols-outlined";
+      favButton.className = "fav-btn";
       favButton.setAttribute("aria-label","Toggle favorite");
-      favButton.textContent = "favorite_border";
+      const favIcon = document.createElement("span");
+      favIcon.className = "material-symbols-outlined";
+      favIcon.textContent = "favorite_border";
+      favButton.appendChild(favIcon);
 
       favButton.addEventListener("click", (e) => {
         e.stopPropagation();
@@ -181,7 +187,10 @@ document.addEventListener("DOMContentLoaded", async () => {
       const isFav = favorites.includes(id);
       card.classList.toggle('favorite', isFav);
       const btn = card.querySelector('.fav-btn');
-      if (btn) btn.textContent = isFav ? 'favorite' : 'favorite_border';
+      if (btn) {
+        const icon = btn.querySelector('.material-symbols-outlined') || btn;
+        icon.textContent = isFav ? 'favorite' : 'favorite_border';
+      }
       (isFav ? favFragment : otherFragment).appendChild(card);
     });
 
@@ -191,13 +200,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (mode === 'radio') {
       if (currentAudio) {
         const isFav = favorites.includes(currentAudio.id);
-        favBtn.textContent = isFav ? 'favorite' : 'favorite_border';
+        const favIconEl = favBtn.querySelector('.material-symbols-outlined') || favBtn;
+        favIconEl.textContent = isFav ? 'favorite' : 'favorite_border';
         favBtn.classList.toggle('favorited', isFav);
         favBtn.disabled = false;
         playPauseBtn.disabled = false;
         muteBtn.disabled = false;
       } else {
-        favBtn.textContent = 'favorite_border';
+        const favIconEl = favBtn.querySelector('.material-symbols-outlined') || favBtn;
+        favIconEl.textContent = 'favorite_border';
         favBtn.classList.remove('favorited');
         favBtn.disabled = true;
         playPauseBtn.disabled = true;

--- a/media-hub.html
+++ b/media-hub.html
@@ -3,11 +3,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-{% include google-tag-manager-head.html %}
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-T63RDQDK');</script>
+  <!-- End Google Tag Manager -->
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
   <!-- End cookieyes banner -->
-  {% include google-analytics.html %}
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-G9N0G15W9V"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-G9N0G15W9V');
+  </script>
   <!-- Standard Meta -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
@@ -23,6 +36,9 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T63RDQDK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <!-- Top bar (same as site) -->
   <header class="top-bar">
     <input type="checkbox" id="nav-toggle">
@@ -91,7 +107,9 @@
               <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
             </div>
             <div class="controls">
-              <button id="favorite-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
+              <button id="favorite-btn" class="fav-btn" type="button" aria-label="Toggle favorite" disabled>
+                <span class="material-symbols-outlined">favorite_border</span>
+              </button>
               <button id="prev-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Previous station" disabled>skip_previous</button>
               <button id="play-pause-btn" class="play-pause-btn" type="button" aria-label="Play or pause" disabled>
                 <span class="material-symbols-outlined label">play_arrow</span>


### PR DESCRIPTION
## Summary
- Ensure favorite star icons appear for Live TV, Free Press, and Creators lists in Media Hub
- Inline Google Tag Manager and Analytics scripts directly in `media-hub.html` to remove raw include tags

## Testing
- `node --check js/media-hub.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0ccc5aba48320bfc78fe9201bdeb4