### PR TITLE
Add embedded media hub previews to homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -326,6 +326,13 @@ section {
   margin-bottom: 10px;
 }
 
+.feature-card .media-hub-embed {
+  width: 100%;
+  height: 360px;
+  border: none;
+  border-radius: 8px;
+}
+
 /* Blog list styling */
 .blog-list ul {
   list-style: none;

--- a/index.html
+++ b/index.html
@@ -130,6 +130,20 @@
     </div>
   </section>
 
+  <!-- Media hub embeds -->
+  <section class="feature-cards">
+    <div class="feature-card">
+      <section class="youtube-section media-hub-section">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card">
+      <section class="youtube-section media-hub-section">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+  </section>
+
   <!-- Main content sections -->
   <section class="intro">
     <h2>PakStream – Stay Connected to Pakistan, Wherever You Are</h2>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -1,0 +1,75 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <title>PakStream Media Hub Embed</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="/css/theme.css" />
+  <link rel="stylesheet" href="/css/media-hub.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+</head>
+<body>
+  <section class="youtube-section media-hub-section">
+    <div class="channel-list open" id="left-rail">
+      <div class="left-rail-header">
+        <div class="search-wrap">
+          <input id="mh-search-input" type="text" placeholder="Search…" />
+        </div>
+      </div>
+    </div>
+
+    <div class="video-section">
+      <div class="button-row">
+        <div class="spacer"></div>
+        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+          <span class="material-symbols-outlined icon">chevron_left</span>
+          <span class="label" data-default="Channels">Channels</span>
+        </button>
+      </div>
+
+      <div class="live-player">
+        <iframe id="playerFrame" src="about:blank"
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+          title="Selected video player"></iframe>
+        <div id="audioWrap" class="audio-wrap" style="display:none;">
+          <div id="player-container" class="radio-player">
+            <div class="station-info">
+              <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
+              <h3 id="current-station" class="station-title">Select a station</h3>
+              <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
+              <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
+            </div>
+            <div class="controls">
+              <button id="favorite-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Toggle favorite" disabled>favorite_border</button>
+              <button id="prev-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Previous station" disabled>skip_previous</button>
+              <button id="play-pause-btn" class="play-pause-btn" type="button" aria-label="Play or pause" disabled>
+                <span class="material-symbols-outlined label">play_arrow</span>
+                <span class="spinner"></span>
+              </button>
+              <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
+              <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
+              <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
+              <audio id="radio-player" autoplay></audio>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="videoList" class="video-list"></div>
+    </div>
+  </section>
+
+  <script src="/js/media-hub.js"></script>
+  <script src="/js/leftmenu.js"></script>
+  <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Embed media hub radio and live TV tabs on the homepage
- Add styling for embedded media hub iframes
- Add minimal media hub page for embedding without header, footer or mode tabs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a37e63f0d083209af19286fde17199