### PR TITLE
Fix gap when channel list collapsed

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -3,10 +3,18 @@
   display: grid;
   grid-template-columns: 220px 1fr 300px;
   grid-template-rows: auto 1fr;
-  gap: 16px;
+  column-gap: 16px;
+  row-gap: 16px;
   grid-template-areas:
     "tabs tabs tabs"
     "left center right";
+}
+.media-hub-section.channels-collapsed {
+  grid-template-columns: 72px 1fr 300px;
+  column-gap: 0;
+}
+.media-hub-section.channels-collapsed .details-container {
+  margin-left: 16px;
 }
 .media-hub-section .mode-tabs { grid-area: tabs; }
 .media-hub-section #left-rail { grid-area: left; }
@@ -20,6 +28,10 @@
 .media-hub-section.no-details .details-container {
   display: none;
 }
+.media-hub-section.channels-collapsed.no-details {
+  grid-template-columns: 72px 1fr;
+  column-gap: 0;
+}
 
 @media (max-width: 1080px) {
   .media-hub-section {
@@ -27,6 +39,10 @@
     grid-template-areas:
       "tabs tabs"
       "left center";
+  }
+  .media-hub-section.channels-collapsed {
+    grid-template-columns: 72px 1fr;
+    column-gap: 0;
   }
   .media-hub-section .details-container { display: none; }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -413,10 +413,18 @@ section {
 }
 
 /* Channel navigation layout */
-.youtube-section,
-.media-hub-section {
+.youtube-section {
   display: flex;
-  gap: 16px;
+}
+
+/* maintain horizontal spacing between flex items */
+.youtube-section > * + * {
+  margin-left: 16px;
+}
+
+/* remove gap when the channel list is collapsed */
+.youtube-section .channel-list.collapsed + .video-section {
+  margin-left: 0;
 }
 
 .youtube-section .channel-list,
@@ -589,9 +597,11 @@ section {
 
 /* Responsive behaviour for channel list */
 @media (max-width: 768px) {
-  .youtube-section,
-  .media-hub-section {
+  .youtube-section {
     display: block;
+  }
+  .youtube-section > * + * {
+    margin-left: 0;
   }
   .youtube-section .channel-list,
   .media-hub-section .channel-list {

--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -4,6 +4,7 @@
   const detailsList = document.querySelector('.details-list');
   const detailsContainer = document.querySelector('.details-container');
   const detailsToggleBtn = document.getElementById('toggle-details');
+  const channelSection = channelList?.closest('.youtube-section, .media-hub-section');
 
   const modeTabs = [
     { el: document.querySelector('.tab-btn[data-mode="favorites"]'), icon: 'favorite' },
@@ -49,6 +50,7 @@
     } else {
       channelList.classList.toggle('collapsed');
       const collapsed = channelList.classList.contains('collapsed');
+      if (channelSection) channelSection.classList.toggle('channels-collapsed', collapsed);
       if (icon) icon.textContent = collapsed ? 'chevron_right' : 'chevron_left';
       localStorage.setItem('channelListCollapsed', collapsed);
     }
@@ -205,6 +207,7 @@
       const icon = channelToggleBtn?.querySelector('.icon');
       if (localStorage.getItem('channelListCollapsed') === 'true') {
         channelList.classList.add('collapsed');
+        if (channelSection) channelSection.classList.add('channels-collapsed');
         if (icon) icon.textContent = 'chevron_right';
       }
       updateModeTabs();


### PR DESCRIPTION
## Summary
- Stop applying flex-based margins to media hub layout
- Adjust grid columns when the channel list is collapsed to remove leftover spacing
- Toggle a `channels-collapsed` class in JS so layout and state stay in sync

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1ea466c83208e3607c784613f5d