### PR TITLE
refactor: use theme variables in media hub

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -88,7 +88,7 @@
   border-color:var(--primary);
   color:var(--on-primary-container);
 }
-.live-player .audio-wrap { background:#fff; border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); padding:12px; }
+.live-player .audio-wrap { background:var(--surface); border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); padding:12px; }
 
 /* layout that mirrors your existing pages */
 .page-wrap { padding-top: 12px; }
@@ -127,17 +127,17 @@
   height: calc(100vh - 120px);
   overflow-y: auto;
 }
-.channel-card { display:flex; align-items:center; gap:10px; padding:10px 12px; background:#fff; border-radius:14px; margin-bottom:10px; box-shadow:var(--card-shadow,0 1px 3px rgba(0,0,0,.06)); }
-.channel-card.active { outline:2px solid #0f7d73; }
+.channel-card { display:flex; align-items:center; gap:10px; padding:10px 12px; background:var(--surface); border-radius:14px; margin-bottom:10px; box-shadow:var(--card-shadow,0 1px 3px rgba(0,0,0,.06)); }
+.channel-card.active { outline:2px solid var(--primary); }
 .channel-thumb { width:40px; height:40px; border-radius:8px; object-fit:cover; }
 .youtube-section .channel-card .play-btn,
 .media-hub-section .channel-card .play-btn { display:none; }
 
 
 .player-container iframe, .player-container .audio-wrap { width:100%; border:0; border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
-.player-container .audio-wrap { padding:14px; background:#fff; }
+.player-container .audio-wrap { padding:14px; background:var(--surface); }
 
-.details-list { background:#fff; border-radius:14px; padding:12px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
+.details-list { background:var(--surface); border-radius:14px; padding:12px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
 .detail-item { margin-bottom:6px; }
 
 /* responsive */


### PR DESCRIPTION
## Summary
- replace hard-coded colors in media-hub.css with theme variables
- ensure channel card active outline uses primary color variable
- keep media hub styling consistent across light and dark themes

## Testing
- `node <<'NODE' ...` (puppeteer render check)


------
https://chatgpt.com/codex/tasks/task_e_68a4b35b95d0832094bfde50819b5517