### PR TITLE
Prevent live-player overflow on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -399,6 +399,7 @@ section {
   display: flex;
   gap: 8px;
   margin-bottom: 8px;
+  min-height: var(--button-row-min, 0px);
 }
 
 .youtube-section .channel-card,
@@ -487,6 +488,7 @@ section {
   display: flex;
   flex-direction: column;
   height: calc(100vh - 120px);
+  min-height: var(--video-section-min, 315px);
 }
 
 .video-section iframe {
@@ -496,9 +498,21 @@ section {
   border-radius: 4px;
 }
 
+.live-player {
+  min-height: 315px;
+}
+
+.youtube-section.media-hub-section {
+  --button-row-min: 56px;
+  --video-list-min: 100px;
+  --video-section-min: calc(315px + var(--button-row-min) + var(--video-list-min));
+  min-height: var(--video-section-min);
+}
+
 .video-section .video-list {
   flex: 1 1 auto;
   overflow-y: auto;
+  min-height: var(--video-list-min, 0px);
 }
 
 .video-list .video-item {


### PR DESCRIPTION
## Summary
- compute a combined min-height for `.video-section` using button row, live player, and video list so the whole section never shrinks below its contents
- expose that combined min-height on the `.youtube-section.media-hub-section` wrapper and give explicit minimums to `.button-row` and `.video-list`

## Testing
- `npx --yes htmlhint freepress.html media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a3940cfbd48320bea021e8babd5c81