### PR TITLE
Fix media hub layout when details are hidden

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -13,6 +13,14 @@
 .media-hub-section .video-section { grid-area: center; }
 .media-hub-section .details-container { grid-area: right; }
 
+/* Hide right rail when there are no details to show */
+.media-hub-section.no-details {
+  grid-template-columns: 220px 1fr;
+}
+.media-hub-section.no-details .details-container {
+  display: none;
+}
+
 @media (max-width: 1080px) {
   .media-hub-section {
     grid-template-columns: 220px 1fr;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const tabs      = document.querySelectorAll(".tab-btn");
   const searchEl  = document.getElementById("mh-search-input");
   const toggleDetailsBtn = document.getElementById("toggle-details");
+  const mediaHubSection = document.querySelector(".media-hub-section");
 
   // Handle top navigation submenu on the media hub page
   const dropdown = document.querySelector('.nav-links .dropdown');
@@ -180,12 +181,14 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (audioWrap) audioWrap.style.display = "";
       if (details) details.style.display = "none";
       if (toggleDetailsBtn) toggleDetailsBtn.style.display = "none";
+      if (mediaHubSection) mediaHubSection.classList.add("no-details");
     } else {
       if (playerIF) playerIF.style.display = "";
       if (audioWrap) audioWrap.style.display = "none";
       const hasDetails = details && details.innerHTML.trim().length > 0;
       if (details) details.style.display = hasDetails ? "" : "none";
       if (toggleDetailsBtn) toggleDetailsBtn.style.display = hasDetails ? "" : "none";
+       if (mediaHubSection) mediaHubSection.classList.toggle("no-details", !hasDetails);
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
 


### PR DESCRIPTION
## Summary
- Add CSS class to collapse the right rail when no details are available
- Toggle the new class from JavaScript so the video section uses full width

## Testing
- `npx -y htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a3a5f16fc48320aca795497d3c49b6