### PR TITLE
Add creator, all, and favorites feature cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,30 @@
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
     </div>
+    <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
+      <span class="material-symbols-outlined">person</span>
+      <h3>Trending Creators</h3>
+      <p>Watch the latest from Pakistani creators.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="all" data-c="geo">
+      <span class="material-symbols-outlined">apps</span>
+      <h3>All Streams</h3>
+      <p>Browse every channel in one place.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="favorites" data-c="wajahatsaeedkhan">
+      <span class="material-symbols-outlined">favorite</span>
+      <h3>Your Favorites</h3>
+      <p>Quick access to your saved channels.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
   </section>
 
   <!-- Main content sections -->


### PR DESCRIPTION
## Summary
- Add second row of feature cards for creators, all streams, and favorites on the home page
- Each card embeds the media hub with the appropriate mode

## Testing
- `jekyll build`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c5526f6883208d67344453228e04