### PR TITLE
Clamp video titles to three lines

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -530,6 +530,15 @@ section {
   flex-direction: column;
 }
 
+.video-list .video-item .video-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+}
+
 .video-list .video-item .video-meta {
   font-size: 0.875rem;
   color: var(--on-surface-variant);


### PR DESCRIPTION
## Summary
- limit `.video-title` to three lines and ellipsis overflow

## Testing
- `npx -y htmlhint "**/*.html"`

------
https://chatgpt.com/codex/tasks/task_e_68a3a7afea4c83208f9c27fd8b54a2a0