### PR TITLE
Show channel details in Media Hub

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -147,6 +147,59 @@ document.addEventListener("DOMContentLoaded", async () => {
     return 'Just now';
   }
 
+  function renderProfiles(list) {
+    const icons = {
+      youtube: { url: 'https://img.icons8.com/color/48/000000/youtube-play.png', label: 'YouTube' },
+      instagram: { url: 'https://img.icons8.com/fluency/48/000000/instagram-new.png', label: 'Instagram' },
+      twitter: { url: 'https://img.icons8.com/color/48/000000/twitter--v1.png', label: 'Twitter' },
+      facebook: { url: 'https://img.icons8.com/color/48/000000/facebook-new.png', label: 'Facebook' },
+      linkedin: { url: 'https://img.icons8.com/fluency/48/000000/linkedin.png', label: 'LinkedIn' },
+      website: { url: 'https://img.icons8.com/ios-filled/50/000000/domain.png', label: 'Website' },
+      tiktok: { url: 'https://img.icons8.com/color/48/000000/tiktok--v1.png', label: 'TikTok' }
+    };
+    const items = list.map(url => {
+      let type = 'website';
+      if (/youtu/.test(url)) type = 'youtube';
+      else if (/instagram/.test(url)) type = 'instagram';
+      else if (/twitter|x\.com/.test(url)) type = 'twitter';
+      else if (/facebook/.test(url)) type = 'facebook';
+      else if (/linkedin/.test(url)) type = 'linkedin';
+      else if (/tiktok/.test(url)) type = 'tiktok';
+      const { url: icon, label } = icons[type] || { url: '', label: type.charAt(0).toUpperCase() + type.slice(1) };
+      const img = icon ? `<img src='${icon}' alt='${label}'>` : '';
+      return `<a class='profile' href='${url}' target='_blank' rel='noopener'><div class='profile-icon'>${img}</div><span>${label}</span></a>`;
+    }).join('');
+    return `<h3>Profiles</h3><div class='profiles'>${items}</div>`;
+  }
+
+  function updateDetails(item) {
+    if (!details || !toggleDetailsBtn) return;
+    const label = toggleDetailsBtn.querySelector('.label');
+    let html = '';
+    if (item) {
+      if (item.details_html) {
+        html = item.details_html;
+      } else {
+        if (item.about) html += item.about;
+        if (item.profiles && item.profiles.length) {
+          html += renderProfiles(item.profiles);
+        }
+      }
+    }
+    if (html) {
+      details.innerHTML = html;
+      details.style.display = '';
+      toggleDetailsBtn.style.display = '';
+      if (label) label.textContent = label.dataset.default || 'About';
+    } else {
+      details.classList.remove('open');
+      details.innerHTML = '';
+      details.style.display = 'none';
+      toggleDetailsBtn.style.display = 'none';
+      if (label) label.textContent = label.dataset.default || 'About';
+    }
+  }
+
   function setActiveVideo(clickedItem) {
     document.querySelectorAll('#videoList .video-item').forEach(item => item.classList.remove('active'));
     if (clickedItem) clickedItem.classList.add('active');
@@ -185,18 +238,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (currentAudio || (!videoPlaying && mode === "radio")) {
       if (playerIF) playerIF.style.display = "none";
       if (audioWrap) audioWrap.style.display = "";
-      if (details) details.style.display = "none";
-      if (toggleDetailsBtn) toggleDetailsBtn.style.display = "none";
-      if (mediaHubSection) mediaHubSection.classList.add("no-details");
     } else {
       if (playerIF) playerIF.style.display = "";
       if (audioWrap) audioWrap.style.display = "none";
-      const hasDetails = details && details.innerHTML.trim().length > 0;
-      if (details) details.style.display = hasDetails ? "" : "none";
-      if (toggleDetailsBtn) toggleDetailsBtn.style.display = hasDetails ? "" : "none";
-       if (mediaHubSection) mediaHubSection.classList.toggle("no-details", !hasDetails);
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
+
+    const hasDetails = details && details.innerHTML.trim().length > 0;
+    if (details) details.style.display = hasDetails ? "" : "none";
+    if (toggleDetailsBtn) toggleDetailsBtn.style.display = hasDetails ? "" : "none";
+    if (mediaHubSection) mediaHubSection.classList.toggle("no-details", !hasDetails);
 
     if (mode === 'favorites') {
       favorites = [];
@@ -260,7 +311,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       playBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         if (!ep) return;
-        playRadio(playBtn, audio, displayName(it), audio.dataset.logo);
+        playRadio(playBtn, audio, displayName(it), audio.dataset.logo, it);
       });
       card.addEventListener("click", (e) => {
         if (e.target.closest("button")) return;
@@ -493,7 +544,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             const btn = card ? card.querySelector('.play-btn') : null;
             const audio = card ? card.querySelector('audio') : null;
             if (btn && audio) {
-              playRadio(btn, audio, displayName(target), thumbOf(target));
+              playRadio(btn, audio, displayName(target), thumbOf(target), target);
             }
           }
         } else if (arr.length) {
@@ -502,7 +553,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           const btn = card ? card.querySelector('.play-btn') : null;
           const audio = card ? card.querySelector('audio') : null;
           if (btn && audio) {
-            playRadio(btn, audio, displayName(first), thumbOf(first));
+            playRadio(btn, audio, displayName(first), thumbOf(first), first);
           }
         }
       }
@@ -520,7 +571,7 @@ document.addEventListener("DOMContentLoaded", async () => {
               document.querySelectorAll('.channel-card').forEach(c => c.classList.toggle('active', c.dataset.key === match.key));
               handled = true;
             } else if (btn && audio) {
-              playRadio(btn, audio, displayName(match), thumbOf(match));
+              playRadio(btn, audio, displayName(match), thumbOf(match), match);
               handled = true;
             }
           } else {
@@ -649,7 +700,6 @@ async function renderLatestVideosRSS(channelId) {
 
     if (videoList) videoList.innerHTML = "";
     currentVideoChannelId = null;
-    if (details) details.innerHTML = "";
     if (playerIF) playerIF.style.display = "";
     if (audioWrap) audioWrap.style.display = "none";
 
@@ -681,18 +731,7 @@ async function renderLatestVideosRSS(channelId) {
     if (item.ids?.youtube_channel_id) {
       renderLatestVideosRSS(item.ids.youtube_channel_id);
     }
-
-    if (details) {
-      if (item.details_html) {
-        details.innerHTML = item.details_html;
-        details.style.display = "";
-        if (toggleDetailsBtn) toggleDetailsBtn.style.display = "";
-      } else {
-        details.innerHTML = "";
-        details.style.display = "none";
-        if (toggleDetailsBtn) toggleDetailsBtn.style.display = "none";
-      }
-    }
+    updateDetails(item);
 
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
@@ -714,7 +753,7 @@ async function renderLatestVideosRSS(channelId) {
     }
   }
 
-  function playRadio(btn, audio, name, logoUrl) {
+  function playRadio(btn, audio, name, logoUrl, item) {
     if (!audio) return;
 
     abortPendingRequests();
@@ -741,6 +780,7 @@ async function renderLatestVideosRSS(channelId) {
     if (stationLogo) stationLogo.src = logoUrl || defaultLogo;
     if (liveBadge) liveBadge.hidden = true;
     if (notLiveBadge) notLiveBadge.hidden = false;
+    updateDetails(item);
 
     if (mainPlayer) {
       mainPlayer.src = audio.src;
@@ -885,7 +925,7 @@ async function renderLatestVideosRSS(channelId) {
     const key = card?.dataset.key;
     const item = items.find(i => i.key === key);
     if (!item) return;
-    playRadio(card.querySelector('.play-btn'), audio, displayName(item), thumbOf(item));
+    playRadio(card.querySelector('.play-btn'), audio, displayName(item), thumbOf(item), item);
   }
 
   // Tabs + Search


### PR DESCRIPTION
## Summary
- centralize channel About/profile rendering into `updateDetails`
- call `updateDetails` from video and radio selections to populate the right menu

## Testing
- `node --check js/media-hub.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f3bb0048832081f6aca73590eceb