### PR TITLE
Prevent radio restart on search filter

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -445,7 +445,11 @@ document.addEventListener("DOMContentLoaded", async () => {
             const card = listEl.querySelector(`.channel-card[data-key="${match.key}"]`);
             const btn = card ? card.querySelector('.play-btn') : null;
             const audio = card ? card.querySelector('audio') : null;
-            if (btn && audio) {
+            const matchId = match.ids?.internal_id || match.key;
+            if (currentAudio && currentAudio.id === matchId) {
+              document.querySelectorAll('.channel-card').forEach(c => c.classList.toggle('active', c.dataset.key === match.key));
+              handled = true;
+            } else if (btn && audio) {
               playRadio(btn, audio, displayName(match), thumbOf(match));
               handled = true;
             }


### PR DESCRIPTION
## Summary
- avoid replaying current radio station when search re-renders the list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1181881488320874a0be8974d8fca