### PR TITLE
Fix inconsistent video thumbnail sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -586,9 +586,11 @@ section {
   cursor: pointer;
 }
 
-.video-list .video-item img {
+.video-list .video-item img,
+.video-list .video-thumb {
   width: 120px;
   height: 67px;
+  flex: 0 0 120px;
   object-fit: cover;
   border-radius: 4px;
   margin-right: 8px;


### PR DESCRIPTION
## Summary
- prevent flexbox from shrinking `.video-thumb` images so all video list thumbnails stay uniform

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a3bfbe78e08320a10e1661033983f0