### PR TITLE
Sync mute button with audio state

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -84,6 +84,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   window.setMuted = function(muted) {
     if (mainPlayer) mainPlayer.muted = muted;
+    // Update mute icon to reflect the current state when muting is triggered
+    if (muteBtn) {
+      muteBtn.textContent = muted ? 'volume_off' : 'volume_up';
+    }
     if (playerIF && playerIF.contentWindow) {
       playerIF.contentWindow.postMessage(
         JSON.stringify({ event: 'command', func: muted ? 'mute' : 'unMute', args: [] }),


### PR DESCRIPTION
## Summary
- Update embedded player script to update mute icon when stream is muted/unmuted from the host page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3acf9e69c83208a668335fa279d57