### PR TITLE
refactor: centralize shadow variables

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -88,7 +88,7 @@
   border-color:var(--primary);
   color:var(--on-primary-container);
 }
-.live-player .audio-wrap { background:var(--surface); border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); padding:12px; }
+.live-player .audio-wrap { background:var(--surface); border-radius:14px; box-shadow:var(--shadow-xs); padding:12px; }
 
 /* layout that mirrors your existing pages */
 .page-wrap { padding-top: 12px; }
@@ -127,17 +127,17 @@
   height: calc(100vh - 120px);
   overflow-y: auto;
 }
-.channel-card { display:flex; align-items:center; gap:10px; padding:10px 12px; background:var(--surface); border-radius:14px; margin-bottom:10px; box-shadow:var(--card-shadow,0 1px 3px rgba(0,0,0,.06)); }
+.channel-card { display:flex; align-items:center; gap:10px; padding:10px 12px; background:var(--surface); border-radius:14px; margin-bottom:10px; box-shadow:var(--card-shadow,var(--shadow-xs)); }
 .channel-card.active { outline:2px solid var(--primary); }
 .channel-thumb { width:40px; height:40px; border-radius:8px; object-fit:cover; }
 .youtube-section .channel-card .play-btn,
 .media-hub-section .channel-card .play-btn { display:none; }
 
 
