### PR TITLE
Add theme tester with dynamic CSS switching

### DIFF
--- a/theme-tester.html
+++ b/theme-tester.html
@@ -1,27 +1,334 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
+{% include google-tag-manager-head.html %}
+  <!-- Start cookieyes banner -->
+  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
+  <!-- End cookieyes banner -->
+  {% include google-analytics.html %}
+  <!-- Standard Meta -->
+  <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press</title>
   <meta charset="UTF-8">
-  <title>Theme Tester</title>
-  <link id="themeStylesheet" rel="stylesheet" href="styles/theme-candy-pop.css">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
+  <meta name="description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.">
+  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
+  <meta name="author" content="PakStream by Chatdroid AB">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pakstream.com/" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <link rel="preload" as="image"
+    href="/images/pakistan-abstract-380.webp"
+    imagesrcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
+    imagesizes="(max-width: 420px) 80vw, 380px"
+    fetchpriority="high">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pakstream.com/">
+  <meta property="og:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
+  <meta property="og:description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.">
+  <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta property="og:site_name" content="PakStream">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://pakstream.com/">
+  <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
+  <meta name="twitter:description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.">
+  <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
+  <meta name="twitter:site" content="@PakStream">
+  <meta name="twitter:creator" content="@PakStream">
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "name": "PakStream",
+    "url": "https://pakstream.com/",
+    "logo": "https://pakstream.com/assets/logo.png",
+    "sameAs": [
+      "https://facebook.com/PakStream",
+      "https://twitter.com/PakStream"
+    ]
+  }
+  </script>
+
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link id="themeStylesheet" rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  
 </head>
 <body>
