### PR TITLE
Fix media hub video list for Free Press channels

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -32,13 +32,6 @@
   box-sizing:border-box;
 }
 
-/* Make video list look like cards */
-.video-list { margin-top:12px; }
-.video-item { display:flex; gap:10px; padding:8px 10px; border-radius:10px; background:#fff; margin-bottom:8px; cursor:pointer; }
-.video-item:hover { background:#f6f9f9; }
-.video-thumb { width:120px; height:68px; border-radius:8px; object-fit:cover; }
-.video-meta { display:flex; align-items:center; font-weight:600; }
-
 /* Responsive keeps your existing behavior */
 
 
@@ -100,12 +93,9 @@
 .channel-thumb { width:40px; height:40px; border-radius:8px; object-fit:cover; }
 .youtube-section .channel-card .play-btn { display:none; }
 
+
 .player-container iframe, .player-container .audio-wrap { width:100%; border:0; border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
 .player-container .audio-wrap { padding:14px; background:#fff; }
-
-.video-list { margin-top:12px; }
-.video-item { display:flex; gap:10px; padding:8px 10px; border-radius:10px; background:#fff; margin-bottom:8px; }
-.video-thumb { width:120px; height:68px; border-radius:8px; object-fit:cover; }
 
 .details-list { background:#fff; border-radius:14px; padding:12px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
 .detail-item { margin-bottom:6px; }

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -488,8 +488,8 @@ async function renderLatestVideosRSS(channelId) {
     let xml = "";
     try {
       xml = await fetch(proxy1, { cache: "no-store" }).then(r => r.text());
-      // r.jina.ai sometimes returns JSON for non-200; cheap sanity check:
-      if (!xml || xml[0] === "{") throw new Error("Proxy1 bad shape");
+      // r.jina.ai may return non-XML (markdown/JSON); ensure we have XML, otherwise fallback
+      if (!xml || !xml.trim().startsWith("<")) throw new Error("Proxy1 bad shape");
     } catch {
       xml = await fetch(proxy2, { cache: "no-store" }).then(r => r.text());
     }


### PR DESCRIPTION
## Summary
- Validate proxy response when loading latest videos so non-XML responses fallback to AllOrigins
- Remove custom video list styles from media hub to match Free Press look

## Testing
- `node -e "new Function(require('fs').readFileSync('js/media-hub.js','utf8'))"`
- `npx --yes htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a1220ca4008320888c6e9163aba1a0