### PR TITLE
feat: add all channels tab

### DIFF
--- a/media-hub.html
+++ b/media-hub.html
@@ -33,6 +33,7 @@
       <div class="dropdown">
         <a href="/media-hub.html">Media Hub</a>
         <div class="dropdown-content">
+          <a href="/media-hub.html?m=all">All Channels</a>
           <a href="/media-hub.html?m=favorites">All Favorites</a>
           <a href="/media-hub.html?m=tv">Live TV</a>
           <a href="/media-hub.html?m=freepress">Free Press</a>
@@ -56,6 +57,7 @@
       <!-- NEW: tabs + search at the very top of left menu -->
       <div class="left-rail-header">
         <div class="mode-tabs">
+          <button class="tab-btn" data-mode="all">All</button>
           <button class="tab-btn" data-mode="favorites">All Favorites</button>
           <button class="tab-btn" data-mode="tv">Live TV</button>
           <button class="tab-btn" data-mode="freepress">Free Press</button>


### PR DESCRIPTION
## Summary
- add "All" channel tab and dropdown link in media hub
- support aggregated channel list in media hub script with favorites and radio controls

## Testing
- `node --check js/media-hub.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ea5e1d8832084181301f0beb1ef