### PR TITLE
Place mode tabs above content grid

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -1,3 +1,34 @@
+/* Layout: mode tabs on top, channel list and video section below */
+.media-hub-section {
+  display: grid;
+  grid-template-columns: 220px 1fr 300px;
+  grid-template-rows: auto 1fr;
+  gap: 16px;
+  grid-template-areas:
+    "tabs tabs tabs"
+    "left center right";
+}
+.media-hub-section .mode-tabs { grid-area: tabs; }
+.media-hub-section #left-rail { grid-area: left; }
+.media-hub-section .video-section { grid-area: center; }
+.media-hub-section .details-container { grid-area: right; }
+
+@media (max-width: 1080px) {
+  .media-hub-section {
+    grid-template-columns: 220px 1fr;
+    grid-template-areas:
+      "tabs tabs"
+      "left center";
+  }
+  .media-hub-section .details-container { display: none; }
+}
+
+@media (max-width: 768px) {
+  .media-hub-section {
+    display: block;
+  }
+}
+
 /* Left rail header with tabs + search */
 .left-rail-header {
   position: sticky;

--- a/media-hub.html
+++ b/media-hub.html
@@ -51,7 +51,7 @@
     <label for="nav-toggle" class="nav-overlay"></label>
   </header>
 
-  <section class="media-hub-section">
+  <section class="youtube-section media-hub-section">
     <div class="mode-tabs">
       <button class="tab-btn" data-mode="all">All</button>
       <button class="tab-btn" data-mode="favorites">Favorites</button>


### PR DESCRIPTION
## Summary
- Position the mode tabs above the channel list and video section using a grid layout
- Tag media hub section with `youtube-section` class for consistent structure

## Testing
- `npx -y htmlhint media-hub.html css/media-hub.css`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37a47b4088320ba41cbc8c8d253fc