-  <h1>Theme Tester</h1>
-  <label for="themeSelector">Choose theme:</label>
-  <select id="themeSelector">
-    <option value="theme-candy-pop.css">Candy Pop</option>
-    <option value="theme-cyber-neon.css">Cyber Neon</option>
-    <option value="theme-nature-calm.css">Nature Calm</option>
-    <option value="theme-pastel-delight.css">Pastel Delight</option>
-    <option value="theme-gradient-glow.css">Gradient Glow</option>
-  </select>
-  <p>This page lets you test different themes.</p>
+{% include google-tag-manager-body.html %}
+  {% include top-bar.html %}
+
+  <div class="theme-picker">
+    <label for="themeSelector">Choose theme:</label>
+    <select id="themeSelector">
+      <option value="/css/theme.css" selected>Default</option>
+      <option value="/css/theme-candy-pop.css">Candy Pop</option>
+      <option value="/css/theme-cyber-neon.css">Cyber Neon</option>
+      <option value="/css/theme-nature-calm.css">Nature Calm</option>
+      <option value="/css/theme-pastel-delight.css">Pastel Delight</option>
+      <option value="/css/theme-gradient-glow.css">Gradient Glow</option>
+    </select>
+  </div>
+
+  <!-- Hero section with image and tagline -->
+  <section class="hero-banner">
+    <picture>
+      <source
+        type="image/webp"
+        srcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
+        sizes="(max-width: 420px) 80vw, 380px" />
+      <img
+        src="/images/pakistan-abstract-380.webp"
+        width="380"
+        height="380"
+        alt="Abstract Pakistan crescent and star"
+        decoding="async"
+        fetchpriority="high"
+        style="aspect-ratio: 1 / 1; object-fit: cover;" />
+    </picture>
+    <div class="hero-text">
+      <h2>Your Gateway to Pakistani Media</h2>
+      <p>Stay Connected to Pakistan — News, Radio &amp; More</p>
+    </div>
+  </section>
+
+  <section class="station-scroller">
+    <button class="scroll-btn prev" aria-label="Scroll left">
+      <span class="material-symbols-outlined">chevron_left</span>
+    </button>
+    <div class="scroller-track"></div>
+    <button class="scroll-btn next" aria-label="Scroll right">
+      <span class="material-symbols-outlined">chevron_right</span>
+    </button>
+  </section>
+
+  <!-- Featured cards -->
+  <section class="feature-cards">
+    <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">
+      <span class="material-symbols-outlined">article</span>
+      <h3>Free Press</h3>
+      <p>Stay updated with the latest new from Independent Voices.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="radio" data-c="audio35">
+      <span class="material-symbols-outlined">radio</span>
+      <h3>Popular Radio Stations</h3>
+      <p>Listen to trending Pakistani radio.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="tv" data-c="24news">
+      <span class="material-symbols-outlined">live_tv</span>
+      <h3>Live TV Channels</h3>
+      <p>Watch the most viewed live TV streams.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
+      <span class="material-symbols-outlined">person</span>
+      <h3>Trending Creators</h3>
+      <p>Watch the latest from Pakistani creators.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="all" data-c="geo">
+      <span class="material-symbols-outlined">apps</span>
+      <h3>All Streams</h3>
+      <p>Browse every channel in one place.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+    <div class="feature-card" data-m="favorites" data-c="wajahatsaeedkhan">
+      <span class="material-symbols-outlined">favorite</span>
+      <h3>Your Favorites</h3>
+      <p>Quick access to your saved channels.</p>
+      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </section>
+    </div>
+  </section>
+
+  <!-- Main content sections -->
+  <section class="intro">
+    <h2>PakStream – Stay Connected to Pakistan, Wherever You Are</h2>
+    <p>Missing home? Whether you're sipping chai in Sweden, commuting in London, or relaxing in Toronto — PakStream is here to bring Pakistan closer to you.</p>
+    <p>Our platform makes it simple to watch Pakistani news online, listen to Urdu radio stations, and stay up-to-date with political talk shows and entertainment – all from one place. No VPNs. No hassle.</p>
+  </section>
+
+  <section class="radio-section">
+    <h3>Live Pakistani Radio – Music, Talk, and More</h3>
+    <p>Stream your favorite Urdu and regional radio stations 24/7. From Mera FM, City FM89, and Mast FM to regional gems from Karachi, Lahore, and beyond – we’ve got them all lined up for you.</p>
+    <ul>
+      <li>No buffering</li>
+      <li>Compatible with mobile &amp; desktop</li>
+      <li>Great for background listening at work or while driving abroad</li>
+    </ul>
+    <p><a href="/radio.html">Listen to Pakistani radio stations</a></p>
+  </section>
+
+  <section class="tv-section">
+    <h3>Watch Pakistani TV Channels – Live &amp; Free</h3>
+    <p>Catch up on Pakistani TV channels online, no matter the time zone. Whether you’re into news, drama, or morning shows, PakStream makes it easy to stream Urdu TV abroad without jumping through hoops.</p>
+    <ul>
+      <li>Live news from major broadcasters</li>
+      <li>Drama serials and morning shows</li>
+      <li>Works on any browser – no app required</li>
+    </ul>
+    <p><a href="/livetv.html">Watch live Pakistani channels</a></p>
+  </section>
+
+  <section class="youtube-home">
+    <h3>Independent YouTube Voices from Pakistan</h3>
+    <p>We bring you hand-picked YouTube channels from across Pakistan — from journalists and commentators to vloggers and analysts.</p>
+    <p>Whether you want political insight, comedy, or cultural commentary — our YouTubers keep you informed and entertained.</p>
+    <p><a href="/freepress.html">Explore Pakistani YouTubers</a></p>
+  </section>
+
+  <section class="blog-section">
+    <h3>Read Blog Posts for Pakistani Expats</h3>
+    <p>We also share useful blog posts on topics that matter to you as a Pakistani living abroad — from cultural stories and current events to how to celebrate Eid in Sweden or where to find Urdu books in London.</p>
+    <ul>
+      <li>Stories from the diaspora</li>
+      <li>Guides, tips, and nostalgia</li>
+      <li>Fresh content posted regularly</li>
+    </ul>
+    <p><a href="/blog.html">Read the blog</a></p>
+  </section>
+
+  <section class="why-section">
+    <h3>Why PakStream?</h3>
+    <p>PakStream isn’t just a media website. It’s a passion project made by Pakistanis who live abroad and know how it feels to miss home. We built this to keep the voices, sounds, and stories of Pakistan within reach — anytime, anywhere.</p>
+  </section>
+
+  <!-- Placeholder for advertising or additional content -->
+  <div class="ad-container">
+    <!-- Google AdSense: Insert your ad code here -->
+  </div>
+
+  <!-- Footer with copyright notice -->
+  <footer>
+    <nav class="footer-nav">
+      <a href="/about.html">About Us</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+    </nav>
+    <p>© 2025 PakStream. All rights reserved.</p>
+  </footer>
   <script>
