### PR TITLE
Open channel list when switching tabs on mobile

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -1013,6 +1013,11 @@ async function renderLatestVideosRSS(channelId) {
     history.replaceState(null, "", "?" + params.toString());
     updateActiveUI();
     renderList(searchEl ? (searchEl.value || "") : "");
+    if (window.innerWidth <= 768 && leftRail &&
+        typeof toggleChannelList === "function" &&
+        !leftRail.classList.contains("open")) {
+      toggleChannelList();
+    }
   }));
   if (searchEl) {
     searchEl.addEventListener("input", e => renderList(e.target.value));


### PR DESCRIPTION
## Summary
- Automatically expand the channel list on mobile when switching tabs in the media hub

## Testing
- `node --check js/media-hub.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a509c0653c83208a25b1ca45f4085c