### PR TITLE
Default to all mode when channel parameter exists

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -1,5 +1,9 @@
 document.addEventListener("DOMContentLoaded", async () => {
   const params = new URLSearchParams(location.search);
+  if (!params.has("m") && params.has("c")) {
+    params.set("m", "all");
+    history.replaceState(null, "", `${location.pathname}?${params}`);
+  }
   let mode = params.get("m") || "tv"; // default, will auto-correct based on data
 
   // DOM


### PR DESCRIPTION
## Summary
- Ensure media hub URLs with a channel ID but no mode parameter automatically append `m=all`

## Testing
- `node --check js/media-hub.js`
- `npx -y htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a115d904bc83208273a9da79ba319b