### PR TITLE
Use YouTube nocookie embeds to avoid third-party cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 PakStream.com is a personal hobby project built as a hands-on experiment in applying AI to software development.
 It serves as a sandbox for practicing and refining AI-assisted coding techniques, with lessons learned to be carried into future projects.
+
+## Privacy
+
+Embedded YouTube videos use the privacy-enhanced `youtube-nocookie.com` domain to reduce third-party cookies.

--- a/all_streams.json
+++ b/all_streams.json
@@ -1341,7 +1341,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/tG2nE5C5TUk"
+          "url": "https://www.youtube-nocookie.com/embed/tG2nE5C5TUk"
         },
         {
           "kind": "channel",
@@ -1368,7 +1368,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/LnD0uWQ2MR0"
+          "url": "https://www.youtube-nocookie.com/embed/LnD0uWQ2MR0"
         },
         {
           "kind": "channel",
@@ -1395,7 +1395,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCCrWQm7bYb28S2URcSsTk9g"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCCrWQm7bYb28S2URcSsTk9g"
         },
         {
           "kind": "channel",
@@ -1422,7 +1422,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCMmpLL2ucRHAXbNHiCPyIyg"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCMmpLL2ucRHAXbNHiCPyIyg"
         },
         {
           "kind": "channel",
@@ -1449,7 +1449,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/YirtbHvyaxY"
+          "url": "https://www.youtube-nocookie.com/embed/YirtbHvyaxY"
         },
         {
           "kind": "channel",
@@ -1476,7 +1476,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UC_XJhq0u8AkMaCwLDH_PjxA"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UC_XJhq0u8AkMaCwLDH_PjxA"
         },
         {
           "kind": "channel",
@@ -1503,7 +1503,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCaxR-D8FjZ-2otbU0_Y2grg"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCaxR-D8FjZ-2otbU0_Y2grg"
         },
         {
           "kind": "channel",
@@ -1530,7 +1530,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/GlHSFtTFfJE"
+          "url": "https://www.youtube-nocookie.com/embed/GlHSFtTFfJE"
         },
         {
           "kind": "channel",
@@ -1557,7 +1557,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/eNyj_nSxXBE"
+          "url": "https://www.youtube-nocookie.com/embed/eNyj_nSxXBE"
         },
         {
           "kind": "channel",
@@ -1584,7 +1584,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/O3DPVlynUM0"
+          "url": "https://www.youtube-nocookie.com/embed/O3DPVlynUM0"
         },
         {
           "kind": "channel",
@@ -1611,7 +1611,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/2bk3gVrO8aQ"
+          "url": "https://www.youtube-nocookie.com/embed/2bk3gVrO8aQ"
         },
         {
           "kind": "channel",
@@ -1638,7 +1638,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/-6o5mV_5wGw"
+          "url": "https://www.youtube-nocookie.com/embed/-6o5mV_5wGw"
         },
         {
           "kind": "channel",
@@ -1665,7 +1665,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCCEMt2W7Y8qXkLSTkr082mw"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCCEMt2W7Y8qXkLSTkr082mw"
         },
         {
           "kind": "channel",
@@ -1692,7 +1692,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCRGzK5yQvhJD9-ZYGP436JQ"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCRGzK5yQvhJD9-ZYGP436JQ"
         },
         {
           "kind": "channel",
@@ -1719,7 +1719,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UC0CbUVRC1d1RvunYbp3w2qQ"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UC0CbUVRC1d1RvunYbp3w2qQ"
         },
         {
           "kind": "channel",
@@ -1746,7 +1746,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/iGOhgkuN-Mc"
+          "url": "https://www.youtube-nocookie.com/embed/iGOhgkuN-Mc"
         },
         {
           "kind": "channel",
@@ -1773,7 +1773,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCElJZvY_RVra6qjD8WSQYog"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCElJZvY_RVra6qjD8WSQYog"
         },
         {
           "kind": "channel",
@@ -1800,7 +1800,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCHlCp7kL8jC9HJrSVJuNJzA"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCHlCp7kL8jC9HJrSVJuNJzA"
         },
         {
           "kind": "channel",
@@ -1827,7 +1827,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/d9-ABo3E2sU"
+          "url": "https://www.youtube-nocookie.com/embed/d9-ABo3E2sU"
         },
         {
           "kind": "channel",
@@ -1854,7 +1854,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCkFGjasXNw-1MlcIW8LSTVQ"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCkFGjasXNw-1MlcIW8LSTVQ"
         },
         {
           "kind": "channel",
@@ -1881,7 +1881,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UCyNUtOyKbLZaOgy3rhe_3lQ"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UCyNUtOyKbLZaOgy3rhe_3lQ"
         },
         {
           "kind": "channel",
@@ -1908,7 +1908,7 @@
         {
           "kind": "embed",
           "provider": "youtube",
-          "url": "https://www.youtube.com/embed/live_stream?channel=UC8Y2g1wCIU3zUB6WGnEwtYg"
+          "url": "https://www.youtube-nocookie.com/embed/live_stream?channel=UC8Y2g1wCIU3zUB6WGnEwtYg"
         },
         {
           "kind": "channel",

--- a/creators.html
+++ b/creators.html
@@ -308,7 +308,7 @@
 
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
   }

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -358,7 +358,7 @@
 
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
   }

