### PR TITLE
style: apply dark theme to scrollbars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,10 +8,29 @@
 
 * {
   transition: background-color 0.3s, color 0.3s, box-shadow 0.3s, transform 0.2s;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 [hidden] {
   display: none !important;
+}
+
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border-radius: 4px;
+  border: 2px solid var(--scrollbar-track);
 }
 
 

--- a/css/theme.css
+++ b/css/theme.css
@@ -32,6 +32,8 @@
   --favorite-row: #00796B;
   --hover-primary: #00695C;
   --hover-link: #1565C0;
+  --scrollbar-track: var(--surface-variant);
+  --scrollbar-thumb: var(--outline);
 }
 
 /* -------- Dark Theme -------- */
@@ -66,4 +68,6 @@
   --favorite-row: #00796B;
   --hover-primary: #00695C;
   --hover-link: #64B5F6;
+  --scrollbar-track: var(--surface);
+  --scrollbar-thumb: var(--outline);
 }


### PR DESCRIPTION
## Summary
- define scrollbar colors for light and dark themes
- style scrollbars to use theme-aware colors

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e9a37158832099b486324337032c