### PR TITLE
Hide placeholder when video views unavailable

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -400,14 +400,16 @@
         }
 
         // Non-blocking view count (best effort)
-        fetchVideoDetails(videoId).then(details => {
-          const meta = itemEl.querySelector('.video-meta');
-          const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : 'Views unavailable';
-          meta.textContent = `${viewsText} • ${timeAgo(video.pubDate)}`;
-        }).catch(() => {
-          const meta = itemEl.querySelector('.video-meta');
-          meta.textContent = `Views unavailable • ${timeAgo(video.pubDate)}`;
-        });
+          fetchVideoDetails(videoId).then(details => {
+            const meta = itemEl.querySelector('.video-meta');
+            const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : null;
+            meta.textContent = viewsText
+              ? `${viewsText} • ${timeAgo(video.pubDate)}`
+              : `${timeAgo(video.pubDate)}`;
+          }).catch(() => {
+            const meta = itemEl.querySelector('.video-meta');
+            meta.textContent = `${timeAgo(video.pubDate)}`;
+          });
       });
     } catch (err) {
       console.error(err);

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -480,14 +480,16 @@
           setActiveVideo(itemEl);
         }
 
-        fetchVideoDetails(videoId).then(details => {
-          const meta = itemEl.querySelector('.video-meta');
-          const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : 'Views unavailable';
-          meta.textContent = `${viewsText} • ${timeAgo(video.pubDate)}`;
-        }).catch(() => {
-          const meta = itemEl.querySelector('.video-meta');
-          meta.textContent = `Views unavailable • ${timeAgo(video.pubDate)}`;
-        });
+          fetchVideoDetails(videoId).then(details => {
+            const meta = itemEl.querySelector('.video-meta');
+            const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : null;
+            meta.textContent = viewsText
+              ? `${viewsText} • ${timeAgo(video.pubDate)}`
+              : `${timeAgo(video.pubDate)}`;
+          }).catch(() => {
+            const meta = itemEl.querySelector('.video-meta');
+            meta.textContent = `${timeAgo(video.pubDate)}`;
+          });
       });
     } catch (err) {
       console.error(err);

--- a/freepress.html
+++ b/freepress.html
@@ -480,14 +480,16 @@
           setActiveVideo(itemEl);
         }
 
-        fetchVideoDetails(videoId).then(details => {
-          const meta = itemEl.querySelector('.video-meta');
-          const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : 'Views unavailable';
-          meta.textContent = `${viewsText} • ${timeAgo(video.pubDate)}`;
-        }).catch(() => {
-          const meta = itemEl.querySelector('.video-meta');
-          meta.textContent = `Views unavailable • ${timeAgo(video.pubDate)}`;
-        });
+          fetchVideoDetails(videoId).then(details => {
+            const meta = itemEl.querySelector('.video-meta');
+            const viewsText = details.view_count ? `${Number(details.view_count).toLocaleString()} views` : null;
+            meta.textContent = viewsText
+              ? `${viewsText} • ${timeAgo(video.pubDate)}`
+              : `${timeAgo(video.pubDate)}`;
+          }).catch(() => {
+            const meta = itemEl.querySelector('.video-meta');
+            meta.textContent = `${timeAgo(video.pubDate)}`;
+          });
       });
     } catch (err) {
       console.error(err);

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -607,10 +607,12 @@ async function renderLatestVideosRSS(channelId) {
       videoList.appendChild(row);
 
       fetchVideoDetails(vid).then(info => {
-        const viewsText = info.view_count ? `${Number(info.view_count).toLocaleString()} views` : 'Views unavailable';
-        meta.textContent = `${viewsText}${published ? " • " + timeAgo(published) : ""}`;
+        const viewsText = info.view_count ? `${Number(info.view_count).toLocaleString()} views` : null;
+        meta.textContent = viewsText
+          ? `${viewsText}${published ? " • " + timeAgo(published) : ""}`
+          : `${published ? timeAgo(published) : ""}`;
       }).catch(() => {
-        meta.textContent = `Views unavailable${published ? " • " + timeAgo(published) : ""}`;
+        meta.textContent = `${published ? timeAgo(published) : ""}`;
       });
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- Skip rendering "Views unavailable" when a video lacks view counts
- Show only publish time in metadata in these cases

## Testing
- `rg 'Views unavailable' -n`


------
https://chatgpt.com/codex/tasks/task_e_68a3abe3d468832081eb21f5d1cdc7ec