### PR TITLE
Auto-unmute feature card when visible on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,18 +226,29 @@
           });
         });
       } else if ('IntersectionObserver' in window) {
-        const observer = new IntersectionObserver(entries => {
-          entries.forEach(entry => {
-            const iframe = entry.target.querySelector('iframe');
-            if (!iframe || !iframe.contentWindow || typeof iframe.contentWindow.setMuted !== 'function') return;
-            if (entry.isIntersecting) {
-              iframe.contentWindow.setMuted(false);
-            } else {
-              iframe.contentWindow.setMuted(true);
+        cards.forEach(card => {
+          const iframe = card.querySelector('iframe');
+          if (!iframe) return;
+
+          let inView = false;
+          const applyMuteState = () => {
+            if (iframe.contentWindow && typeof iframe.contentWindow.setMuted === 'function') {
+              iframe.contentWindow.setMuted(!inView);
             }
-          });
-        }, { threshold: 0.5 });
-        cards.forEach(card => observer.observe(card));
+          };
+
+          const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+              if (entry.target !== card) return;
+              inView = entry.isIntersecting;
+              applyMuteState();
+            });
+          }, { threshold: 0.5 });
+
+          observer.observe(card);
+
+          iframe.addEventListener('load', applyMuteState);
+        });
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- ensure mobile devices automatically unmute embedded media when a feature card enters the viewport
- apply mute state again after iframe loads to handle slow loading

## Testing
- `npm test` (fails: ENOENT package.json)
- `bundle exec jekyll build` (fails: Could not locate Gemfile)


------
https://chatgpt.com/codex/tasks/task_e_68a3aa927034832089aa3ff3798d93db