### PR TITLE
Add right-aligned details toggle with info icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -456,6 +456,10 @@ section {
   margin-bottom: 8px;
 }
 
+.button-row .spacer {
+  flex: 1;
+}
+
 .youtube-section .channel-card,
 .media-hub-section .channel-card,
 .youtube-section .detail-item,
@@ -779,7 +783,7 @@ button:hover,
 
 .channel-toggle .icon,
 .details-toggle .icon {
-  display: none;
+  display: inline-block;
 }
 
 @media (min-width: 769px) {
@@ -796,11 +800,6 @@ button:hover,
   .channel-toggle .label,
   .details-toggle .label {
     display: none;
-  }
-
-  .channel-toggle .icon,
-  .details-toggle .icon {
-    display: inline-block;
   }
 
   .channel-toggle:hover,

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -71,8 +71,9 @@
           <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label" data-default="Channels">Channels</span>
         </button>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
+        <div class="spacer"></div>
+        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list">
+          <span class="material-symbols-outlined icon">info</span>
           <span class="label" data-default="About">About</span>
         </button>
       </div>

--- a/freepress.html
+++ b/freepress.html
@@ -71,8 +71,9 @@
           <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label" data-default="Channels">Channels</span>
         </button>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
+        <div class="spacer"></div>
+        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list">
+          <span class="material-symbols-outlined icon">info</span>
           <span class="label" data-default="About">About</span>
         </button>
       </div>

--- a/media-hub.html
+++ b/media-hub.html
@@ -49,13 +49,13 @@
     <!-- CENTER -->
     <div class="video-section">
       <div class="button-row">
-        <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label" data-default="Channels">Channels</span>
         </button>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
+        <div class="spacer"></div>
+        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list">
+          <span class="material-symbols-outlined icon">info</span>
           <span class="label" data-default="About">About</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Expose details toggle button with Material info icon on Free Press and Media Hub pages
- Show toggle icons by default so the details button's info symbol is visible across screen sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eaa9de088320833b57ba5e01fa51