### PR TITLE
fix: restore initial scrolling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -11,8 +11,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function updateScrollLock() {
     var navOpen = navToggle && navToggle.checked;
-    var sideOpen = document.querySelector('.channel-list.open, .details-list.open');
-    var anyOpen = navOpen || !!sideOpen;
+    var channelOpen = document.querySelector('.channel-list.open');
+    var detailsOpen = document.querySelector('.details-list.open');
+    var sideOpen = window.innerWidth <= 768 && (channelOpen || detailsOpen);
+    var anyOpen = navOpen || sideOpen;
     document.body.classList.toggle('no-scroll', anyOpen);
     if (overlay) overlay.classList.toggle('active', anyOpen);
   }


### PR DESCRIPTION
## Summary
- ensure scroll lock only applies on mobile side menus to keep scrollbar visible on initial load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a501acc6fc8320878700e4ec29911f