### PR TITLE
Centralize active video highlight color in theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -565,7 +565,7 @@ section {
 }
 
 .video-list .video-item.active {
-  background: rgba(0,100,0,0.1);
+  background: var(--active-row);
 }
 
 .video-list .video-item .video-details {

--- a/css/theme.css
+++ b/css/theme.css
@@ -30,6 +30,7 @@
   --accent-success: #43A047;
   --accent-info: #4FC3F7;
   --favorite-row: #00796B;
+  --active-row: rgba(0,100,0,0.1);
   --hover-primary: #00695C;
   --hover-link: #1565C0;
   --scrollbar-track: var(--surface-variant);
@@ -77,6 +78,7 @@
   --accent-success: #66BB6A;
   --accent-info: #81D4FA;
   --favorite-row: #00796B;
+  --active-row: rgba(0,100,0,0.3);
   --hover-primary: #00695C;
   --hover-link: #64B5F6;
   --scrollbar-track: var(--surface);


### PR DESCRIPTION
## Summary
- add `--active-row` variable in light and dark themes
- use `var(--active-row)` for active video list items

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a4bbfde6948320b6cb8f83b9267870