### PR TITLE
Sync right menu collapse behavior with left

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -15,10 +15,25 @@
 .media-hub-section.channels-collapsed .details-container {
   margin-left: 16px;
 }
-.media-hub-section .mode-tabs { grid-area: tabs; }
-.media-hub-section #left-rail { grid-area: left; }
-.media-hub-section .video-section { grid-area: center; }
-.media-hub-section .details-container { grid-area: right; }
+.media-hub-section.details-collapsed {
+  grid-template-columns: 220px 1fr 24px;
+}
+.media-hub-section.channels-collapsed.details-collapsed {
+  grid-template-columns: 72px 1fr 24px;
+  column-gap: 0;
+}
+.media-hub-section .mode-tabs {
+  grid-area: tabs;
+}
+.media-hub-section #left-rail {
+  grid-area: left;
+}
+.media-hub-section .video-section {
+  grid-area: center;
+}
+.media-hub-section .details-container {
+  grid-area: right;
+}
 
 /* Hide right rail when there are no details to show */
 .media-hub-section.no-details {
@@ -43,7 +58,9 @@
     grid-template-columns: 72px 1fr;
     column-gap: 0;
   }
-  .media-hub-section .details-container { display: none; }
+  .media-hub-section .details-container {
+    display: none;
+  }
 }
 
 @media (max-width: 768px) {
@@ -62,78 +79,113 @@
   padding: 8px 0 10px;
   border-bottom: 1px solid var(--outline);
 }
-.mode-tabs { display:flex; gap:8px; flex-wrap:nowrap; overflow-x:auto; overflow-y:hidden; margin-bottom:8px; }
+.mode-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+}
 .tab-btn {
-  padding:8px 12px;
-  border:1px solid var(--surface-variant);
-  background:var(--surface-variant);
-  color:var(--on-surface);
-  border-radius:8px;
-  cursor:pointer;
+  padding: 8px 12px;
+  border: 1px solid var(--surface-variant);
+  background: var(--surface-variant);
+  color: var(--on-surface);
+  border-radius: 8px;
+  cursor: pointer;
 }
 .tab-btn.active {
-  background:var(--primary-container);
-  border-color:var(--primary);
-  color:var(--on-primary-container);
+  background: var(--primary-container);
+  border-color: var(--primary);
+  color: var(--on-primary-container);
 }
 .search-wrap input {
-  width:100%;
-  padding:8px 10px;
-  border:1px solid var(--outline);
-  background:var(--surface);
-  color:var(--on-surface);
-  border-radius:8px;
-  box-sizing:border-box;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--outline);
+  background: var(--surface);
+  color: var(--on-surface);
+  border-radius: 8px;
+  box-sizing: border-box;
 }
 
 /* Responsive keeps your existing behavior */
 
-
-.mode-tabs { display:flex; gap:8px; flex-wrap:nowrap; overflow-x:auto; overflow-y:hidden; }
+.mode-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
 .tab-btn {
-  padding:8px 14px;
-  border:1px solid var(--surface-variant);
-  background:var(--surface-variant);
-  color:var(--on-surface);
-  border-radius:8px;
-  cursor:pointer;
+  padding: 8px 14px;
+  border: 1px solid var(--surface-variant);
+  background: var(--surface-variant);
+  color: var(--on-surface);
+  border-radius: 8px;
+  cursor: pointer;
 }
 .tab-btn.active {
-  background:var(--primary-container);
-  border-color:var(--primary);
-  color:var(--on-primary-container);
+  background: var(--primary-container);
+  border-color: var(--primary);
+  color: var(--on-primary-container);
 }
-.live-player .audio-wrap { background:var(--surface); border-radius:14px; box-shadow:var(--shadow-xs); padding:12px; }
+.live-player .audio-wrap {
+  background: var(--surface);
+  border-radius: 14px;
+  box-shadow: var(--shadow-xs);
+  padding: 12px;
+}
 
 /* layout that mirrors your existing pages */
