### PR TITLE
Add right-aligned details toggle with info icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -456,6 +456,10 @@ section {
   margin-bottom: 8px;
 }
 
+.button-row .spacer {
+  flex: 1;
+}
+
 .youtube-section .channel-card,
 .media-hub-section .channel-card,
 .youtube-section .detail-item,

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -71,8 +71,9 @@
           <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label" data-default="Channels">Channels</span>
         </button>
+        <div class="spacer"></div>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
+          <span class="material-symbols-outlined icon">info</span>
           <span class="label" data-default="About">About</span>
         </button>
       </div>

--- a/freepress.html
+++ b/freepress.html
@@ -71,8 +71,9 @@
           <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label" data-default="Channels">Channels</span>
         </button>
+        <div class="spacer"></div>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
+          <span class="material-symbols-outlined icon">info</span>
           <span class="label" data-default="About">About</span>
         </button>
       </div>

--- a/media-hub.html
+++ b/media-hub.html
@@ -49,13 +49,13 @@
     <!-- CENTER -->
     <div class="video-section">
       <div class="button-row">
-        <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label" data-default="Channels">Channels</span>
         </button>
+        <div class="spacer"></div>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
+          <span class="material-symbols-outlined icon">info</span>
           <span class="label" data-default="About">About</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Add details toggle button with Material information icon in Free Press and Media Hub pages
- Right-align details toggle via spacer and new CSS rule

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eaa9de088320833b57ba5e01fa51