### PR TITLE
Remove Media Hub dropdown from navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -116,55 +116,6 @@ footer nav a:hover {
     background: color-mix(in oklab, var(--primary) 12%, transparent);
   }
 
-  .nav-links .dropdown {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
-
-  .nav-links .dropdown-content {
-    display: none;
-    position: absolute;
-    background: var(--primary);
-    border: 1px solid var(--primary-container);
-    border-radius: 4px;
-    top: 100%;
-    left: 0;
-    flex-direction: column;
-    padding: 4px 0;
-    z-index: 1003;
-  }
-
-  .nav-links .dropdown:hover .dropdown-content,
-  .nav-links .dropdown:focus-within .dropdown-content {
-    display: flex;
-  }
-
-  /* Allow JS toggle via .open */
-  .nav-links .dropdown.open .dropdown-content {
-    display: flex;
-  }
-
-  .nav-links .dropdown-content a {
-    padding: 8px 12px;
-    border-radius: 0;
-    white-space: nowrap;
-  }
-
-  .nav-links .dropdown-content a:hover {
-    background: color-mix(in oklab, var(--primary) 12%, transparent);
-  }
-
-@media (max-width: 768px) {
-  /* On small screens hide the Media Hub dropdown menu */
-  .nav-links .dropdown-content {
-    display: none !important;
-    position: static;
-    border: 0;
-    background: none;
-    padding: 0;
-  }
-}
 
 .search-form {
   margin-left: 16px;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -20,52 +20,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const toggleDetailsBtn = document.getElementById("toggle-details");
   const mediaHubSection = document.querySelector(".media-hub-section");
 
-  // Handle top navigation submenu on the media hub page
-  const dropdown = document.querySelector('.nav-links .dropdown');
-  const topLink = dropdown ? dropdown.querySelector('a[href*="media-hub.html"]') : null;
-  if (topLink && topLink.pathname === location.pathname) {
-    topLink.addEventListener('click', (e) => {
-      if (window.innerWidth <= 768) {
-        // On small screens, go directly to the main Media Hub with the
-        // "All" tab selected and the channel list visible.
-        e.preventDefault();
-        const allTab = document.querySelector('.tab-btn[data-mode="all"]');
-        if (allTab) allTab.click();
-        const list = document.querySelector('.channel-list');
-        if (list && !list.classList.contains('open') && typeof window.toggleChannelList === 'function') {
-          window.toggleChannelList();
-        }
-        dropdown.classList.remove('open');
-      } else {
-        // Only toggle the submenu, don't navigate
-        e.preventDefault();
-        dropdown.classList.toggle('open');
-      }
-    });
-  }
-
-  const topLinks = dropdown ? dropdown.querySelectorAll('.dropdown-content a[href*="media-hub.html"]') : [];
-  topLinks.forEach(link => {
-    link.addEventListener('click', (e) => {
-      // Always close the submenu first
-      dropdown.classList.remove('open');
-
-      if (link.pathname === location.pathname) {
-        e.preventDefault();
-        const newMode = new URL(link.href, location.origin).searchParams.get('m');
-        const tab = Array.from(tabs).find(t => t.dataset.mode === newMode);
-        if (tab) tab.click();
-
-        if (window.innerWidth <= 768) {
-          const list = document.querySelector('.channel-list');
-          if (list && !list.classList.contains('open') && typeof window.toggleChannelList === 'function') {
-            window.toggleChannelList();
-          }
-        }
-      }
-    });
-  });
-
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");

--- a/media-hub.html
+++ b/media-hub.html
@@ -30,17 +30,7 @@
     <h1 class="logo-title">PakStream</h1>
     <nav class="nav-links">
       <a href="/">Home</a>
-      <div class="dropdown">
-        <a href="/media-hub.html">Media Hub</a>
-        <div class="dropdown-content">
-          <a href="/media-hub.html?m=all">All Channels</a>
-          <a href="/media-hub.html?m=favorites">Favorites</a>
-          <a href="/media-hub.html?m=tv">Live TV</a>
-          <a href="/media-hub.html?m=freepress">Free Press</a>
-          <a href="/media-hub.html?m=creator">Creators</a>
-          <a href="/media-hub.html?m=radio">Live Radio</a>
-        </div>
-      </div>
+      <a href="/media-hub.html">Media Hub</a>
       <a href="/blog.html">Blog</a>
       <a href="/about.html">About</a>
       <a href="/contact.html">Contact</a>


### PR DESCRIPTION
## Summary
- Simplify Media Hub navigation by removing redundant dropdown submenu
- Strip unused dropdown styles and JavaScript handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c16f330c8320a558b7acc6786646