--- a/freepress.html
+++ b/freepress.html
@@ -358,7 +358,7 @@
 
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
   }

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -582,7 +582,7 @@ async function renderLatestVideosRSS(channelId) {
       row.addEventListener("click", () => {
         if (playerIF) {
           playerIF.style.display = "";
-          playerIF.src = `https://www.youtube.com/embed/${vid}?autoplay=1&rel=0&enablejsapi=1${muteParam}`;
+          playerIF.src = `https://www.youtube-nocookie.com/embed/${vid}?autoplay=1&rel=0&enablejsapi=1${muteParam}`;
           if (window.resizeLivePlayers) window.resizeLivePlayers();
         }
         if (audioWrap) audioWrap.style.display = "none";
@@ -644,8 +644,8 @@ async function renderLatestVideosRSS(channelId) {
     } else if (item.ids?.youtube_channel_id) {
       const upl = uploadsId(item.ids.youtube_channel_id);
       src = upl
-        ? `https://www.youtube.com/embed/videoseries?list=${upl}&autoplay=1&rel=0&enablejsapi=1${muteParam}`
-        : `https://www.youtube.com/embed/live_stream?channel=${item.ids.youtube_channel_id}&autoplay=1&rel=0&enablejsapi=1${muteParam}`;
+        ? `https://www.youtube-nocookie.com/embed/videoseries?list=${upl}&autoplay=1&rel=0&enablejsapi=1${muteParam}`
+        : `https://www.youtube-nocookie.com/embed/live_stream?channel=${item.ids.youtube_channel_id}&autoplay=1&rel=0&enablejsapi=1${muteParam}`;
     }
     if (playerIF) playerIF.src = src || "about:blank";
     if (playerIF && window.resizeLivePlayers) window.resizeLivePlayers();

--- a/livetv.html
+++ b/livetv.html
@@ -394,7 +394,7 @@
               player.loadVideoById(entry.videoId);
             } else {
               const iframe = document.getElementById(playerId);
-              iframe.src = `https://www.youtube.com/embed/${entry.videoId}?${YT_PARAMS}`;
+              iframe.src = `https://www.youtube-nocookie.com/embed/${entry.videoId}?${YT_PARAMS}`;
             }
             setActiveStream(item);
           });
@@ -406,7 +406,7 @@
               player.loadVideoById(entry.videoId);
             } else {
               const iframe = document.getElementById(playerId);
-              iframe.src = `https://www.youtube.com/embed/${entry.videoId}?${YT_PARAMS}`;
+              iframe.src = `https://www.youtube-nocookie.com/embed/${entry.videoId}?${YT_PARAMS}`;
             }
             setActiveStream(item);
           }

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -164,7 +164,7 @@
           about: about,
           media: { thumbnail_url: thumb },
           endpoints: [
-            { kind: 'embed', provider: 'youtube', url: `https://www.youtube.com/embed/live_stream?channel=${channelId}` },
+            { kind: 'embed', provider: 'youtube', url: `https://www.youtube-nocookie.com/embed/live_stream?channel=${channelId}` },
             { kind: 'channel', provider: 'youtube', url: channelUrl }
           ],
           ids: { youtube_channel_id: channelId },


### PR DESCRIPTION
## Summary
- switch media hub and page embeds to youtube-nocookie domain
- update stream metadata to use nocookie URLs
- adjust onboarding helper for privacy-enhanced embeds
- document nocookie approach in README

## Testing
- `npx --yes htmlhint freepress.html freepress-old.html creators.html livetv.html onboard-channel.html`
- `npx --yes eslint js/media-hub.js` *(fails: ESLint couldn't find an eslint.config.* file)*
- `curl -sI https://www.youtube-nocookie.com/embed/tG2nE5C5TUk`
- `curl -sI https://www.youtube-nocookie.com/embed/live_stream?channel=UCCrWQm7bYb28S2URcSsTk9g`


------
https://chatgpt.com/codex/tasks/task_e_68a4539db92883208114d3489a79f7a3