### PR TITLE
Ensure Live TV tab only shows Live TV channels

### DIFF
--- a/livetv.html
+++ b/livetv.html
@@ -211,7 +211,7 @@
         .then(res => res.json())
         .then(data => {
           const channels = (data.items || [])
-            .filter(item => item.type === 'tv')
+            .filter(item => item.type === 'livetv')
             .map(item => ({
               id: item.key,
               name: item.name,


### PR DESCRIPTION
## Summary
- Filter Live TV channels to only include entries of type `livetv`

## Testing
- `npx -y htmlhint livetv.html`

------
https://chatgpt.com/codex/tasks/task_e_68a0e1bedce08320b971cc7a22a42c6b