### PR TITLE
Prevent live-player overflow on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -487,6 +487,7 @@ section {
   display: flex;
   flex-direction: column;
   height: calc(100vh - 120px);
+  min-height: 315px;
 }
 
 .video-section iframe {
@@ -494,6 +495,14 @@ section {
   height: 315px;
   border: none;
   border-radius: 4px;
+}
+
+.live-player {
+  min-height: 315px;
+}
+
+.youtube-section.media-hub-section {
+  min-height: 315px;
 }
 
 .video-section .video-list {


### PR DESCRIPTION
## Summary
- keep `.video-section`, `.live-player`, and `.youtube-section.media-hub-section` at least as tall as the iframe to stop media from overflowing on small screens

## Testing
- `npx --yes htmlhint freepress.html media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a3940cfbd48320bea021e8babd5c81