### PR TITLE
Add scrolling station logo marquee to homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -301,6 +301,29 @@ section {
   color: var(--on-primary-container);
 }
 
+.station-scroller {
+  overflow: hidden;
+  margin: 20px auto;
+  max-width: 960px;
+}
+
+.station-scroller .scroller-track {
+  display: flex;
+  width: max-content;
+  animation: station-scroll 40s linear infinite;
+}
+
+.station-scroller img {
+  height: 60px;
+  width: auto;
+  margin-right: 16px;
+}
+
+@keyframes station-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
 /* Featured card layout */
 .feature-cards {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@
     </div>
   </section>
 
+  <section class="station-scroller">
+    <div class="scroller-track"></div>
+  </section>
+
   <!-- Featured cards -->
   <section class="feature-cards">
     <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">

--- a/js/main.js
+++ b/js/main.js
@@ -204,6 +204,27 @@ document.addEventListener('DOMContentLoaded', function () {
   window.resizeLivePlayers = resizeLivePlayers;
   resizeLivePlayers();
 
+  var scroller = document.querySelector('.station-scroller .scroller-track');
+  if (scroller) {
+    fetch('/all_streams.json')
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var items = Array.isArray(data.items) ? data.items : [];
+        items.forEach(function (it) {
+          if (it.media && it.media.logo_url) {
+            var img = document.createElement('img');
+            img.src = it.media.logo_url;
+            img.alt = '';
+            scroller.appendChild(img);
+          }
+        });
+        scroller.innerHTML += scroller.innerHTML;
+      })
+      .catch(function (err) {
+        console.error('Failed to load station logos', err);
+      });
+  }
+
   if ('IntersectionObserver' in window) {
     const lazyElements = document.querySelectorAll('img[data-src], iframe[data-src]');
     const observer = new IntersectionObserver((entries, obs) => {


### PR DESCRIPTION
## Summary
- Add station logo scroller beneath hero banner on homepage
- Style marquee for continuous right-to-left logo animation
- Load station logos from `all_streams.json` and duplicate track for seamless looping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b963ccac83208e4bad878bd0ae3e