### PR TITLE
Open Media Hub page on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -155,6 +155,17 @@ footer nav a:hover {
     background: color-mix(in oklab, var(--primary) 12%, transparent);
   }
 
+@media (max-width: 768px) {
+  /* On small screens hide the Media Hub dropdown menu */
+  .nav-links .dropdown-content {
+    display: none !important;
+    position: static;
+    border: 0;
+    background: none;
+    padding: 0;
+  }
+}
+
 .search-form {
   margin-left: 16px;
   position: relative;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -22,9 +22,22 @@ document.addEventListener("DOMContentLoaded", async () => {
   const topLink = dropdown ? dropdown.querySelector('a[href*="media-hub.html"]') : null;
   if (topLink && topLink.pathname === location.pathname) {
     topLink.addEventListener('click', (e) => {
-      // Only toggle the submenu, don't navigate
-      e.preventDefault();
-      dropdown.classList.toggle('open');
+      if (window.innerWidth <= 768) {
+        // On small screens, go directly to the main Media Hub with the
+        // "All" tab selected and the channel list visible.
+        e.preventDefault();
+        const allTab = document.querySelector('.tab-btn[data-mode="all"]');
+        if (allTab) allTab.click();
+        const list = document.querySelector('.channel-list');
+        if (list && !list.classList.contains('open') && typeof window.toggleChannelList === 'function') {
+          window.toggleChannelList();
+        }
+        dropdown.classList.remove('open');
+      } else {
+        // Only toggle the submenu, don't navigate
+        e.preventDefault();
+        dropdown.classList.toggle('open');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Open Media Hub main page on small screens instead of toggling dropdown
- Hide Media Hub dropdown menu on small screens

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/pakstream/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a12d1e8a14832086838101f6525981