### PR TITLE
Disable search bar history suggestions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -50,11 +50,13 @@ document.addEventListener('DOMContentLoaded', function () {
     var searchForm = document.createElement('form');
     searchForm.id = 'search-form';
     searchForm.className = 'search-form';
+    searchForm.setAttribute('autocomplete', 'off');
     var input = document.createElement('input');
     input.type = 'search';
     input.id = 'search-input';
     input.placeholder = 'Search...';
     input.setAttribute('aria-label', 'Search');
+    input.setAttribute('autocomplete', 'off');
     searchForm.appendChild(input);
 
     input.addEventListener('focus', function () {


### PR DESCRIPTION
## Summary
- disable browser autocomplete on top navigation search bar to hide previous search history

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f3a8cdec8320848458f7a28743dd