### PR TITLE
Make mode tabs horizontally scrollable

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -8,7 +8,7 @@
   padding: 8px 8px 10px;
   border-bottom: 1px solid var(--outline);
 }
-.mode-tabs { display:flex; gap:8px; flex-wrap:wrap; margin-bottom:8px; }
+.mode-tabs { display:flex; gap:8px; flex-wrap:nowrap; overflow-x:auto; overflow-y:hidden; margin-bottom:8px; }
 .tab-btn {
   padding:8px 12px;
   border:1px solid var(--surface-variant);
@@ -42,7 +42,7 @@
 /* Responsive keeps your existing behavior */
 
 
-.mode-tabs { display:flex; gap:8px; flex-wrap:wrap; }
+.mode-tabs { display:flex; gap:8px; flex-wrap:nowrap; overflow-x:auto; overflow-y:hidden; }
 .tab-btn {
   padding:8px 14px;
   border:1px solid var(--surface-variant);


### PR DESCRIPTION
## Summary
- keep mode tabs on a single row and allow horizontal scrolling

## Testing
- `npx -y htmlhint media-hub.html`
- `npx -y stylelint css/media-hub.css` *(fails: ConfigurationError: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ef047948320a7e94fcf96aa1148