### PR TITLE
Fix gap when channel list collapsed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -416,7 +416,18 @@ section {
 .youtube-section,
 .media-hub-section {
   display: flex;
-  gap: 16px;
+}
+
+/* maintain horizontal spacing between flex items */
+.youtube-section > * + *,
+.media-hub-section > * + * {
+  margin-left: 16px;
+}
+
+/* remove gap when the channel list is collapsed */
+.youtube-section .channel-list.collapsed + .video-section,
+.media-hub-section .channel-list.collapsed + .video-section {
+  margin-left: 0;
 }
 
 .youtube-section .channel-list,
@@ -592,6 +603,10 @@ section {
   .youtube-section,
   .media-hub-section {
     display: block;
+  }
+  .youtube-section > * + *,
+  .media-hub-section > * + * {
+    margin-left: 0;
   }
   .youtube-section .channel-list,
   .media-hub-section .channel-list {


### PR DESCRIPTION
## Summary
- Remove flex gap and replace with explicit margins between columns
- Eliminate extra spacing when channel list is collapsed
- Preserve spacing across responsive breakpoints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1ea466c83208e3607c784613f5d