### PR TITLE
Fix search tab switching in Media Hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -405,8 +405,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (!listEl) return;
 
     // Get items; if none for current mode, auto-switch to an available mode
+    // Only auto-switch when not actively filtering to avoid jumping tabs during search
     let arr = filteredByMode(mode, filterText);
-    if (arr.length === 0 && mode !== 'favorites') {
+    if (!filterText && arr.length === 0 && mode !== 'favorites') {
       mode = detectAvailableMode();
       params.set("m", mode);
       history.replaceState(null, "", "?" + params.toString());


### PR DESCRIPTION
## Summary
- prevent Media Hub search from auto-switching tabs when filtering results

## Testing
- `node --check js/media-hub.js`
- `npx --yes htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a119c76e4c8320938971c69fe9be56