### PR TITLE
Fix media hub tab filtering for Free Press and Creators

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -215,9 +215,17 @@ document.addEventListener("DOMContentLoaded", async () => {
         (i.endpoints||[]).some(e => e.provider === "youtube")
       );
     } else if (m === "freepress") {
-      arr = arr.filter(i => i.category === "freepress" || /freepress|journalist|news/i.test(i.tags || ""));
+      arr = arr.filter(i =>
+        i.category === "freepress" ||
+        i.type === "freepress" ||
+        /freepress|journalist|news/i.test(i.tags || "")
+      );
     } else if (m === "creator") {
-      arr = arr.filter(i => i.category === "creator" || /creator|vlog|podcast/i.test(i.tags || ""));
+      arr = arr.filter(i =>
+        i.category === "creator" ||
+        i.type === "creator" ||
+        /creator|vlog|podcast/i.test(i.tags || "")
+      );
     }
 
     // Search


### PR DESCRIPTION
## Summary
- ensure Free Press and Creator tabs show correct items by filtering on `type`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc344b548320928f636caa12ea97