### PR TITLE
Sort inactive streams last on media hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -141,7 +141,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     favorites = JSON.parse(localStorage.getItem(favKeys[mode]) || "[]");
 
     const q = filter.trim().toLowerCase();
-    const list = items.filter(i => i.type === mode && (!q || i.name.toLowerCase().includes(q)));
+    const list = items
+      .filter(i => i.type === mode && (!q || i.name.toLowerCase().includes(q)))
+      .sort((a, b) => (b.status?.active ? 1 : 0) - (a.status?.active ? 1 : 0));
 
     list.forEach(it => listEl.appendChild(makeChannelCard(it)));
 


### PR DESCRIPTION
## Summary
- Sort channel list so inactive streams are appended after active ones

## Testing
- `node --check js/media-hub.js`
- `npx htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a0d6caeab483208153fbfa7dce7417