### PR TITLE
Skip redundant top bar search on media hub

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -44,7 +44,8 @@ document.addEventListener('DOMContentLoaded', function () {
     topBar.insertBefore(backBtn, label.nextSibling);
   }
 
-  if (topBar) {
+  // The media hub has its own search in the left menu, so skip the top-bar search there.
+  if (topBar && currentPath !== '/media-hub.html') {
     var themeBtn = themeToggle;
     var logoTitle = document.querySelector('.logo-title');
     var searchForm = document.createElement('form');


### PR DESCRIPTION
## Summary
- Avoid rendering the top bar search on `media-hub.html` since the page already provides a search field in the left menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a11dd904608320bdb664e79661aac6