### PR TITLE
Add Media Hub submenu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -111,10 +111,42 @@ footer nav a:hover {
   text-decoration: underline;
 }
 
-.top-bar nav a.active,
-.top-bar nav a[aria-current="page"] {
-  background: color-mix(in oklab, var(--primary) 12%, transparent);
-}
+  .top-bar nav a.active,
+  .top-bar nav a[aria-current="page"] {
+    background: color-mix(in oklab, var(--primary) 12%, transparent);
+  }
+
+  .nav-links .dropdown {
+    position: relative;
+  }
+
+  .nav-links .dropdown-content {
+    display: none;
+    position: absolute;
+    background: var(--primary);
+    border: 1px solid var(--primary-container);
+    border-radius: 4px;
+    top: 100%;
+    left: 0;
+    flex-direction: column;
+    padding: 4px 0;
+    z-index: 1003;
+  }
+
+  .nav-links .dropdown:hover .dropdown-content,
+  .nav-links .dropdown:focus-within .dropdown-content {
+    display: flex;
+  }
+
+  .nav-links .dropdown-content a {
+    padding: 8px 12px;
+    border-radius: 0;
+    white-space: nowrap;
+  }
+
+  .nav-links .dropdown-content a:hover {
+    background: color-mix(in oklab, var(--primary) 12%, transparent);
+  }
 
 .search-form {
   margin-left: 16px;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -13,6 +13,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   const searchEl  = document.getElementById("mh-search-input");
   const toggleDetailsBtn = document.getElementById("toggle-details");
 
+  // Handle top navigation submenu links without reloading
+  const topLinks = document.querySelectorAll('.dropdown-content a[href*="media-hub.html"]');
+  topLinks.forEach(link => {
+    link.addEventListener('click', (e) => {
+      if (link.pathname === location.pathname) {
+        e.preventDefault();
+        const newMode = new URL(link.href, location.origin).searchParams.get('m');
+        const tab = Array.from(tabs).find(t => t.dataset.mode === newMode);
+        if (tab) tab.click();
+      }
+    });
+  });
+
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");

--- a/media-hub.html
+++ b/media-hub.html
@@ -30,7 +30,16 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
       <a href="/">Home</a>
-      <a href="/media-hub.html">Media Hub</a>
+      <div class="dropdown">
+        <a href="/media-hub.html">Media Hub</a>
+        <div class="dropdown-content">
+          <a href="/media-hub.html?m=favorites">All Favorites</a>
+          <a href="/media-hub.html?m=tv">Live TV</a>
+          <a href="/media-hub.html?m=freepress">Free Press</a>
+          <a href="/media-hub.html?m=creator">Creators</a>
+          <a href="/media-hub.html?m=radio">Radio</a>
+        </div>
+      </div>
       <a href="/blog.html">Blog</a>
       <a href="/about.html">About</a>
       <a href="/contact.html">Contact</a>


### PR DESCRIPTION
## Summary
- add Media Hub dropdown with quick links to All Favorites, Live TV, Free Press, Creators and Radio
- style dropdown for hover and focus within top navigation
- switch Media Hub submenu links without reloading when already on Media Hub page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f9f2592883208e1e3dad818a4f3a