### PR TITLE
Fix media hub right menu visibility

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -58,9 +58,6 @@
     grid-template-columns: 72px 1fr;
     column-gap: 0;
   }
-  .media-hub-section .details-container {
-    display: none;
-  }
 }
 
 @media (max-width: 768px) {

--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -151,7 +151,7 @@
     if (!detailsList || !detailsToggleBtn) return;
     const icon = detailsToggleBtn.querySelector(".icon");
     const label = detailsToggleBtn.querySelector(".label");
-    if (window.innerWidth <= 768) {
+    if (window.innerWidth <= 1080) {
       if (detailsToggleBtn.style.display === "none") return;
       detailsList.classList.toggle("open");
       if (label) {


### PR DESCRIPTION
## Summary
- Ensure media hub details panel works on mid-sized screens by treating widths up to 1080px as mobile overlay
- Stop hiding the details container at <=1080px so the panel can slide in

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a50b5e4594832088188c2a0a78dd2a