### PR TITLE
Play first search result on Enter in media hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -696,7 +696,17 @@ async function renderLatestVideosRSS(channelId) {
     updateActiveUI();
     renderList(searchEl ? (searchEl.value || "") : "");
   }));
-  if (searchEl) searchEl.addEventListener("input", e => renderList(e.target.value));
+  if (searchEl) {
+    searchEl.addEventListener("input", e => renderList(e.target.value));
+    searchEl.addEventListener("keydown", e => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        renderList(searchEl.value);
+        const firstCard = listEl.querySelector('.channel-card');
+        if (firstCard) firstCard.click();
+      }
+    });
+  }
 
   // ===== Init =====
   // If current mode has no items, switch to first available


### PR DESCRIPTION
## Summary
- Auto-play the top search result when pressing Enter in the media hub search box

## Testing
- `node --check js/media-hub.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0faebdc848320ad28f1a262f7055d