### PR TITLE
Fix mobile menu remaining open on video autoplay

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -542,6 +542,14 @@ async function renderLatestVideosRSS(channelId) {
       }
     }
 
+    if (window.innerWidth <= 768) {
+      const list = document.querySelector('.channel-list');
+      if (list) list.classList.remove('open');
+      const label = document.querySelector('#toggle-channels .label');
+      if (label) label.textContent = label.dataset.default || label.textContent;
+      if (typeof window.updateScrollLock === 'function') window.updateScrollLock();
+    }
+
     updateActiveUI();
   }
 


### PR DESCRIPTION
## Summary
- Auto-close channel list on mobile when a video stream is selected or autoloaded

## Testing
- `node --check js/media-hub.js`
- `npx --yes htmlhint media-hub.html`

------
https://chatgpt.com/codex/tasks/task_e_68a10ab62d6c8320957cc3b94294af5a