### PR TITLE
fix: align media hub nav button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -118,6 +118,8 @@ footer nav a:hover {
 
   .nav-links .dropdown {
     position: relative;
+    display: flex;
+    align-items: center;
   }
 
   .nav-links .dropdown-content {


### PR DESCRIPTION
## Summary
- ensure the Media Hub dropdown button aligns with other top bar links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fdee91b083209547b027eded1439