### PR TITLE
Collapse details panel by default

### DIFF
--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -211,7 +211,8 @@
     }
     if (detailsContainer && detailsToggleBtn) {
       const icon = detailsToggleBtn.querySelector('.icon');
-      if (localStorage.getItem('detailsListCollapsed') === 'true') {
+      const collapsedPref = localStorage.getItem('detailsListCollapsed');
+      if (collapsedPref === null || collapsedPref === 'true') {
         detailsContainer.classList.add('collapsed');
         if (icon) icon.textContent = 'chevron_left';
       }


### PR DESCRIPTION
## Summary
- Ensure details panel starts collapsed unless explicitly expanded by the user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a377a0c60483208f9f4cd2f9bda952