### PR TITLE
Hide play icons in Media Hub left menu

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -98,6 +98,7 @@
 .channel-card { display:flex; align-items:center; gap:10px; padding:10px 12px; background:#fff; border-radius:14px; margin-bottom:10px; box-shadow:var(--card-shadow,0 1px 3px rgba(0,0,0,.06)); }
 .channel-card.active { outline:2px solid #0f7d73; }
 .channel-thumb { width:40px; height:40px; border-radius:8px; object-fit:cover; }
+.youtube-section .channel-card .play-btn { display:none; }
 
 .player-container iframe, .player-container .audio-wrap { width:100%; border:0; border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
 .player-container .audio-wrap { padding:14px; background:#fff; }


### PR DESCRIPTION
## Summary
- hide play/stop buttons on Media Hub channel cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa66fff88320be9309910d598f66