### PR TITLE
Fix inconsistent video thumbnail sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -586,7 +586,8 @@ section {
   cursor: pointer;
 }
 
-.video-list .video-item img {
+.video-list .video-item img,
+.video-list .video-thumb {
   width: 120px;
   height: 67px;
   object-fit: cover;


### PR DESCRIPTION
## Summary
- ensure thumbnails in video lists have uniform dimensions by styling `.video-thumb`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a3bfbe78e08320a10e1661033983f0