### PR TITLE
feat: make station scroller interactive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -305,22 +305,42 @@ section {
   overflow: hidden;
   margin: 20px auto;
   max-width: 960px;
+  position: relative;
+  touch-action: pan-y;
+}
+
+.station-scroller::before,
+.station-scroller::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 40px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.station-scroller::before {
+  left: 0;
+  background: linear-gradient(to right, var(--surface), transparent);
+}
+
+.station-scroller::after {
+  right: 0;
+  background: linear-gradient(to left, var(--surface), transparent);
 }
 
 .station-scroller .scroller-track {
   display: flex;
   width: max-content;
-  animation: station-scroll 80s linear infinite;
-}
-
-.station-scroller:hover .scroller-track {
-  animation-play-state: paused;
+  will-change: transform;
 }
 
 .station-scroller .scroller-track a {
   display: flex;
   align-items: center;
   flex: 0 0 auto;
+  position: relative;
 }
 
 .station-scroller .channel-thumb {
@@ -329,11 +349,45 @@ section {
   border-radius: 8px;
   object-fit: cover;
   margin-right: 16px;
+  transition: transform 0.3s, box-shadow 0.3s;
 }
 
-@keyframes station-scroll {
-  from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
+.station-scroller .scroller-track a:hover .channel-thumb {
+  transform: scale(1.15);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 2;
+}
+
+.station-scroller .scroll-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: var(--surface-variant);
+  color: var(--on-surface-variant);
+  z-index: 2;
+  opacity: 0.6;
+  transition: opacity 0.3s;
+}
+
+.station-scroller .scroll-btn:hover {
+  opacity: 1;
+}
+
+.station-scroller .scroll-btn.prev { left: 8px; }
+.station-scroller .scroll-btn.next { right: 8px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .station-scroller .scroller-track {
+    transition: none;
+  }
 }
 
 /* Featured card layout */

--- a/index.html
+++ b/index.html
@@ -112,7 +112,13 @@
   </section>
 
   <section class="station-scroller">
+    <button class="scroll-btn prev" aria-label="Scroll left">
+      <span class="material-symbols-outlined">chevron_left</span>
+    </button>
     <div class="scroller-track"></div>
+    <button class="scroll-btn next" aria-label="Scroll right">
+      <span class="material-symbols-outlined">chevron_right</span>
+    </button>
   </section>
 
   <!-- Featured cards -->

--- a/js/main.js
+++ b/js/main.js
@@ -229,10 +229,94 @@ document.addEventListener('DOMContentLoaded', function () {
           }
         });
         scroller.innerHTML += scroller.innerHTML;
+        initStationScroller();
       })
       .catch(function (err) {
         console.error('Failed to load station logos', err);
       });
+  }
+
+  function initStationScroller() {
+    var wrap = document.querySelector('.station-scroller');
+    var track = wrap.querySelector('.scroller-track');
+    var prev = wrap.querySelector('.scroll-btn.prev');
+    var next = wrap.querySelector('.scroll-btn.next');
+    var base = 0.3;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      base = 0;
+    }
+    var direction = -1;
+    var speed = base * direction;
+    var offset = 0;
+    var isDragging = false;
+    var lastX = 0;
+    var lastTime = 0;
+    var velocity = 0;
+    var trackWidth = track.scrollWidth / 2;
+
+    function normalize() {
+      if (offset <= -trackWidth) offset += trackWidth;
+      if (offset >= 0) offset -= trackWidth;
+    }
+
+    window.addEventListener('resize', function () {
+      trackWidth = track.scrollWidth / 2;
+      normalize();
+    });
+
+    function frame() {
+      offset += speed;
+      normalize();
+      track.style.transform = 'translateX(' + offset + 'px)';
+      if (!isDragging) {
+        var target = base * direction;
+        speed += (target - speed) * 0.02;
+      }
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+
+    wrap.addEventListener('pointerdown', function (e) {
+      isDragging = true;
+      wrap.setPointerCapture(e.pointerId);
+      lastX = e.clientX;
+      lastTime = e.timeStamp;
+      speed = 0;
+    });
+
+    wrap.addEventListener('pointermove', function (e) {
+      if (!isDragging) return;
+      var dx = e.clientX - lastX;
+      offset += dx;
+      normalize();
+      var dt = e.timeStamp - lastTime;
+      if (dt > 0) velocity = dx / dt * 16;
+      lastX = e.clientX;
+      lastTime = e.timeStamp;
+    });
+
+    function endDrag() {
+      if (!isDragging) return;
+      isDragging = false;
+      speed = velocity;
+      direction = speed === 0 ? direction : (speed > 0 ? 1 : -1);
+    }
+
+    wrap.addEventListener('pointerup', endDrag);
+    wrap.addEventListener('pointerleave', endDrag);
+
+    prev && prev.addEventListener('click', function () {
+      offset += 200;
+      normalize();
+      direction = 1;
+      speed = base * direction;
+    });
+    next && next.addEventListener('click', function () {
+      offset -= 200;
+      normalize();
+      direction = -1;
+      speed = base * direction;
+    });
   }
 
   if ('IntersectionObserver' in window) {


### PR DESCRIPTION
## Summary
- allow dragging the station scroller with momentum that eases back to a steady crawl
- add left and right buttons for quick directional jumps
- normalize offsets so the scroller doesn't snap back after fast drags

## Testing
- `gem install jekyll --no-document` *(interrupted while building native extensions)*
- `apt-get install -y jekyll`
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a3be3191e88320944ab41d85018e46