### PR TITLE
Mute autoplay media on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
       <h3>Free Press</h3>
       <p>Stay updated with the latest new from Independent Voices.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=imranriazkhan" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=imranriazkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
     </div>
     <div class="feature-card">
@@ -126,7 +126,7 @@
       <h3>Popular Radio Stations</h3>
       <p>Listen to trending Pakistani radio.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
     </div>
     <div class="feature-card">
@@ -134,7 +134,7 @@
       <h3>Live TV Channels</h3>
       <p>Watch the most viewed live TV streams.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
     </div>
   </section>

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -5,6 +5,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     history.replaceState(null, "", `${location.pathname}?${params}`);
   }
   let mode = params.get("m") || "all"; // default, will auto-correct based on data
+  const isMuted = params.get("muted") === "1";
+  const muteParam = isMuted ? "&mute=1" : "";
 
   // DOM
   const leftRail  = document.getElementById("left-rail");
@@ -66,6 +68,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");
+  if (mainPlayer && isMuted) mainPlayer.muted = true;
   const currentLabel = document.getElementById("current-station");
   const stationLogo = document.getElementById("station-logo");
   const liveBadge = document.getElementById("live-badge");
@@ -568,7 +571,7 @@ async function renderLatestVideosRSS(channelId) {
       row.addEventListener("click", () => {
         if (playerIF) {
           playerIF.style.display = "";
-          playerIF.src = `https://www.youtube.com/embed/${vid}?autoplay=1&rel=0`;
+          playerIF.src = `https://www.youtube.com/embed/${vid}?autoplay=1&rel=0${muteParam}`;
         }
         if (audioWrap) audioWrap.style.display = "none";
         if (details && toggleDetailsBtn && details.innerHTML.trim().length) {
@@ -621,12 +624,12 @@ async function renderLatestVideosRSS(channelId) {
     const emb = ytEmbed(item);
     let src = "";
     if (emb) {
-      src = emb.url.includes("?") ? `${emb.url}&autoplay=1` : `${emb.url}?autoplay=1`;
+      src = emb.url.includes("?") ? `${emb.url}&autoplay=1${muteParam}` : `${emb.url}?autoplay=1${muteParam}`;
     } else if (item.ids?.youtube_channel_id) {
       const upl = uploadsId(item.ids.youtube_channel_id);
       src = upl
-        ? `https://www.youtube.com/embed/videoseries?list=${upl}&autoplay=1&rel=0`
-        : `https://www.youtube.com/embed/live_stream?channel=${item.ids.youtube_channel_id}&autoplay=1&rel=0`;
+        ? `https://www.youtube.com/embed/videoseries?list=${upl}&autoplay=1&rel=0${muteParam}`
+        : `https://www.youtube.com/embed/live_stream?channel=${item.ids.youtube_channel_id}&autoplay=1&rel=0${muteParam}`;
     }
     if (playerIF) playerIF.src = src || "about:blank";
 


### PR DESCRIPTION
## Summary
- Default media widgets on the homepage to load muted by appending `muted=1` to iframe URLs.
- Support a `muted` query flag in `media-hub.js` to mute the radio player and add `&mute=1` to autoplaying video URLs.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a395aac638832086bdcbac601e4a4d