### PR TITLE
Enable top bar search on media hub

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -44,8 +44,8 @@ document.addEventListener('DOMContentLoaded', function () {
     topBar.insertBefore(backBtn, label.nextSibling);
   }
 
-  // The media hub has its own search in the left menu, so skip the top-bar search there.
-  if (topBar && currentPath !== '/media-hub.html') {
+  // Add top-bar search on all pages, including the media hub.
+  if (topBar) {
     var themeBtn = themeToggle;
     var logoTitle = document.querySelector('.logo-title');
     var searchForm = document.createElement('form');


### PR DESCRIPTION
## Summary
- Always inject top-bar search so media-hub page also shows the site search

## Testing
- `node --check js/main.js`
- `npx --yes htmlhint media-hub.html`


------
https://chatgpt.com/codex/tasks/task_e_68a501f168cc8320921f3d7c39443829