### PR TITLE
Ensure mobile left menu fills viewport height

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -62,3 +62,11 @@
   .left-rail { order:1; }
   .center-rail { order:2; }
 }
+
+/* Make left menu cover full height on mobile */
+@media (max-width: 768px) {
+  .youtube-section .channel-list {
+    top: 0;
+    height: 100vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Allow left rail on Media Hub to span from top to bottom on mobile by overriding its top and height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cdb04f748320bb0b9b55ea086c09