-.player-container iframe, .player-container .audio-wrap { width:100%; border:0; border-radius:14px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
+.player-container iframe, .player-container .audio-wrap { width:100%; border:0; border-radius:14px; box-shadow:var(--shadow-xs); }
 .player-container .audio-wrap { padding:14px; background:var(--surface); }
 
-.details-list { background:var(--surface); border-radius:14px; padding:12px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
+.details-list { background:var(--surface); border-radius:14px; padding:12px; box-shadow:var(--shadow-xs); }
 .detail-item { margin-bottom:6px; }
 
 /* responsive */

--- a/css/style.css
+++ b/css/style.css
@@ -55,7 +55,7 @@ body.no-scroll {
   align-items: center;
   padding: 0 16px;
   height: 56px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: var(--shadow-md);
   border-bottom: 2px solid var(--primary-container);
   position: relative;
   z-index: 1002;
@@ -152,7 +152,7 @@ footer nav a:hover {
   color: var(--on-surface);
   border: 1px solid var(--primary-container);
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: var(--shadow-md);
   width: 100%;
   max-height: 300px;
   overflow-y: auto;
@@ -197,7 +197,7 @@ section {
   margin: 20px auto;
   padding: 16px;
   border-radius: 4px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  box-shadow: var(--shadow-sm);
   max-width: 960px;
 }
 
@@ -207,7 +207,7 @@ section {
   background: var(--primary);
   color: var(--on-primary);
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: var(--shadow-lg);
   margin: 20px auto;
 }
 
@@ -225,7 +225,7 @@ section {
   max-width: 960px;
   border-radius: 4px;
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  box-shadow: var(--shadow-sm);
 }
 
 .hero-banner img {
@@ -239,7 +239,7 @@ section {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay-strong);
   color: var(--on-primary);
   padding: 24px;
   border-radius: 8px;
@@ -305,7 +305,7 @@ section {
 
 .station-scroller .scroller-track a:hover .channel-thumb {
   transform: scale(1.15);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-hover);
   z-index: 2;
 }
 
@@ -355,7 +355,7 @@ section {
   background: var(--surface);
   border-radius: 12px;
   padding: 20px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: var(--shadow-lg);
   text-align: center;
   flex: 1 1 250px;
   cursor: pointer;
@@ -454,7 +454,7 @@ section {
   padding: 8px 16px;
   min-height: 56px;
   border-radius: 20px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  box-shadow: var(--shadow-sm);
   cursor: pointer;
   transition: box-shadow 0.2s, background 0.2s;
   user-select: none;
@@ -502,7 +502,7 @@ section {
 
 .youtube-section .channel-card:hover,
 .media-hub-section .channel-card:hover {
-  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+  box-shadow: var(--shadow-xl);
 }
 
 .youtube-section .channel-card.active,
@@ -604,7 +604,7 @@ section {
     background: var(--surface);
     transform: translateX(-100%);
     transition: transform 0.3s ease;
-    box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+    box-shadow: var(--shadow-side-right);
     overflow-y: auto;
     padding: 16px 8px;
     z-index: 1004;
@@ -627,7 +627,7 @@ section {
     background: var(--surface);
     transform: translateX(100%);
     transition: transform 0.3s ease;
-    box-shadow: -2px 0 5px rgba(0,0,0,0.3);
+    box-shadow: var(--shadow-side-left);
     overflow-y: auto;
     padding: 16px 8px;
     z-index: 1004;
@@ -805,7 +805,7 @@ button:hover,
 .channel-toggle:hover {
   transform: scale(1.03);
   transition: transform 0.2s ease, background-color 0.2s ease;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-xxl);
 }
 
 .play-pause-btn {
@@ -826,7 +826,7 @@ button:hover,
   background: linear-gradient(180deg, var(--surface), var(--surface-variant));
   padding: 16px;
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: var(--shadow-lg);
   margin-bottom: 16px;
   display: flex;
   flex-direction: column;
@@ -996,7 +996,7 @@ table tbody tr.favorite {
   background: var(--surface);
   padding: 16px;
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: var(--shadow-lg);
 }
 
 .post h1 {
@@ -1067,7 +1067,7 @@ table tbody tr.favorite {
     transform: translateX(-100%);
     transition: transform 0.3s ease-in-out;
     will-change: transform;
-    box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+    box-shadow: var(--shadow-side-right);
     z-index: 1004;
     flex-direction: column;
     padding: 16px;
@@ -1096,7 +1096,7 @@ table tbody tr.favorite {
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0,0,0,0.4);
+    background: var(--overlay-bg);
     display: none;
     z-index: 1003;
   }

--- a/css/theme.css
+++ b/css/theme.css
@@ -34,6 +34,17 @@
   --hover-link: #1565C0;
   --scrollbar-track: var(--surface-variant);
   --scrollbar-thumb: var(--outline);
+  --shadow-xs: 0 1px 3px rgba(0,0,0,0.06);
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.2);
+  --shadow-md: 0 2px 4px rgba(0,0,0,0.2);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.1);
+  --shadow-xl: 0 4px 6px rgba(0,0,0,0.3);
+  --shadow-side-right: 2px 0 5px rgba(0,0,0,0.3);
+  --shadow-side-left: -2px 0 5px rgba(0,0,0,0.3);
+  --overlay-bg: rgba(0,0,0,0.4);
+  --overlay-strong: rgba(0,0,0,0.6);
+  --shadow-hover: 0 4px 12px rgba(0,0,0,0.3);
+  --shadow-xxl: 0 8px 20px rgba(0,0,0,0.15);
 }
 
 /* -------- Dark Theme -------- */
@@ -70,4 +81,15 @@
   --hover-link: #64B5F6;
   --scrollbar-track: var(--surface);
   --scrollbar-thumb: var(--outline);
+  --shadow-xs: 0 1px 3px rgba(0,0,0,0.5);
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.6);
+  --shadow-md: 0 2px 4px rgba(0,0,0,0.6);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.5);
+  --shadow-xl: 0 4px 6px rgba(0,0,0,0.7);
+  --shadow-side-right: 2px 0 5px rgba(0,0,0,0.7);
+  --shadow-side-left: -2px 0 5px rgba(0,0,0,0.7);
+  --overlay-bg: rgba(0,0,0,0.6);
+  --overlay-strong: rgba(0,0,0,0.8);
+  --shadow-hover: 0 4px 12px rgba(0,0,0,0.8);
+  --shadow-xxl: 0 8px 20px rgba(0,0,0,0.4);
 }


### PR DESCRIPTION
## Summary
- add reusable shadow and overlay CSS variables for light & dark themes
- replace hard-coded rgba() shadows in style and media-hub styles with the new variables

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b875cb90832082e7a08170dee18b