### PR TITLE
Ensure Live TV tab only shows Live TV channels

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -265,10 +265,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       arr = arr.filter(i => i.category === "radio" || i.type === "radio" || /radio/i.test(i.platform || ""));
     } else if (m === "tv") {
       arr = arr.filter(i =>
-        i.category === "tv" ||
+        i.type === "livetv" ||
         i.type === "tv" ||
-        i.ids?.youtube_channel_id ||
-        (i.endpoints||[]).some(e => e.provider === "youtube")
+        i.category === "tv"
       );
     } else if (m === "freepress") {
       arr = arr.filter(i =>

--- a/livetv.html
+++ b/livetv.html
@@ -211,7 +211,7 @@
         .then(res => res.json())
         .then(data => {
           const channels = (data.items || [])
-            .filter(item => item.type === 'tv')
+            .filter(item => item.type === 'livetv')
             .map(item => ({
               id: item.key,
               name: item.name,


### PR DESCRIPTION
## Summary
- Filter Live TV channels to only include entries of type `livetv`

## Testing
- `npx -y htmlhint media-hub.html`
- `node --check js/media-hub.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1bedce08320b971cc7a22a42c6b