### PR TITLE
Clear video list when switching to radio stream

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -615,6 +615,11 @@ async function renderLatestVideosRSS(channelId) {
 
     currentVideoKey = null;
 
+    // Ensure any previously displayed video list is cleared when
+    // switching to a radio stream, since radio channels don't have
+    // associated video playlists.
+    if (videoList) videoList.innerHTML = "";
+
     // stop previous
     if (currentAudio && currentAudio !== audio) {
       currentAudio.pause();


### PR DESCRIPTION
## Summary
- Clear previously displayed video list when a radio stream is selected
- Prevents leftover videos from prior channels without video lists

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1253abba48320b61bcca6b1ce928f