-    const selector = document.getElementById('themeSelector');
-    const link = document.getElementById('themeStylesheet');
-    selector.addEventListener('change', function() {
-      link.href = 'styles/' + this.value;
+    document.addEventListener('DOMContentLoaded', function () {
+      const cards = document.querySelectorAll('.feature-card');
+      cards.forEach(card => {
+        const mode = card.dataset.m;
+        const channel = card.dataset.c;
+        card.addEventListener('click', () => {
+          if (!mode) return;
+          let url = `/media-hub.html?m=${encodeURIComponent(mode)}`;
+          if (channel) {
+            url += `&c=${encodeURIComponent(channel)}`;
+          }
+          window.location.href = url;
+        });
+      });
+      const sendMuteMessage = (iframe, muted) => {
+        if (iframe.contentWindow) {
+          iframe.contentWindow.postMessage({ type: 'media-hub-set-muted', muted }, '*');
+        }
+      };
+      const sendPlayMessage = (iframe, playing) => {
+        if (iframe.contentWindow) {
+          iframe.contentWindow.postMessage({ type: 'media-hub-set-playing', playing }, '*');
+        }
+      };
+
+      const canHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches && navigator.maxTouchPoints === 0;
+      const isLaptop = canHover && window.matchMedia('(min-width: 1024px)').matches;
+
+      if (canHover) {
+        let freepressCard = null;
+        let fpIframe = null;
+        if (isLaptop) {
+          freepressCard = document.querySelector('.feature-card[data-m="freepress"]');
+          if (freepressCard) {
+            fpIframe = freepressCard.querySelector('iframe');
+            if (fpIframe) {
+              const unmute = () => sendMuteMessage(fpIframe, false);
+              fpIframe.addEventListener('load', unmute);
+              unmute();
+            }
+          }
+        }
+
+        const cardArray = Array.from(cards);
+        cardArray.forEach(card => {
+          const iframe = card.querySelector('iframe');
+          if (!iframe) return;
+          const isFreepress = isLaptop && card === freepressCard;
+          sendPlayMessage(iframe, isFreepress);
+          card.addEventListener('mouseenter', () => {
+            cardArray.forEach(c => {
+              const ifr = c.querySelector('iframe');
+              if (!ifr) return;
+              const isCurrent = c === card;
+              sendMuteMessage(ifr, !isCurrent);
+              sendPlayMessage(ifr, isCurrent);
+            });
+          });
+          card.addEventListener('mouseleave', () => {
+            sendMuteMessage(iframe, true);
+            sendPlayMessage(iframe, false);
+          });
+        });
+      } else if ('IntersectionObserver' in window) {
+        cards.forEach(card => {
+          const iframe = card.querySelector('iframe');
+          if (!iframe) return;
+
+          let inView = false;
+          const applyState = () => {
+            sendMuteMessage(iframe, !inView);
+            sendPlayMessage(iframe, inView);
+          };
+
+          const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+              if (entry.target !== card) return;
+              inView = entry.isIntersecting;
+              applyState();
+            });
+          }, { threshold: 0.5 });
+
+          observer.observe(card);
+
+          iframe.addEventListener('load', applyState);
+        });
+      }
     });
   </script>
+  <script>
+    document.getElementById('themeSelector').addEventListener('change', function () {
+      document.getElementById('themeStylesheet').href = this.value;
+    });
+  </script>
+  <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Duplicate index layout into theme-tester page
- Add theme selection dropdown to swap between available theme styles
- Include client-side script to update stylesheet link

## Testing
- `npx -y htmlhint theme-tester.html`

------
https://chatgpt.com/codex/tasks/task_e_68a4c5b2da6483208a77b8a2cd89b9c7