### PR TITLE
Replace Free Press link with Media Hub on media hub page

### DIFF
--- a/media-hub.html
+++ b/media-hub.html
@@ -30,7 +30,7 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
       <a href="/">Home</a>
-      <a href="/freepress.html">Free Press</a>
+      <a href="/media-hub.html">Media Hub</a>
       <a href="/blog.html">Blog</a>
       <a href="/about.html">About</a>
       <a href="/contact.html">Contact</a>


### PR DESCRIPTION
## Summary
- Update top navigation on media hub page to link to Media Hub instead of Free Press.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7844edc832094bef58a22c273d0