### PR TITLE
Simplify mode switching via topbar menu

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -1,4 +1,4 @@
-/* Left rail header with tabs + search */
+/* Left rail header with search */
 .left-rail-header {
   position: sticky;
   top: 0;
@@ -7,29 +7,6 @@
   z-index: 2;
   padding: 8px 8px 10px;
   border-bottom: 1px solid var(--outline);
-}
-.mode-tabs { display:flex; gap:8px; flex-wrap:wrap; margin-bottom:8px; }
-.tab-btn {
-  padding:8px 12px;
-  border:1px solid var(--surface-variant);
-  background:var(--surface-variant);
-  color:var(--on-surface);
-  border-radius:8px;
-  cursor:pointer;
-}
-.tab-btn.active {
-  background:var(--primary-container);
-  border-color:var(--primary);
-  color:var(--on-primary-container);
-}
-.search-wrap input {
-  width:100%;
-  padding:8px 10px;
-  border:1px solid var(--outline);
-  background:var(--surface);
-  color:var(--on-surface);
-  border-radius:8px;
-  box-sizing:border-box;
 }
 
 /* Make video list look like cards */
@@ -42,38 +19,10 @@
 /* Responsive keeps your existing behavior */
 
 
-.mode-tabs { display:flex; gap:8px; flex-wrap:wrap; }
-.tab-btn {
-  padding:8px 14px;
-  border:1px solid var(--surface-variant);
-  background:var(--surface-variant);
-  color:var(--on-surface);
-  border-radius:8px;
-  cursor:pointer;
-}
-.tab-btn.active {
-  background:var(--primary-container);
-  border-color:var(--primary);
-  color:var(--on-primary-container);
-}
 .live-player .audio-wrap { background:#fff; border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); padding:12px; }
 
 /* layout that mirrors your existing pages */
 .page-wrap { padding-top: 12px; }
-.tabs-row { display:flex; gap:8px; margin:8px 0 12px; }
-.tab-btn {
-  background:var(--surface-variant);
-  border:1px solid var(--surface-variant);
-  border-radius:8px;
-  padding:8px 14px;
-  color:var(--on-surface);
-  cursor:pointer;
-}
-.tab-btn.active {
-  background:var(--primary-container);
-  border-color:var(--primary);
-  color:var(--on-primary-container);
-}
 .content-grid { display:grid; gap:16px; grid-template-columns: 320px 1fr 340px; }
 .left-rail { min-width:280px; }
 .center-rail { min-width:0; }

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -9,9 +9,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   const audioWrap = document.getElementById("audioWrap");
   const videoList = document.getElementById("videoList");
   const details   = document.querySelector(".details-list");
-  const tabs      = document.querySelectorAll(".tab-btn");
   const searchEl  = document.getElementById("mh-search-input");
   const toggleDetailsBtn = document.getElementById("toggle-details");
+
+  function activateMode(newMode) {
+    mode = newMode;
+    params.set("m", mode);
+    history.replaceState(null, "", "?" + params.toString());
+    updateActiveUI();
+    renderList(searchEl ? (searchEl.value || "") : "");
+  }
 
   // Handle top navigation submenu on the media hub page
   const dropdown = document.querySelector('.nav-links .dropdown');
@@ -33,8 +40,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (link.pathname === location.pathname) {
         e.preventDefault();
         const newMode = new URL(link.href, location.origin).searchParams.get('m');
-        const tab = Array.from(tabs).find(t => t.dataset.mode === newMode);
-        if (tab) tab.click();
+        activateMode(newMode);
       }
     });
   });
@@ -98,13 +104,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     return "tv";
   }
 
-  // One place for UI updates (tabs, player visibility, details toggle, favorites cache)
+  // One place for UI updates (player visibility, details toggle, favorites cache)
   function updateActiveUI() {
-    tabs.forEach(t => {
-      const isActive = t.dataset.mode === mode;
-      t.classList.toggle("active", isActive);
-      t.setAttribute("aria-pressed", isActive ? "true" : "false");
-    });
 
     const videoPlaying = playerIF && playerIF.src && playerIF.src !== "about:blank";
     if (currentAudio || (!videoPlaying && mode === "radio")) {
@@ -714,14 +715,7 @@ async function renderLatestVideosRSS(channelId) {
     playRadio(card.querySelector('.play-btn'), audio, displayName(item), thumbOf(item));
   }
 
-  // Tabs + Search
-  tabs.forEach(t => t.addEventListener("click", () => {
-    mode = t.dataset.mode;
-    params.set("m", mode);
-    history.replaceState(null, "", "?" + params.toString());
-    updateActiveUI();
-    renderList(searchEl ? (searchEl.value || "") : "");
-  }));
+  // Search
   if (searchEl) {
     searchEl.addEventListener("input", e => renderList(e.target.value));
     searchEl.addEventListener("keydown", e => {

--- a/media-hub.html
+++ b/media-hub.html
@@ -52,22 +52,15 @@
 
   <section class="youtube-section">
     <!-- LEFT RAIL -->
-    <div class="channel-list open" id="left-rail">
-      <!-- NEW: tabs + search at the very top of left menu -->
-      <div class="left-rail-header">
-        <div class="mode-tabs">
-          <button class="tab-btn" data-mode="favorites">All Favorites</button>
-          <button class="tab-btn" data-mode="tv">Live TV</button>
-          <button class="tab-btn" data-mode="freepress">Free Press</button>
-          <button class="tab-btn" data-mode="creator">Creators</button>
-          <button class="tab-btn" data-mode="radio">Radio</button>
+      <div class="channel-list open" id="left-rail">
+        <!-- NEW: search at the very top of left menu -->
+        <div class="left-rail-header">
+          <div class="search-wrap">
+            <input id="mh-search-input" type="text" placeholder="Search…" />
+          </div>
         </div>
-        <div class="search-wrap">
-          <input id="mh-search-input" type="text" placeholder="Search…" />
-        </div>
+        <!-- list gets injected here -->
       </div>
-      <!-- list gets injected here -->
-    </div>
 
     <!-- CENTER -->
     <div class="video-section">


### PR DESCRIPTION
## Summary
- remove deprecated mode tab buttons from media hub
- handle data mode changes directly when selecting from top menu
- drop associated tab styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1016ab768832098864a4ebc2f2931