### PR TITLE
Fix media hub video list for Free Press channels

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -488,8 +488,8 @@ async function renderLatestVideosRSS(channelId) {
     let xml = "";
     try {
       xml = await fetch(proxy1, { cache: "no-store" }).then(r => r.text());
-      // r.jina.ai sometimes returns JSON for non-200; cheap sanity check:
-      if (!xml || xml[0] === "{") throw new Error("Proxy1 bad shape");
+      // r.jina.ai may return non-XML (markdown/JSON); ensure we have XML, otherwise fallback
+      if (!xml || !xml.trim().startsWith("<")) throw new Error("Proxy1 bad shape");
     } catch {
       xml = await fetch(proxy2, { cache: "no-store" }).then(r => r.text());
     }


### PR DESCRIPTION
## Summary
- Validate proxy response when loading latest videos so non-XML responses fallback to AllOrigins

## Testing
- `node -e "new Function(require('fs').readFileSync('js/media-hub.js','utf8'))"`
- `npx --yes htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a1220ca4008320888c6e9163aba1a0