### PR TITLE
Populate freepress channel internal IDs

### DIFF
--- a/all_streams.json
+++ b/all_streams.json
@@ -2247,7 +2247,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCaszgR2TH3qNw_CxLHAd2SQ"
+        "youtube_channel_id": "UCaszgR2TH3qNw_CxLHAd2SQ",
+        "internal_id": "imranriazkhan"
       },
       "status": {
         "active": true
@@ -2269,7 +2270,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCY7eFg5TEMsk_aTqM0pVB4w"
+        "youtube_channel_id": "UCY7eFg5TEMsk_aTqM0pVB4w",
+        "internal_id": "sabirshakir"
       },
       "status": {
         "active": true
@@ -2291,7 +2293,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCFCzDl-XQq1TCo_fvBzCoyw"
+        "youtube_channel_id": "UCFCzDl-XQq1TCo_fvBzCoyw",
+        "internal_id": "samiabraham"
       },
       "status": {
         "active": true
@@ -2313,7 +2316,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UClDtMswg3muouH60XTKlVEw"
+        "youtube_channel_id": "UClDtMswg3muouH60XTKlVEw",
+        "internal_id": "mansooralikhank"
       },
       "status": {
         "active": true
@@ -2335,7 +2339,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCnkYymEbl1qZ0VhGrzH9guw"
+        "youtube_channel_id": "UCnkYymEbl1qZ0VhGrzH9guw",
+        "internal_id": "moeedpirzada"
       },
       "status": {
         "active": true
@@ -2357,7 +2362,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCslugpmYWJiZK5rbvtcaV7Q"
+        "youtube_channel_id": "UCslugpmYWJiZK5rbvtcaV7Q",
+        "internal_id": "mubasherlucman"
       },
       "status": {
         "active": true
@@ -2379,7 +2385,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UChOzmkBxTHbZNZdiiYolWoA"
+        "youtube_channel_id": "UChOzmkBxTHbZNZdiiYolWoA",
+        "internal_id": "faisalwarraich"
       },
       "status": {
         "active": true
@@ -2401,7 +2408,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCYdLgIyZnHVwlDkF3Y0G_cQ"
+        "youtube_channel_id": "UCYdLgIyZnHVwlDkF3Y0G_cQ",
+        "internal_id": "abdulqadir"
       },
       "status": {
         "active": true
@@ -2423,7 +2431,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCw6Gt_4bm-n4yLNUaqon_qA"
+        "youtube_channel_id": "UCw6Gt_4bm-n4yLNUaqon_qA",
+        "internal_id": "ansarabbasi"
       },
       "status": {
         "active": true
@@ -2445,7 +2454,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCYAIiV0G2ups3CyiFcPeBlg"
+        "youtube_channel_id": "UCYAIiV0G2ups3CyiFcPeBlg",
+        "internal_id": "asmashirazi"
       },
       "status": {
         "active": true
@@ -2467,7 +2477,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UC0UiDwKaevYAOTmVzXkrHSQ"
+        "youtube_channel_id": "UC0UiDwKaevYAOTmVzXkrHSQ",
+        "internal_id": "arshadsharif"
       },
       "status": {
         "active": true
@@ -2489,7 +2500,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCKtRaClqV6naRHzuxrsDPnA"
+        "youtube_channel_id": "UCKtRaClqV6naRHzuxrsDPnA",
+        "internal_id": "nasimzehra"
       },
       "status": {
         "active": true
@@ -2511,7 +2523,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCreAj2r67xRSmf3EQxM5KuQ"
+        "youtube_channel_id": "UCreAj2r67xRSmf3EQxM5KuQ",
+        "internal_id": "raufklasra"
       },
       "status": {
         "active": true
@@ -2533,7 +2546,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCpjldgul1pMZJpiL09j8JxA"
+        "youtube_channel_id": "UCpjldgul1pMZJpiL09j8JxA",
+        "internal_id": "zaidzamanhamid"
       },
       "status": {
         "active": true
@@ -2555,7 +2569,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCIyAy8lIQwnj-2CGt9e-N3g"
+        "youtube_channel_id": "UCIyAy8lIQwnj-2CGt9e-N3g",
+        "internal_id": "taimurrahman"
       },
       "status": {
         "active": true
@@ -2577,7 +2592,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCep38ldld-DjkOJt9Oh0gOA"
+        "youtube_channel_id": "UCep38ldld-DjkOJt9Oh0gOA",
+        "internal_id": "syedalihaider"
       },
       "status": {
         "active": true
@@ -2599,7 +2615,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UC-PoCqWxInxzN-9r9FxXJGg"
+        "youtube_channel_id": "UC-PoCqWxInxzN-9r9FxXJGg",
+        "internal_id": "siddiquejaan"
       },
       "status": {
         "active": true
@@ -2621,7 +2638,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCAO1utA5OhesHBHWjXd1wMw"
+        "youtube_channel_id": "UCAO1utA5OhesHBHWjXd1wMw",
+        "internal_id": "usamaghazi"
       },
       "status": {
         "active": true
@@ -2643,7 +2661,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCeqdeoG3nRSkkbBKT9u3wQQ"
+        "youtube_channel_id": "UCeqdeoG3nRSkkbBKT9u3wQQ",
+        "internal_id": "jameelfarooqui"
       },
       "status": {
         "active": true
@@ -2665,7 +2684,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCFqjOGv7tON3rY9kHPLa-OQ"
+        "youtube_channel_id": "UCFqjOGv7tON3rY9kHPLa-OQ",
+        "internal_id": "waqarmalik"
       },
       "status": {
         "active": true
@@ -2687,7 +2707,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCAyd8kYxON-KM0UuRuK_sIg"
+        "youtube_channel_id": "UCAyd8kYxON-KM0UuRuK_sIg",
+        "internal_id": "syedmuzammil"
       },
       "status": {
         "active": true
@@ -2709,7 +2730,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCzVdIJeAwQfBZbG_8AOXgBw"
+        "youtube_channel_id": "UCzVdIJeAwQfBZbG_8AOXgBw",
+        "internal_id": "nayadaurtv"
       },
       "status": {
         "active": false
@@ -2731,7 +2753,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCXORDenrw6IHFUvg0PH-3hg"
+        "youtube_channel_id": "UCXORDenrw6IHFUvg0PH-3hg",
+        "internal_id": "asadaliToor"
       },
       "status": {
         "active": true
@@ -2753,7 +2776,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UC-hJ0cobUiWlBFTHgLwt8sQ"
+        "youtube_channel_id": "UC-hJ0cobUiWlBFTHgLwt8sQ",
+        "internal_id": "matiullahjan"
       },
       "status": {
         "active": true
@@ -2775,7 +2799,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCFqEO3bSGcp5I8HVgXYdYRQ"
+        "youtube_channel_id": "UCFqEO3bSGcp5I8HVgXYdYRQ",
+        "internal_id": "aftabiqbal"
       },
       "status": {
         "active": true
@@ -2797,7 +2822,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCfL1eqnP_EYuE5gt9OrFHuA"
+        "youtube_channel_id": "UCfL1eqnP_EYuE5gt9OrFHuA",
+        "internal_id": "aminhafeez"
       },
       "status": {
         "active": true
@@ -2819,7 +2845,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UC57P3Cnt2Lq2W310oJxe7sA"
+        "youtube_channel_id": "UC57P3Cnt2Lq2W310oJxe7sA",
+        "internal_id": "muneebfarooq"
       },
       "status": {
         "active": true
@@ -2841,7 +2868,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCokfj4SqQZsdjRoG4mUci4A"
+        "youtube_channel_id": "UCokfj4SqQZsdjRoG4mUci4A",
+        "internal_id": "ahmadnoorani"
       },
       "status": {
         "active": true
@@ -2863,7 +2891,8 @@
         }
       ],
       "ids": {
-        "youtube_channel_id": "UCAvhohWtYwPdpKVGiMkkKOQ"
+        "youtube_channel_id": "UCAvhohWtYwPdpKVGiMkkKOQ",
+        "internal_id": "independenturdu"
       },
       "status": {
         "active": true
@@ -3339,7 +3368,7 @@
         }
       ],
       "ids": {
-        "internal_id": "UC5N0MlMQopPTGMLUxHISfDg",
+        "internal_id": "hamid-mir",
         "youtube_channel_id": "UC5N0MlMQopPTGMLUxHISfDg"
       },
       "status": {
@@ -3362,7 +3391,7 @@
         }
       ],
       "ids": {
-        "internal_id": "UC5kUxR5q8SKtGB-9z7Rr1Iw",
+        "internal_id": "habib-akram",
         "youtube_channel_id": "UC5kUxR5q8SKtGB-9z7Rr1Iw"
       },
       "status": {
@@ -3385,7 +3414,7 @@
         }
       ],
       "ids": {
-        "internal_id": "UCXORDenrw6IHFUvg0PH-3hg",
+        "internal_id": "asad-toor",
         "youtube_channel_id": "UCXORDenrw6IHFUvg0PH-3hg"
       },
       "status": {
@@ -3408,7 +3437,7 @@
         }
       ],
       "ids": {
-        "internal_id": "UCxaMbYDd4o_zVvfr9_wKAxQ",
+        "internal_id": "wajahatsaeedkhan",
         "youtube_channel_id": "UCxaMbYDd4o_zVvfr9_wKAxQ"
       },
       "status": {
@@ -3431,7 +3460,7 @@
         }
       ],
       "ids": {
-        "internal_id": "UCfTQGgFP5U53mcbbRRLl1yQ",
+        "internal_id": "zaeem-leghari",
         "youtube_channel_id": "UCfTQGgFP5U53mcbbRRLl1yQ"
       },
       "status": {


### PR DESCRIPTION
## Summary
- Set each freepress channel's `internal_id` to its key and preserve YouTube channel IDs
- Restore media hub lookup to rely on these internal IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b54b4b748320a01a43a9128bd96f