### PR TITLE
Highlight active video in media hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -147,6 +147,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     return 'Just now';
   }
 
+  function setActiveVideo(clickedItem) {
+    document.querySelectorAll('#videoList .video-item').forEach(item => item.classList.remove('active'));
+    if (clickedItem) clickedItem.classList.add('active');
+  }
+
   async function fetchVideoDetails(videoId, signal) {
     const resp = await fetch(`https://noembed.com/embed?url=https://www.youtube.com/watch?v=${videoId}`, { signal });
     if (!resp.ok) throw new Error('Failed to load video details');
@@ -610,6 +615,7 @@ async function renderLatestVideosRSS(channelId) {
         if (details && toggleDetailsBtn && details.innerHTML.trim().length) {
           toggleDetailsBtn.style.display = "";
         }
+        setActiveVideo(row);
       });
 
       videoList.appendChild(row);


### PR DESCRIPTION
## Summary
- add setActiveVideo helper to manage highlighted video rows in media hub
- mark clicked videos as active so users can see which one is playing

## Testing
- `jekyll build` *(command not found: jekyll)*
- `bundle exec jekyll build` *(Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f0493ae48320826ae0fc010c30f2