### PR TITLE
Auto-unmute feature card when visible on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,35 +209,46 @@
   <script>
     document.addEventListener('DOMContentLoaded', function () {
       const cards = document.querySelectorAll('.feature-card');
-      const canHover = window.matchMedia('(hover: hover)').matches || window.innerWidth > 768;
+      const sendMuteMessage = (iframe, muted) => {
+        if (iframe.contentWindow) {
+          iframe.contentWindow.postMessage({ type: 'media-hub-set-muted', muted }, '*');
+        }
+      };
+
+      const canHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches && navigator.maxTouchPoints === 0;
       if (canHover) {
         cards.forEach(card => {
           const iframe = card.querySelector('iframe');
           if (!iframe) return;
           card.addEventListener('mouseenter', () => {
-            if (iframe.contentWindow && typeof iframe.contentWindow.setMuted === 'function') {
-              iframe.contentWindow.setMuted(false);
-            }
+            sendMuteMessage(iframe, false);
           });
           card.addEventListener('mouseleave', () => {
-            if (iframe.contentWindow && typeof iframe.contentWindow.setMuted === 'function') {
-              iframe.contentWindow.setMuted(true);
-            }
+            sendMuteMessage(iframe, true);
           });
         });
       } else if ('IntersectionObserver' in window) {
-        const observer = new IntersectionObserver(entries => {
-          entries.forEach(entry => {
-            const iframe = entry.target.querySelector('iframe');
-            if (!iframe || !iframe.contentWindow || typeof iframe.contentWindow.setMuted !== 'function') return;
-            if (entry.isIntersecting) {
-              iframe.contentWindow.setMuted(false);
-            } else {
-              iframe.contentWindow.setMuted(true);
-            }
-          });
-        }, { threshold: 0.5 });
-        cards.forEach(card => observer.observe(card));
+        cards.forEach(card => {
+          const iframe = card.querySelector('iframe');
+          if (!iframe) return;
+
+          let inView = false;
+          const applyMuteState = () => {
+            sendMuteMessage(iframe, !inView);
+          };
+
+          const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+              if (entry.target !== card) return;
+              inView = entry.isIntersecting;
+              applyMuteState();
+            });
+          }, { threshold: 0.5 });
+
+          observer.observe(card);
+
+          iframe.addEventListener('load', applyMuteState);
+        });
       }
     });
   </script>

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -89,8 +89,20 @@ document.addEventListener("DOMContentLoaded", async () => {
         JSON.stringify({ event: 'command', func: muted ? 'mute' : 'unMute', args: [] }),
         '*'
       );
+      if (!muted) {
+        playerIF.contentWindow.postMessage(
+          JSON.stringify({ event: 'command', func: 'playVideo', args: [] }),
+          '*'
+        );
+      }
     }
   };
+
+  window.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'media-hub-set-muted') {
+      window.setMuted(!!event.data.muted);
+    }
+  });
 
   const favKeys = { tv: "tvFavorites", freepress: "ytFavorites", creator: "ytFavorites", radio: "radioFavorites" };
   let favorites;


### PR DESCRIPTION
## Summary
- rely on `postMessage` to toggle iframe mute state for better cross-browser support
- listen for parent mute requests and resume playback when unmuting
- treat touch-capable devices as non-hover so cards unmute when scrolled into view

## Testing
- `npm test` (fails: Could not read package.json)
- `bundle exec jekyll build` (fails: Could not locate Gemfile or .bundle/ directory)


------
https://chatgpt.com/codex/tasks/task_e_68a3aa927034832089aa3ff3798d93db