### PR TITLE
fix: keep mode tab buttons textual

### DIFF
--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -8,36 +8,6 @@
     ".youtube-section, .media-hub-section",
   );
 
-  const modeTabs = [
-    {
-      el: document.querySelector('.tab-btn[data-mode="favorites"]'),
-      icon: "favorite",
-    },
-    { el: document.querySelector('.tab-btn[data-mode="tv"]'), icon: "live_tv" },
-    {
-      el: document.querySelector('.tab-btn[data-mode="radio"]'),
-      icon: "radio",
-    },
-  ];
-
-  modeTabs.forEach((tab) => {
-    tab.default = tab.el?.textContent.trim() || "";
-  });
-
-  function updateModeTabs() {
-    const collapsed = channelList?.classList.contains("collapsed");
-    modeTabs.forEach((tab) => {
-      if (!tab.el) return;
-      if (collapsed) {
-        tab.el.classList.add("fav-btn", "material-symbols-outlined");
-        tab.el.textContent = tab.icon;
-      } else {
-        tab.el.classList.remove("fav-btn", "material-symbols-outlined");
-        tab.el.textContent = tab.default;
-      }
-    });
-  }
-
   const channelLabelEl = channelToggleBtn?.querySelector(".label");
   const channelToggleDefaultText =
     channelLabelEl?.textContent || channelToggleBtn?.textContent || "";
@@ -66,7 +36,6 @@
       if (icon) icon.textContent = collapsed ? "chevron_right" : "chevron_left";
       localStorage.setItem("channelListCollapsed", collapsed);
     }
-    updateModeTabs();
   }
   window.toggleChannelList = toggleChannelList;
 
@@ -252,7 +221,6 @@
         if (channelSection) channelSection.classList.add("channels-collapsed");
         if (icon) icon.textContent = "chevron_right";
       }
-      updateModeTabs();
     }
     if (detailsContainer && detailsToggleBtn) {
       const icon = detailsToggleBtn.querySelector(".icon");


### PR DESCRIPTION
## Summary
- Remove icon-swap logic for mode tabs in the left menu so buttons always display text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a574e0e880832087d9ec763aaef201