### PR TITLE
Refine scrolling station logo marquee on homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -301,6 +301,41 @@ section {
   color: var(--on-primary-container);
 }
 
+.station-scroller {
+  overflow: hidden;
+  margin: 20px auto;
+  max-width: 960px;
+}
+
+.station-scroller .scroller-track {
+  display: flex;
+  width: max-content;
+  animation: station-scroll 80s linear infinite;
+}
+
+.station-scroller:hover .scroller-track {
+  animation-play-state: paused;
+}
+
+.station-scroller .scroller-track a {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.station-scroller .channel-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+  margin-right: 16px;
+}
+
+@keyframes station-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
 /* Featured card layout */
 .feature-cards {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@
     </div>
   </section>
 
+  <section class="station-scroller">
+    <div class="scroller-track"></div>
+  </section>
+
   <!-- Featured cards -->
   <section class="feature-cards">
     <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">

--- a/js/main.js
+++ b/js/main.js
@@ -204,6 +204,37 @@ document.addEventListener('DOMContentLoaded', function () {
   window.resizeLivePlayers = resizeLivePlayers;
   resizeLivePlayers();
 
+  var scroller = document.querySelector('.station-scroller .scroller-track');
+  if (scroller) {
+    fetch('/all_streams.json')
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var items = Array.isArray(data.items) ? data.items : [];
+        var typeToMode = { livetv: 'tv', tv: 'tv', radio: 'radio', freepress: 'freepress', creator: 'creator' };
+        items.forEach(function (it) {
+          if (it.media && it.media.logo_url && !it.media.logo_url.includes('default_radio.png')) {
+            var mode = typeToMode[it.type] || 'tv';
+            var channelId = it.type === 'radio' && it.ids && it.ids.internal_id
+              ? it.ids.internal_id
+              : it.key;
+            var a = document.createElement('a');
+            a.href = '/media-hub.html?c=' + encodeURIComponent(channelId) + '&m=' + mode;
+            a.title = it.name || '';
+            var img = document.createElement('img');
+            img.src = it.media.logo_url;
+            img.alt = it.name || '';
+            img.className = 'channel-thumb';
+            a.appendChild(img);
+            scroller.appendChild(a);
+          }
+        });
+        scroller.innerHTML += scroller.innerHTML;
+      })
+      .catch(function (err) {
+        console.error('Failed to load station logos', err);
+      });
+  }
+
   if ('IntersectionObserver' in window) {
     const lazyElements = document.querySelectorAll('img[data-src], iframe[data-src]');
     const observer = new IntersectionObserver((entries, obs) => {


### PR DESCRIPTION
## Summary
- Slow station logo scroll and pause on hover
- Style logos with `channel-thumb` look and link to Media Hub with proper parameters
- Skip default radio logos when building marquee

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b963ccac83208e4bad878bd0ae3e