### PR TITLE
Use media hub top bar sitewide

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -1,0 +1,16 @@
+<header class="top-bar">
+  <input type="checkbox" id="nav-toggle">
+  <label for="nav-toggle" class="nav-toggle-label">☰</label>
+  <h1 class="logo-title">PakStream</h1>
+  <nav class="nav-links">
+    <a href="/">Home</a>
+    <a href="/media-hub.html">Media Hub</a>
+    <a href="/blog.html">Blog</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+    <a href="/privacy.html">Privacy</a>
+    <a href="/terms.html">Terms</a>
+  </nav>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+  <label for="nav-toggle" class="nav-overlay"></label>
+</header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,25 +60,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <main>
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -60,25 +60,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <main class="post-container">
     <article class="post">

--- a/about.html
+++ b/about.html
@@ -65,25 +65,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- About section describing the mission of PakStream -->
   <section>

--- a/contact.html
+++ b/contact.html
@@ -66,25 +66,7 @@
 <body>
 {% include google-tag-manager-body.html %}
   <!-- Header with navigation -->
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- Contact section with instructions to reach us -->
 <section>

--- a/creators.html
+++ b/creators.html
@@ -46,25 +46,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/freepress.html">Free Press</a>
-      <a href="/livetv.html">Live TV</a>
-      <a href="/creators.html">Creators</a>
-      <a href="/radio.html">Radio</a>
-      <a href="/blog.html">Blog</a>
-      <a href="/about.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy</a>
-      <a href="/terms.html">Terms</a>
-    </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- Creators section with channel list and video player -->
   <section class="youtube-section">

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -61,25 +61,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/freepress.html">Free Press</a>
-      <a href="/livetv.html">Live TV</a>
-      <a href="/creators.html">Creators</a>
-      <a href="/radio.html">Radio</a>
-      <a href="/blog.html">Blog</a>
-      <a href="/about.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy</a>
-      <a href="/terms.html">Terms</a>
-    </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <section class="youtube-section">
     <div class="channel-list"></div>

--- a/freepress.html
+++ b/freepress.html
@@ -61,25 +61,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/freepress.html">Free Press</a>
-      <a href="/livetv.html">Live TV</a>
-      <a href="/creators.html">Creators</a>
-      <a href="/radio.html">Radio</a>
-      <a href="/blog.html">Blog</a>
-      <a href="/about.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy</a>
-      <a href="/terms.html">Terms</a>
-    </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <section class="youtube-section">
     <div class="channel-list"></div>

--- a/index.html
+++ b/index.html
@@ -69,25 +69,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- Hero section with image and tagline -->
   <section class="hero-banner">

--- a/livetv.html
+++ b/livetv.html
@@ -62,25 +62,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
 
   <!-- TV Livestream section -->

--- a/media-hub.html
+++ b/media-hub.html
@@ -24,22 +24,7 @@
 </head>
 <body>
   <!-- Top bar (same as site) -->
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/media-hub.html">Media Hub</a>
-      <a href="/blog.html">Blog</a>
-      <a href="/about.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy</a>
-      <a href="/terms.html">Terms</a>
-    </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <section class="youtube-section media-hub-section">
     <div class="mode-tabs">

--- a/nav.html
+++ b/nav.html
@@ -15,24 +15,6 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 </body>
 </html>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -24,25 +24,7 @@
 </head>
 <body>
   {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/freepress.html">Free Press</a>
-      <a href="/livetv.html">Live TV</a>
-      <a href="/creators.html">Creators</a>
-      <a href="/radio.html">Radio</a>
-      <a href="/blog.html">Blog</a>
-      <a href="/about.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy</a>
-      <a href="/terms.html">Terms</a>
-    </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <main class="container">
     <h2>Onboard YouTube Channel</h2>

--- a/privacy.html
+++ b/privacy.html
@@ -66,25 +66,7 @@
 <body>
 {% include google-tag-manager-body.html %}
   <!-- Header with navigation -->
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- Privacy policy content -->
 <section>

--- a/radio.html
+++ b/radio.html
@@ -62,25 +62,7 @@
   
 </head>
 <body class="radio-list">
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- Radio station listing -->
   <section class="youtube-section">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,22 +4,10 @@
     <loc>https://pakstream.com/</loc>
   </url>
   <url>
+    <loc>https://pakstream.com/media-hub.html</loc>
+  </url>
+  <url>
     <loc>https://pakstream.com/blog.html</loc>
-  </url>
-  <url>
-    <loc>https://pakstream.com/ads.txt</loc>
-  </url>
-  <url>
-    <loc>https://pakstream.com/freepress.html</loc>
-  </url>
-  <url>
-    <loc>https://pakstream.com/creators.html</loc>
-  </url>
-  <url>
-    <loc>https://pakstream.com/radio.html</loc>
-  </url>
-  <url>
-    <loc>https://pakstream.com/livetv.html</loc>
   </url>
   <url>
     <loc>https://pakstream.com/about.html</loc>
@@ -34,7 +22,7 @@
     <loc>https://pakstream.com/terms.html</loc>
   </url>
   <url>
-    <loc>https://pakstream.com/nadraimage.html</loc>
+    <loc>https://pakstream.com/ads.txt</loc>
   </url>
   <url>
     <loc>https://pakstream.com/404.html</loc>

--- a/terms.html
+++ b/terms.html
@@ -66,25 +66,7 @@
 <body>
 {% include google-tag-manager-body.html %}
   <!-- Header with navigation -->
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-        <a href="/">Home</a>
-        <a href="/freepress.html">Free Press</a>
-        <a href="/livetv.html">Live TV</a>
-        <a href="/creators.html">Creators</a>
-        <a href="/radio.html">Radio</a>
-        <a href="/blog.html">Blog</a>
-        <a href="/about.html">About</a>
-        <a href="/contact.html">Contact</a>
-        <a href="/privacy.html">Privacy</a>
-        <a href="/terms.html">Terms</a>
-      </nav>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <!-- Terms and conditions content -->
 <section>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -24,25 +24,7 @@
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  <header class="top-bar">
-    <input type="checkbox" id="nav-toggle">
-    <label for="nav-toggle" class="nav-toggle-label">☰</label>
-    <h1 class="logo-title">PakStream</h1>
-    <nav class="nav-links">
-      <a href="/">Home</a>
-      <a href="/freepress.html">Free Press</a>
-      <a href="/livetv.html">Live TV</a>
-      <a href="/creators.html">Creators</a>
-      <a href="/radio.html">Radio</a>
-      <a href="/blog.html">Blog</a>
-      <a href="/about.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy</a>
-      <a href="/terms.html">Terms</a>
-    </nav>
-    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-    <label for="nav-toggle" class="nav-overlay"></label>
-  </header>
+  {% include top-bar.html %}
 
   <main class="container">
     <h2>YouTube Playground</h2>


### PR DESCRIPTION
## Summary
- consolidate top bar into `_includes/top-bar.html`
- include shared top bar across pages and layouts
- refresh sitemap with media hub entry

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a3cdc9bb688320a7b375d68b0f9436