-.page-wrap { padding-top: 12px; }
-.tabs-row { display:flex; gap:8px; margin:8px 0 12px; }
+.page-wrap {
+  padding-top: 12px;
+}
+.tabs-row {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0 12px;
+}
 .tab-btn {
-  background:var(--surface-variant);
-  border:1px solid var(--surface-variant);
-  border-radius:8px;
-  padding:8px 14px;
-  color:var(--on-surface);
-  cursor:pointer;
+  background: var(--surface-variant);
+  border: 1px solid var(--surface-variant);
+  border-radius: 8px;
+  padding: 8px 14px;
+  color: var(--on-surface);
+  cursor: pointer;
 }
 .tab-btn.active {
-  background:var(--primary-container);
-  border-color:var(--primary);
-  color:var(--on-primary-container);
+  background: var(--primary-container);
+  border-color: var(--primary);
+  color: var(--on-primary-container);
 }
-.content-grid { display:grid; gap:16px; grid-template-columns: 320px 1fr 340px; }
-.left-rail { min-width:280px; }
-.center-rail { min-width:0; }
-.right-rail { min-width:300px; }
-.search-wrap { margin:6px 0 10px; }
+.content-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 320px 1fr 340px;
+}
+.left-rail {
+  min-width: 280px;
+}
+.center-rail {
+  min-width: 0;
+}
+.right-rail {
+  min-width: 300px;
+}
+.search-wrap {
+  margin: 6px 0 10px;
+}
 .search-wrap input {
-  width:100%;
-  padding:8px 10px;
-  border:1px solid var(--outline);
-  background:var(--surface);
-  color:var(--on-surface);
-  border-radius:8px;
-  box-sizing:border-box;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--outline);
+  background: var(--surface);
+  color: var(--on-surface);
+  border-radius: 8px;
+  box-sizing: border-box;
 }
 
 /* reuse your card list visuals */
@@ -142,28 +194,71 @@
   height: calc(100vh - 120px);
   overflow-y: auto;
 }
-.channel-card { display:flex; align-items:center; gap:10px; padding:10px 12px; background:var(--surface); border-radius:14px; margin-bottom:10px; box-shadow:var(--card-shadow,var(--shadow-xs)); }
-.channel-card.active { outline:2px solid var(--primary); }
-.channel-thumb { width:40px; height:40px; border-radius:8px; object-fit:cover; }
+.channel-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--surface);
+  border-radius: 14px;
+  margin-bottom: 10px;
+  box-shadow: var(--card-shadow, var(--shadow-xs));
+}
+.channel-card.active {
+  outline: 2px solid var(--primary);
+}
+.channel-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+}
 .youtube-section .channel-card .play-btn,
-.media-hub-section .channel-card .play-btn { display:none; }
+.media-hub-section .channel-card .play-btn {
+  display: none;
+}
 
+.player-container iframe,
+.player-container .audio-wrap {
+  width: 100%;
+  border: 0;
+  border-radius: 14px;
+  box-shadow: var(--shadow-xs);
+}
+.player-container .audio-wrap {
+  padding: 14px;
+  background: var(--surface);
+}
 
-.player-container iframe, .player-container .audio-wrap { width:100%; border:0; border-radius:14px; box-shadow:var(--shadow-xs); }
-.player-container .audio-wrap { padding:14px; background:var(--surface); }
-
-.details-list { background:var(--surface); border-radius:14px; padding:12px; box-shadow:var(--shadow-xs); }
-.detail-item { margin-bottom:6px; }
+.details-list {
+  background: var(--surface);
+  border-radius: 14px;
+  padding: 12px;
+  box-shadow: var(--shadow-xs);
+}
+.detail-item {
+  margin-bottom: 6px;
+}
 
 /* responsive */
 @media (max-width: 1080px) {
-  .content-grid { grid-template-columns: 300px 1fr; }
-  .right-rail { display:none; }
+  .content-grid {
+    grid-template-columns: 300px 1fr;
+  }
+  .right-rail {
+    display: none;
+  }
 }
 @media (max-width: 820px) {
-  .content-grid { grid-template-columns: 1fr; }
-  .left-rail { order:1; }
-  .center-rail { order:2; }
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+  .left-rail {
+    order: 1;
+  }
+  .center-rail {
+    order: 2;
+  }
 }
 
 /* Make left menu cover full height on mobile */

