### PR TITLE
feat: cache thumbnails with service worker

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -217,3 +217,11 @@ document.addEventListener('DOMContentLoaded', function () {
   window.addEventListener('mousemove', onUserInteraction, {once:true});
   window.addEventListener('touchstart', onUserInteraction, {once:true});
 })();
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/sw.js').catch(function (err) {
+      console.error('Service worker registration failed', err);
+    });
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'pakstream-image-cache-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  const req = event.request;
+  if (req.destination === 'image') {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(cache =>
+        cache.match(req).then(resp => {
+          if (resp) return resp;
+          return fetch(req).then(networkResp => {
+            if (networkResp && networkResp.status === 200) {
+              cache.put(req, networkResp.clone());
+            }
+            return networkResp;
+          });
+        })
+      )
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add service worker to cache images for offline reuse
- register service worker so thumbnail requests use cache-first strategy

## Testing
- `npx --yes htmlhint .`
- `node --check js/main.js`
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0f06ec9048320b19c0db51de49f58