### PR TITLE
Open channel list after submenu navigation on mobile

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -35,6 +35,13 @@ document.addEventListener("DOMContentLoaded", async () => {
         const newMode = new URL(link.href, location.origin).searchParams.get('m');
         const tab = Array.from(tabs).find(t => t.dataset.mode === newMode);
         if (tab) tab.click();
+
+        if (window.innerWidth <= 768) {
+          const list = document.querySelector('.channel-list');
+          if (list && !list.classList.contains('open') && typeof window.toggleChannelList === 'function') {
+            window.toggleChannelList();
+          }
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
- Ensure mobile users see the channel selector after picking a Media Hub submenu item by auto-opening the channel list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a107ceb00c8320b13529b3f4aa1942