### PR TITLE
Fix media hub search bar overflow

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -29,6 +29,7 @@
   background:var(--surface);
   color:var(--on-surface);
   border-radius:8px;
+  box-sizing:border-box;
 }
 
 /* Make video list look like cards */
@@ -85,6 +86,7 @@
   background:var(--surface);
   color:var(--on-surface);
   border-radius:8px;
+  box-sizing:border-box;
 }
 
 /* reuse your card list visuals */


### PR DESCRIPTION
## Summary
- Prevent search bar overflow in media hub left menu by applying border-box sizing

## Testing
- `npx --yes htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a0f998903c8320af947cd1a1acd3b2