### PR TITLE
fix media hub dropdown

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -140,6 +140,11 @@ footer nav a:hover {
     display: flex;
   }
 
+  /* Allow JS toggle via .open */
+  .nav-links .dropdown.open .dropdown-content {
+    display: flex;
+  }
+
   .nav-links .dropdown-content a {
     padding: 8px 12px;
     border-radius: 0;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -13,10 +13,23 @@ document.addEventListener("DOMContentLoaded", async () => {
   const searchEl  = document.getElementById("mh-search-input");
   const toggleDetailsBtn = document.getElementById("toggle-details");
 
-  // Handle top navigation submenu links without reloading
-  const topLinks = document.querySelectorAll('.dropdown-content a[href*="media-hub.html"]');
+  // Handle top navigation submenu on the media hub page
+  const dropdown = document.querySelector('.nav-links .dropdown');
+  const topLink = dropdown ? dropdown.querySelector('a[href*="media-hub.html"]') : null;
+  if (topLink && topLink.pathname === location.pathname) {
+    topLink.addEventListener('click', (e) => {
+      // Only toggle the submenu, don't navigate
+      e.preventDefault();
+      dropdown.classList.toggle('open');
+    });
+  }
+
+  const topLinks = dropdown ? dropdown.querySelectorAll('.dropdown-content a[href*="media-hub.html"]') : [];
   topLinks.forEach(link => {
     link.addEventListener('click', (e) => {
+      // Always close the submenu first
+      dropdown.classList.remove('open');
+
       if (link.pathname === location.pathname) {
         e.preventDefault();
         const newMode = new URL(link.href, location.origin).searchParams.get('m');


### PR DESCRIPTION
## Summary
- Ensure Media Hub link toggles submenu on click without navigating
- Close submenu before handling submenu link actions
- Enable JavaScript-controlled dropdown with new CSS rule

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a0fecb4d248320ac4fb578d6008dbc