### PR TITLE
Enable radio station navigation in media hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -193,6 +193,8 @@ document.addEventListener("DOMContentLoaded", async () => {
         favBtn.disabled = false;
       }
       if (playPauseBtn) playPauseBtn.disabled = false;
+      const hasStations = listEl.querySelectorAll('.channel-card audio').length > 0;
+      if (prevBtn && nextBtn) prevBtn.disabled = nextBtn.disabled = !hasStations;
       return;
     }
 
@@ -230,6 +232,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
       if (playPauseBtn) playPauseBtn.disabled = false;
     }
+    const hasStations = listEl.querySelectorAll('.channel-card audio').length > 0;
+    if (prevBtn && nextBtn) prevBtn.disabled = nextBtn.disabled = !hasStations;
   }
 
     function toggleFavorite(id, itemMode = mode) {


### PR DESCRIPTION
## Summary
- Activate prev/next radio controls in media hub based on available stations
- Keep navigation buttons disabled when no radio stations are listed

## Testing
- `node --check js/media-hub.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f3460ea88320a6600a0b3cdbdebd