### PR TITLE
Add bio and profiles for Wajahat Saeed Khan

### DIFF
--- a/all_streams.json
+++ b/all_streams.json
@@ -3404,6 +3404,15 @@
       "name": "Wajahat Saeed Khan",
       "type": "freepress",
       "platform": "youtube",
+      "about": "<span>Wajahat S. Khan is an Emmy-nominated journalist and author reporting on Indo-Pacific security and focusing on the Af-Pak conflict.<br>An adjunct professor at NYU's Center of Global Affairs and non-resident Senior Fellow at the Atlantic Council, he has reported from 16 countries and served as NBC News bureau chief in Kabul and Islamabad.<br>He wrote the 2019 bestseller \"Game Changer: Being Shahid Afridi\" and lives between New York, London and Karachi.</span>",
+      "profiles": [
+        "https://whatsapp.com/channel/0029Vb65Ah17oQhcb3EHSK1V",
+        "https://wajskhan.substack.com/",
+        "https://twitter.com/wajskhan",
+        "https://www.instagram.com/wajskhan",
+        "https://www.facebook.com/journalismwsk",
+        "https://www.youtube.com/channel/UCxaMbYDd4o_zVvfr9_wKAxQ/join"
+      ],
       "media": {
         "thumbnail_url": "https://yt3.ggpht.com/t2HBS8LUfMyss8aFeuGY-9UH28AipjLpCtw4z0PqMHvwXHTogmwQ31Cn7VNYay053k9cCWVv=s800-c-k-c0x00ffffff-no-rj"
       },


### PR DESCRIPTION
## Summary
- add biographical information for Wajahat S. Khan
- include WhatsApp, Substack, Twitter, Instagram, Facebook and YouTube membership links

## Testing
- `npm test` *(fails: could not read package.json)*
- `jq . all_streams.json`


------
https://chatgpt.com/codex/tasks/task_e_68a4fa9dd5fc832092889e3506b45743