### PR TITLE
Close mobile channel list after selection

### DIFF
--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -41,6 +41,16 @@
   });
 
   if (channelList) {
+    channelList.addEventListener('click', e => {
+      if (window.innerWidth > 768) return;
+      if (e.target.closest('.channel-card')) {
+        channelList.classList.remove('open');
+        const label = channelToggleBtn?.querySelector('.label');
+        if (label) label.textContent = channelToggleDefaultText;
+        if (typeof updateScrollLock === 'function') updateScrollLock();
+      }
+    });
+
     let touchStartX = null;
     channelList.addEventListener('touchstart', e => {
       if (!channelList.classList.contains('open')) return;


### PR DESCRIPTION
## Summary
- Close the channel list automatically on mobile when a channel card is selected
- Keep body scroll and overlay state in sync after closing the list

## Testing
- `node --check js/leftmenu.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cf954c188320b479ccf5d2d24475