### PR TITLE
Ensure unmuted state persists when switching channels

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -5,8 +5,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     history.replaceState(null, "", `${location.pathname}?${params}`);
   }
   let mode = params.get("m") || "all"; // default, will auto-correct based on data
-  const isMuted = params.get("muted") === "1";
-  const muteParam = isMuted ? "&mute=1" : "";
+  let isMuted = params.get("muted") === "1";
+  let muteParam = isMuted ? "&mute=1" : "";
 
   // DOM
   const leftRail  = document.getElementById("left-rail");
@@ -83,6 +83,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const shareBtn = document.getElementById("share-btn");
 
   window.setMuted = function(muted) {
+    isMuted = muted;
+    muteParam = muted ? '&mute=1' : '';
     if (mainPlayer) mainPlayer.muted = muted;
     // Update mute icon to reflect the current state when muting is triggered
     if (muteBtn) {


### PR DESCRIPTION
## Summary
- Track media hub mute state dynamically
- Update mute parameter whenever the state changes to keep new selections unmuted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b190c3c883209fe489e6063d9108