--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -1,125 +1,147 @@
-(function() {
-  const channelList = document.querySelector('.channel-list');
-  const channelToggleBtn = document.getElementById('toggle-channels');
-  const detailsList = document.querySelector('.details-list');
-  const detailsContainer = document.querySelector('.details-container');
-  const detailsToggleBtn = document.getElementById('toggle-details');
-  const channelSection = channelList?.closest('.youtube-section, .media-hub-section');
+(function () {
+  const channelList = document.querySelector(".channel-list");
+  const channelToggleBtn = document.getElementById("toggle-channels");
+  const detailsList = document.querySelector(".details-list");
+  const detailsContainer = document.querySelector(".details-container");
+  const detailsToggleBtn = document.getElementById("toggle-details");
+  const channelSection = channelList?.closest(
+    ".youtube-section, .media-hub-section",
+  );
 
   const modeTabs = [
-    { el: document.querySelector('.tab-btn[data-mode="favorites"]'), icon: 'favorite' },
-    { el: document.querySelector('.tab-btn[data-mode="tv"]'), icon: 'live_tv' },
-    { el: document.querySelector('.tab-btn[data-mode="radio"]'), icon: 'radio' }
+    {
+      el: document.querySelector('.tab-btn[data-mode="favorites"]'),
+      icon: "favorite",
+    },
+    { el: document.querySelector('.tab-btn[data-mode="tv"]'), icon: "live_tv" },
+    {
+      el: document.querySelector('.tab-btn[data-mode="radio"]'),
+      icon: "radio",
+    },
   ];
 
-  modeTabs.forEach(tab => {
-    tab.default = tab.el?.textContent.trim() || '';
+  modeTabs.forEach((tab) => {
+    tab.default = tab.el?.textContent.trim() || "";
   });
 
   function updateModeTabs() {
-    const collapsed = channelList?.classList.contains('collapsed');
-    modeTabs.forEach(tab => {
+    const collapsed = channelList?.classList.contains("collapsed");
+    modeTabs.forEach((tab) => {
       if (!tab.el) return;
       if (collapsed) {
-        tab.el.classList.add('fav-btn', 'material-symbols-outlined');
+        tab.el.classList.add("fav-btn", "material-symbols-outlined");
         tab.el.textContent = tab.icon;
       } else {
-        tab.el.classList.remove('fav-btn', 'material-symbols-outlined');
+        tab.el.classList.remove("fav-btn", "material-symbols-outlined");
         tab.el.textContent = tab.default;
       }
     });
   }
 
-  const channelLabelEl = channelToggleBtn?.querySelector('.label');
-  const channelToggleDefaultText = channelLabelEl?.textContent || channelToggleBtn?.textContent || '';
+  const channelLabelEl = channelToggleBtn?.querySelector(".label");
+  const channelToggleDefaultText =
+    channelLabelEl?.textContent || channelToggleBtn?.textContent || "";
   if (channelLabelEl) channelLabelEl.dataset.default = channelToggleDefaultText;
-  const detailsLabelEl = detailsToggleBtn?.querySelector('.label');
-  const detailsToggleDefaultText = detailsLabelEl?.textContent || 'About';
+  const detailsLabelEl = detailsToggleBtn?.querySelector(".label");
+  const detailsToggleDefaultText = detailsLabelEl?.textContent || "About";
   if (detailsLabelEl) detailsLabelEl.dataset.default = detailsToggleDefaultText;
 
   function toggleChannelList() {
     if (!channelList || !channelToggleBtn) return;
-    const icon = channelToggleBtn.querySelector('.icon');
-    const label = channelToggleBtn.querySelector('.label');
+    const icon = channelToggleBtn.querySelector(".icon");
+    const label = channelToggleBtn.querySelector(".label");
     if (window.innerWidth <= 768) {
-      channelList.classList.toggle('open');
+      channelList.classList.toggle("open");
       if (label) {
-        label.textContent = channelList.classList.contains('open') ? `Close ${channelToggleDefaultText}` : channelToggleDefaultText;
+        label.textContent = channelList.classList.contains("open")
+          ? `Close ${channelToggleDefaultText}`
+          : channelToggleDefaultText;
       }
-      if (typeof updateScrollLock === 'function') updateScrollLock();
+      if (typeof updateScrollLock === "function") updateScrollLock();
     } else {
-      channelList.classList.toggle('collapsed');
-      const collapsed = channelList.classList.contains('collapsed');
-      if (channelSection) channelSection.classList.toggle('channels-collapsed', collapsed);
-      if (icon) icon.textContent = collapsed ? 'chevron_right' : 'chevron_left';
-      localStorage.setItem('channelListCollapsed', collapsed);
+      channelList.classList.toggle("collapsed");
+      const collapsed = channelList.classList.contains("collapsed");
+      if (channelSection)
+        channelSection.classList.toggle("channels-collapsed", collapsed);
+      if (icon) icon.textContent = collapsed ? "chevron_right" : "chevron_left";
+      localStorage.setItem("channelListCollapsed", collapsed);
     }
     updateModeTabs();
   }
   window.toggleChannelList = toggleChannelList;
 
-  document.addEventListener('click', e => {
-    if (channelList && channelToggleBtn && channelList.classList.contains('open') && !channelList.contains(e.target) && !channelToggleBtn.contains(e.target)) {
-      channelList.classList.remove('open');
-      const label = channelToggleBtn.querySelector('.label');
+  document.addEventListener("click", (e) => {
+    if (
+      channelList &&
+      channelToggleBtn &&
+      channelList.classList.contains("open") &&
+      !channelList.contains(e.target) &&
+      !channelToggleBtn.contains(e.target)
+    ) {
+      channelList.classList.remove("open");
+      const label = channelToggleBtn.querySelector(".label");
       if (label) label.textContent = channelToggleDefaultText;
-      if (typeof updateScrollLock === 'function') updateScrollLock();
+      if (typeof updateScrollLock === "function") updateScrollLock();
     }
   });
 
   if (channelList) {
-    channelList.addEventListener('click', e => {
+    channelList.addEventListener("click", (e) => {
       if (window.innerWidth > 768) return;
-      if (e.target.closest('.channel-card')) {
-        channelList.classList.remove('open');
-        const label = channelToggleBtn?.querySelector('.label');
+      if (e.target.closest(".channel-card")) {
+        channelList.classList.remove("open");
+        const label = channelToggleBtn?.querySelector(".label");
         if (label) label.textContent = channelToggleDefaultText;
-        if (typeof updateScrollLock === 'function') updateScrollLock();
+        if (typeof updateScrollLock === "function") updateScrollLock();
       }
     });
 
     let touchStartX = null;
     let touchFromModeTabs = false;
-    channelList.addEventListener('touchstart', e => {
-      if (!channelList.classList.contains('open')) return;
+    channelList.addEventListener("touchstart", (e) => {
+      if (!channelList.classList.contains("open")) return;
       touchStartX = e.touches[0].clientX;
       // If the gesture started inside the horizontal mode tabs, ignore it for closing
-      touchFromModeTabs = e.target.closest('.mode-tabs') !== null;
+      touchFromModeTabs = e.target.closest(".mode-tabs") !== null;
     });
-    channelList.addEventListener('touchend', e => {
+    channelList.addEventListener("touchend", (e) => {
       if (touchStartX === null) return;
       const touchEndX = e.changedTouches[0].clientX;
       if (!touchFromModeTabs && touchStartX - touchEndX > 50) {
-        channelList.classList.remove('open');
-        const label = channelToggleBtn?.querySelector('.label');
+        channelList.classList.remove("open");
+        const label = channelToggleBtn?.querySelector(".label");
         if (label) label.textContent = channelToggleDefaultText;
-        if (typeof updateScrollLock === 'function') updateScrollLock();
+        if (typeof updateScrollLock === "function") updateScrollLock();
       }
       touchStartX = null;
       touchFromModeTabs = false;
     });
 
     let openStartX = null;
-    document.addEventListener('touchstart', e => {
-      if (channelList.classList.contains('open')) return;
+    document.addEventListener("touchstart", (e) => {
+      if (channelList.classList.contains("open")) return;
       openStartX = e.touches[0].clientX;
     });
-    document.addEventListener('touchmove', e => {
-      if (openStartX === null) return;
-      const currentX = e.touches[0].clientX;
-      if (openStartX < 50 && currentX - openStartX > 10) {
-        e.preventDefault();
-      }
-    }, { passive: false });
-    document.addEventListener('touchend', e => {
-      if (channelList.classList.contains('open')) return;
+    document.addEventListener(
+      "touchmove",
+      (e) => {
+        if (openStartX === null) return;
+        const currentX = e.touches[0].clientX;
+        if (openStartX < 50 && currentX - openStartX > 10) {
+          e.preventDefault();
+        }
+      },
+      { passive: false },
+    );
+    document.addEventListener("touchend", (e) => {
+      if (channelList.classList.contains("open")) return;
       if (openStartX === null) return;
       const touchEndX = e.changedTouches[0].clientX;
       if (touchEndX - openStartX > 50 && openStartX < 50) {
-        channelList.classList.add('open');
-        const label = channelToggleBtn?.querySelector('.label');
+        channelList.classList.add("open");
+        const label = channelToggleBtn?.querySelector(".label");
         if (label) label.textContent = `Close ${channelToggleDefaultText}`;
-        if (typeof updateScrollLock === 'function') updateScrollLock();
+        if (typeof updateScrollLock === "function") updateScrollLock();
       }
       openStartX = null;
     });
@@ -127,97 +149,118 @@
 
   function toggleDetailsList() {
     if (!detailsList || !detailsToggleBtn) return;
-    const icon = detailsToggleBtn.querySelector('.icon');
-    const label = detailsToggleBtn.querySelector('.label');
+    const icon = detailsToggleBtn.querySelector(".icon");
+    const label = detailsToggleBtn.querySelector(".label");
     if (window.innerWidth <= 768) {
-      if (detailsToggleBtn.style.display === 'none') return;
-      detailsList.classList.toggle('open');
+      if (detailsToggleBtn.style.display === "none") return;
+      detailsList.classList.toggle("open");
       if (label) {
-        label.textContent = detailsList.classList.contains('open') ? `Close ${detailsToggleDefaultText}` : detailsToggleDefaultText;
+        label.textContent = detailsList.classList.contains("open")
+          ? `Close ${detailsToggleDefaultText}`
+          : detailsToggleDefaultText;
       }
-      if (typeof updateScrollLock === 'function') updateScrollLock();
+      if (typeof updateScrollLock === "function") updateScrollLock();
     } else {
       if (!detailsContainer) return;
-      detailsContainer.classList.toggle('collapsed');
-      const collapsed = detailsContainer.classList.contains('collapsed');
-      if (icon) icon.textContent = collapsed ? 'chevron_left' : 'chevron_right';
-      localStorage.setItem('detailsListCollapsed', collapsed);
+      detailsContainer.classList.toggle("collapsed");
+      const collapsed = detailsContainer.classList.contains("collapsed");
+      if (channelSection)
+        channelSection.classList.toggle("details-collapsed", collapsed);
+      if (icon) icon.textContent = collapsed ? "chevron_left" : "chevron_right";
+      localStorage.setItem("detailsListCollapsed", collapsed);
     }
   }
   window.toggleDetailsList = toggleDetailsList;
 
-  document.addEventListener('click', e => {
-    if (detailsList && detailsToggleBtn && detailsList.classList.contains('open') && !detailsList.contains(e.target) && !detailsToggleBtn.contains(e.target)) {
-      detailsList.classList.remove('open');
-      const label = detailsToggleBtn.querySelector('.label');
+  document.addEventListener("click", (e) => {
+    if (
+      detailsList &&
+      detailsToggleBtn &&
+      detailsList.classList.contains("open") &&
+      !detailsList.contains(e.target) &&
+      !detailsToggleBtn.contains(e.target)
+    ) {
+      detailsList.classList.remove("open");
+      const label = detailsToggleBtn.querySelector(".label");
       if (label) label.textContent = detailsToggleDefaultText;
-      if (typeof updateScrollLock === 'function') updateScrollLock();
+      if (typeof updateScrollLock === "function") updateScrollLock();
     }
   });
 
   if (detailsList && detailsToggleBtn) {
     let detailsTouchStartX = null;
-    detailsList.addEventListener('touchstart', e => {
-      if (!detailsList.classList.contains('open')) return;
+    detailsList.addEventListener("touchstart", (e) => {
+      if (!detailsList.classList.contains("open")) return;
       detailsTouchStartX = e.touches[0].clientX;
     });
-    detailsList.addEventListener('touchend', e => {
+    detailsList.addEventListener("touchend", (e) => {
       if (detailsTouchStartX === null) return;
       const touchEndX = e.changedTouches[0].clientX;
       if (touchEndX - detailsTouchStartX > 50) {
-        detailsList.classList.remove('open');
-        const label = detailsToggleBtn.querySelector('.label');
+        detailsList.classList.remove("open");
+        const label = detailsToggleBtn.querySelector(".label");
         if (label) label.textContent = detailsToggleDefaultText;
-        if (typeof updateScrollLock === 'function') updateScrollLock();
+        if (typeof updateScrollLock === "function") updateScrollLock();
       }
       detailsTouchStartX = null;
     });
 
     let detailsOpenStartX = null;
-    document.addEventListener('touchstart', e => {
-      if (detailsList.classList.contains('open')) return;
-      if (detailsToggleBtn.style.display === 'none') return;
+    document.addEventListener("touchstart", (e) => {
+      if (detailsList.classList.contains("open")) return;
+      if (detailsToggleBtn.style.display === "none") return;
       detailsOpenStartX = e.touches[0].clientX;
     });
-    document.addEventListener('touchmove', e => {
+    document.addEventListener(
+      "touchmove",
+      (e) => {
+        if (detailsOpenStartX === null) return;
+        if (detailsToggleBtn.style.display === "none") return;
+        const currentX = e.touches[0].clientX;
+        if (
+          detailsOpenStartX > window.innerWidth - 50 &&
+          detailsOpenStartX - currentX > 10
+        ) {
+          e.preventDefault();
+        }
+      },
+      { passive: false },
+    );
+    document.addEventListener("touchend", (e) => {
+      if (detailsList.classList.contains("open")) return;
       if (detailsOpenStartX === null) return;
-      if (detailsToggleBtn.style.display === 'none') return;
-      const currentX = e.touches[0].clientX;
-      if (detailsOpenStartX > window.innerWidth - 50 && detailsOpenStartX - currentX > 10) {
-        e.preventDefault();
-      }
-    }, { passive: false });
-    document.addEventListener('touchend', e => {
-      if (detailsList.classList.contains('open')) return;
-      if (detailsOpenStartX === null) return;
-      if (detailsToggleBtn.style.display === 'none') return;
+      if (detailsToggleBtn.style.display === "none") return;
       const touchEndX = e.changedTouches[0].clientX;
-      if (detailsOpenStartX > window.innerWidth - 50 && detailsOpenStartX - touchEndX > 50) {
-        detailsList.classList.add('open');
-        const label = detailsToggleBtn.querySelector('.label');
+      if (
+        detailsOpenStartX > window.innerWidth - 50 &&
+        detailsOpenStartX - touchEndX > 50
+      ) {
+        detailsList.classList.add("open");
+        const label = detailsToggleBtn.querySelector(".label");
         if (label) label.textContent = `Close ${detailsToggleDefaultText}`;
-        if (typeof updateScrollLock === 'function') updateScrollLock();
+        if (typeof updateScrollLock === "function") updateScrollLock();
       }
       detailsOpenStartX = null;
     });
   }
 
-  (function() {
+  (function () {
     if (channelList) {
-      const icon = channelToggleBtn?.querySelector('.icon');
-      if (localStorage.getItem('channelListCollapsed') === 'true') {
-        channelList.classList.add('collapsed');
-        if (channelSection) channelSection.classList.add('channels-collapsed');
-        if (icon) icon.textContent = 'chevron_right';
+      const icon = channelToggleBtn?.querySelector(".icon");
+      if (localStorage.getItem("channelListCollapsed") === "true") {
+        channelList.classList.add("collapsed");
+        if (channelSection) channelSection.classList.add("channels-collapsed");
+        if (icon) icon.textContent = "chevron_right";
       }
       updateModeTabs();
     }
     if (detailsContainer && detailsToggleBtn) {
-      const icon = detailsToggleBtn.querySelector('.icon');
-      const collapsedPref = localStorage.getItem('detailsListCollapsed');
-      if (collapsedPref === null || collapsedPref === 'true') {
-        detailsContainer.classList.add('collapsed');
-        if (icon) icon.textContent = 'chevron_left';
+      const icon = detailsToggleBtn.querySelector(".icon");
+      const collapsedPref = localStorage.getItem("detailsListCollapsed");
+      if (collapsedPref === null || collapsedPref === "true") {
+        detailsContainer.classList.add("collapsed");
+        if (channelSection) channelSection.classList.add("details-collapsed");
+        if (icon) icon.textContent = "chevron_left";
       }
     }
   })();


### PR DESCRIPTION
## Summary
- add `details-collapsed` grid styles so the right menu shrink behaves like the left rail
- toggle new `details-collapsed` class from `leftmenu.js` to update layout and remember state

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes htmlhint media-hub.html`
- `npx --yes prettier --check css/media-hub.css js/leftmenu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4f9d0397c8320862d6e8490bfd17c