### PR TITLE
Add embedded media hub previews to homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -326,6 +326,13 @@ section {
   margin-bottom: 10px;
 }
 
+.feature-card .media-hub-embed {
+  width: 100%;
+  height: 360px;
+  border: none;
+  border-radius: 8px;
+}
+
 /* Blog list styling */
 .blog-list ul {
   list-style: none;

--- a/index.html
+++ b/index.html
@@ -130,6 +130,20 @@
     </div>
   </section>
 
+  <!-- Media hub embeds -->
+  <section class="feature-cards">
+    <div class="feature-card">
+      <section class="youtube-section media-hub-section">
+        <iframe class="media-hub-embed" src="/media-hub.html?m=radio" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card">
+      <section class="youtube-section media-hub-section">
+        <iframe class="media-hub-embed" src="/media-hub.html?m=tv" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+  </section>
+
   <!-- Main content sections -->
   <section class="intro">
     <h2>PakStream – Stay Connected to Pakistan, Wherever You Are</h2>


### PR DESCRIPTION
## Summary
- Embed media hub radio and live TV tabs on the homepage
- Add styling for embedded media hub iframes

## Testing
- `npm test` *(fails: no package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a37e63f0d083209af19286fde17199