### PR TITLE
Wrap control buttons on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -832,6 +832,7 @@ button:hover,
 
 .controls {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   margin-top: 12px;
@@ -845,7 +846,7 @@ button:hover,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin: 0 4px;
+  margin: 4px;
   background: var(--primary);
   color: var(--on-primary);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- allow radio control buttons to wrap onto multiple lines on narrow screens
- give control buttons uniform margins for spacing when wrapped

## Testing
- `npx -y htmlhint index.html`
- `npx -y stylelint css/style.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a393c941dc8320ab2ca1b613646ff2