### PR TITLE
Use unified stream data for top bar search

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -76,22 +76,24 @@ document.addEventListener('DOMContentLoaded', function () {
     var loaded = false;
     function loadData() {
       if (loaded) return Promise.resolve(searchData);
-      var sources = [
-        { url: '/channels.json', map: c => ({ name: c.name, link: '/livetv.html?tvchannel=' + c.id }) },
-        { url: '/freepress_channels.json', map: c => ({ name: c.name, link: '/freepress.html?newsanchor=' + c.key }) },
-        { url: '/radio_channels.json', map: c => ({ name: c.name, link: '/radio.html?station=' + c.id }) }
-      ];
-      return Promise.all(
-        sources.map(s =>
-          fetch(s.url)
-            .then(r => r.json())
-            .then(data => (Array.isArray(data) ? data : data.channels || []).map(s.map))
-        )
-      ).then(res => {
-        searchData = res.flat();
-        loaded = true;
-        return searchData;
-      });
+      return fetch('/all_streams.json')
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          var items = Array.isArray(data.items) ? data.items : [];
+          var typeToMode = { livetv: 'tv', tv: 'tv', radio: 'radio', freepress: 'freepress', creator: 'creator' };
+          searchData = items.map(function (it) {
+            var mode = typeToMode[it.type] || 'tv';
+            var channelId = it.type === 'radio' && it.ids && it.ids.internal_id
+              ? it.ids.internal_id
+              : it.key;
+            return {
+              name: it.name,
+              link: '/media-hub.html?c=' + encodeURIComponent(channelId) + '&m=' + mode
+            };
+          });
+          loaded = true;
+          return searchData;
+        });
     }
 
     input.addEventListener('input', function () {


### PR DESCRIPTION
## Summary
- Load search suggestions from `all_streams.json`
- Build links to `media-hub.html` so results open the chosen stream
- Use radio station `internal_id` when constructing media hub links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eea905788320bfc707c9e2deb648