### PR TITLE
Ensure left rail header sits at top on mobile

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -126,5 +126,6 @@
   .youtube-section .channel-list {
     top: 0;
     height: 100vh;
+    padding-top: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Remove extra top padding from mobile channel list so the left rail header aligns with the top of the screen.

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a10be182f883208ec167a7c0afa1c9