### PR TITLE
Remove horizontal padding from left rail header

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -5,7 +5,7 @@
   background: var(--surface);
   color: var(--on-surface);
   z-index: 2;
-  padding: 8px 8px 10px;
+  padding: 8px 0 10px;
   border-bottom: 1px solid var(--outline);
 }
 .mode-tabs { display:flex; gap:8px; flex-wrap:nowrap; overflow-x:auto; overflow-y:hidden; margin-bottom:8px; }


### PR DESCRIPTION
## Summary
- remove horizontal padding from left rail header so header spans edge-to-edge within channel list

## Testing
- `npm test` *(fails: Could not read package.json)*
- `htmlhint media-hub.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a113bfa4588320b04612d5efb23f07