### PR TITLE
feat(discovery): add Continue Watching/Listening and Trending rails

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1322,3 +1322,59 @@ footer nav a:hover {
   margin: 0;
   padding: 0;
 }
+
+/* Discovery rails */
+.rail-section {
+  margin: 20px auto;
+  max-width: 960px;
+}
+.rail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.rail-cards {
+  display: flex;
+  overflow-x: auto;
+  gap: 12px;
+}
+.rail-card {
+  flex: 0 0 160px;
+  background: var(--surface);
+  border-radius: 8px;
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+  color: inherit;
+  padding: 4px;
+}
+.rail-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+}
+.rail-title {
+  font-size: 0.875rem;
+  margin-top: 4px;
+}
+.clear-btn {
+  background: none;
+  border: none;
+  color: var(--accent-link);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.875rem;
+}
+.rail-progress {
+  position: relative;
+  height: 4px;
+  background: var(--surface-variant);
+  border-radius: 2px;
+  margin-top: 4px;
+}
+.rail-progress-inner {
+  height: 100%;
+  background: var(--primary);
+  border-radius: 2px;
+}

--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
     </div>
   </section>
 
+  <section id="trending-rail" class="rail-section lazy-rail" aria-label="Trending Now"></section>
+  <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
+
   <section class="station-scroller-wrap" aria-label="Trending channels">
     <div class="scroller-header">
       <h2 class="scroller-title">Trending Channels</h2>
@@ -230,7 +233,7 @@
     <nav class="footer-nav">
       <a href="/about.html">About Us</a>
       <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/privacy.html">Privacy &amp; History</a>
     <a href="/terms.html">Terms</a>
     </nav>
     {% include support-us.html %}
@@ -326,6 +329,7 @@
       }
     });
   </script>
+  <script defer src="/js/discovery.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/discovery.js
+++ b/js/discovery.js
@@ -1,0 +1,198 @@
+(function(){
+  const HISTORY_KEY = 'pakstream.user.history.v1';
+  const HISTORY_ENABLED_KEY = 'pakstream.user.history.enabled';
+  const TRENDING_KEY = 'pakstream.trending.signals.v1';
+
+  function load(key, fallback){
+    try{
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : fallback;
+    }catch(e){
+      return fallback;
+    }
+  }
+  function save(key, val){
+    try{ localStorage.setItem(key, JSON.stringify(val)); }catch(e){}
+  }
+
+  const historyService = {
+    enabled(){
+      try{ return localStorage.getItem(HISTORY_ENABLED_KEY) !== '0'; }
+      catch(e){ return false; }
+    },
+    get(){
+      return this.enabled() ? load(HISTORY_KEY, []) : [];
+    },
+    add(item){
+      if(!this.enabled()) return;
+      const list = load(HISTORY_KEY, []);
+      const id = item.id;
+      const idx = list.findIndex(it => it.id === id && it.type === item.type);
+      if(idx >= 0) list.splice(idx,1);
+      item.lastPlayedAt = new Date().toISOString();
+      list.unshift(item);
+      if(list.length > 30) list.length = 30;
+      save(HISTORY_KEY, list);
+    },
+    clear(){
+      try{ localStorage.removeItem(HISTORY_KEY); }catch(e){}
+    }
+  };
+
+  const trendingService = {
+    _signals(){ return load(TRENDING_KEY, {}); },
+    _save(sig){ save(TRENDING_KEY, sig); },
+    recordClick(item){
+      const sig = this._signals();
+      const id = item.id;
+      const now = new Date().toISOString();
+      sig[id] = sig[id] || {clicks:0, firstSeen:now, lastSeen:now, type:item.type};
+      sig[id].clicks += 1;
+      sig[id].lastSeen = now;
+      sig[id].type = item.type || sig[id].type;
+      this._save(sig);
+    },
+    clear(){ try{ localStorage.removeItem(TRENDING_KEY); }catch(e){} },
+    getRanking(items){
+      const sig = this._signals();
+      const map = {};
+      items.forEach(it => { map[it.key] = it; });
+      const now = Date.now();
+      const scored = Object.keys(sig).map(id => {
+        const s = sig[id];
+        const it = map[id];
+        if(!it) return null;
+        const isNew = s.firstSeen && (now - new Date(s.firstSeen).getTime() < 7*86400*1000) ? 1 : 0;
+        const isLive = it.status && it.status.active ? 1 : 0;
+        const score = 3*(s.clicks||0) + 2*isNew + 1*isLive;
+        return {item:it, score};
+      }).filter(Boolean);
+      scored.sort((a,b) => b.score - a.score);
+      return scored.map(x => x.item);
+    }
+  };
+
+  window.historyService = historyService;
+  window.trendingService = trendingService;
+
+  function thumbOf(it){ return it.media && (it.media.thumbnail_url || it.media.logo_url) || '/assets/avatar-fallback.png'; }
+  function displayName(it){ return it.name || it.title || it.key || 'Untitled'; }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    const rails = document.querySelectorAll('.lazy-rail');
+    if('IntersectionObserver' in window){
+      const obs = new IntersectionObserver(entries => {
+        entries.forEach(e => {
+          if(e.isIntersecting){
+            renderRail(e.target.id);
+            obs.unobserve(e.target);
+          }
+        });
+      });
+      rails.forEach(r => obs.observe(r));
+    } else {
+      rails.forEach(r => renderRail(r.id));
+    }
+
+    document.addEventListener('click', function(ev){
+      const link = ev.target.closest('a[data-trend-id]');
+      if(link){
+        trendingService.recordClick({id:link.getAttribute('data-trend-id'), type:link.getAttribute('data-trend-type')});
+      }
+    });
+  });
+
+  function renderRail(id){
+    if(id === 'continue-rail') return renderContinue();
+    if(id === 'trending-rail') return renderTrending();
+  }
+
+  function renderContinue(){
+    const container = document.getElementById('continue-rail');
+    if(!container) return;
+    const list = historyService.get().slice(0,10);
+    if(list.length === 0){ container.remove(); return; }
+    container.innerHTML = '';
+    const header = document.createElement('div');
+    header.className = 'rail-header';
+    const title = document.createElement('h2');
+    title.textContent = 'Continue Watching and Listening';
+    title.setAttribute('aria-label', 'Continue Watching and Listening');
+    const clear = document.createElement('button');
+    clear.textContent = 'Clear history';
+    clear.className = 'clear-btn';
+    clear.addEventListener('click', () => {
+      if(confirm('Clear local history?')){ historyService.clear(); container.remove(); }
+    });
+    header.appendChild(title);
+    header.appendChild(clear);
+    const rail = document.createElement('div');
+    rail.className = 'rail-cards';
+    list.forEach(it => {
+      const a = document.createElement('a');
+      a.className = 'rail-card';
+      a.href = it.url;
+      a.setAttribute('data-trend-id', it.id);
+      a.setAttribute('data-trend-type', it.type);
+      const img = document.createElement('img');
+      img.src = it.poster;
+      img.alt = it.title;
+      a.appendChild(img);
+      const name = document.createElement('div');
+      name.className = 'rail-title';
+      name.textContent = it.title;
+      a.appendChild(name);
+      if(it.progressSeconds && it.durationSeconds){
+        const perc = Math.min(100, Math.floor((it.progressSeconds/it.durationSeconds)*100));
+        const bar = document.createElement('div');
+        bar.className = 'rail-progress';
+        const inner = document.createElement('div');
+        inner.className = 'rail-progress-inner';
+        inner.style.width = perc + '%';
+        bar.appendChild(inner);
+        bar.setAttribute('aria-valuenow', String(perc));
+        bar.setAttribute('aria-label', 'Watched ' + perc + '%');
+        a.appendChild(bar);
+      }
+      rail.appendChild(a);
+    });
+    container.appendChild(header);
+    container.appendChild(rail);
+  }
+
+  function renderTrending(){
+    const container = document.getElementById('trending-rail');
+    if(!container) return;
+    container.innerHTML = '';
+    fetch('/all_streams.json').then(r=>r.json()).then(data => {
+      const items = trendingService.getRanking(data.items || []).slice(0,12);
+      if(items.length < 3){ container.remove(); return; }
+      const title = document.createElement('h2');
+      title.textContent = 'Trending Now';
+      title.setAttribute('aria-label', 'Trending Now');
+      const rail = document.createElement('div');
+      rail.className = 'rail-cards';
+      items.forEach(it => {
+        const mode = (it.category || it.type || '').toLowerCase();
+        const id = it.ids && it.ids.internal_id ? it.ids.internal_id : it.key;
+        const url = '/media-hub.html?c=' + encodeURIComponent(id) + '&m=' + mode;
+        const a = document.createElement('a');
+        a.className = 'rail-card';
+        a.href = url;
+        a.setAttribute('data-trend-id', id);
+        a.setAttribute('data-trend-type', mode);
+        const img = document.createElement('img');
+        img.src = thumbOf(it);
+        img.alt = displayName(it);
+        a.appendChild(img);
+        const name = document.createElement('div');
+        name.className = 'rail-title';
+        name.textContent = displayName(it);
+        a.appendChild(name);
+        rail.appendChild(a);
+      });
+      container.appendChild(title);
+      container.appendChild(rail);
+    }).catch(() => container.remove());
+  }
+})();

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -820,6 +820,20 @@ async function renderLatestVideosRSS(channelId) {
     }
 
     updateActiveUI();
+
+    if (window.historyService) {
+      const m = modeOfItem(item);
+      window.historyService.add({
+        id: item.key,
+        type: m,
+        title: displayName(item),
+        url: '/media-hub.html?c=' + encodeURIComponent(item.key) + '&m=' + m,
+        poster: thumbOf(item)
+      });
+    }
+    if (window.trendingService) {
+      window.trendingService.recordClick({ id: item.key, type: modeOfItem(item) });
+    }
   }
 
   // ---- Radio playback ----
@@ -859,6 +873,21 @@ async function renderLatestVideosRSS(channelId) {
     if (liveBadge) liveBadge.hidden = true;
     if (notLiveBadge) notLiveBadge.hidden = false;
     updateDetails(item);
+
+    if (window.historyService) {
+      const id = item.ids?.internal_id || item.key;
+      window.historyService.add({
+        id,
+        type: 'radio',
+        title: name,
+        url: '/media-hub.html?m=radio&c=' + encodeURIComponent(id),
+        poster: logoUrl || thumbOf(item)
+      });
+    }
+    if (window.trendingService) {
+      const id = item.ids?.internal_id || item.key;
+      window.trendingService.recordClick({ id, type: 'radio' });
+    }
 
     if (mainPlayer) {
       mainPlayer.src = audio.src;

--- a/media-hub.html
+++ b/media-hub.html
@@ -24,7 +24,10 @@
 </head>
 <body>
   <!-- Top bar (same as site) -->
-  {% include top-bar.html %}
+{% include top-bar.html %}
+
+  <section id="trending-rail" class="rail-section lazy-rail" aria-label="Trending Now"></section>
+  <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
   <section class="youtube-section media-hub-section">
     <div class="mode-tabs">
@@ -104,7 +107,7 @@
     <nav class="footer-nav">
       <a href="/about.html">About Us</a>
       <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/privacy.html">Privacy &amp; History</a>
     <a href="/terms.html">Terms</a>
   </nav>
     {% include support-us.html %}
@@ -115,6 +118,7 @@
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/discovery.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,7 @@
   <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
-  <title>PakStream - Privacy Policy</title>
+  <title>PakStream - Privacy &amp; History</title>
   <meta name="description" content="Stream Pakistani TV channels, radio stations, independent news, and political talk shows — all in one place. Stay connected to Pakistan from anywhere in the world.">
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="Chatdroid AB">
@@ -70,12 +70,18 @@
 
   <!-- Privacy policy content -->
 <section>
-  <h2>Privacy Policy</h2>
+  <h2>Privacy &amp; History</h2>
   <p>At PakStream, your privacy is important. This website uses cookies to deliver and improve the service. We use Google Analytics to understand how visitors interact with the site, and we plan to integrate Google Ads which may also use cookies for ad personalisation.</p>
   <p>We do not collect personal data directly. Any information gathered through cookies is processed by Google in accordance with their policies. You can manage your cookie preferences through your browser settings or via the cookie consent banner.</p>
-  <p>If you have any privacy concerns or questions, feel free to contact me at:  
+  <p>If you have any privacy concerns or questions, feel free to contact me at:
     <a href="mailto:atif.sheikh87@gmail.com">atif.sheikh87@gmail.com</a>
   </p>
+
+  <div class="history-panel">
+    <p>Personalization features like Continue Watching use only local storage on this device.</p>
+    <label><input type="checkbox" id="history-enable"> Enable watch/listen history</label>
+    <button id="history-clear" type="button">Clear local history</button>
+  </div>
 </section>
 
 
@@ -89,12 +95,30 @@
     <nav class="footer-nav">
       <a href="/about.html">About Us</a>
       <a href="/contact.html">Contact</a>
-      <a href="/privacy.html">Privacy Policy</a>
+      <a href="/privacy.html">Privacy &amp; History</a>
     <a href="/terms.html">Terms</a>
     </nav>
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      const toggle = document.getElementById('history-enable');
+      const btn = document.getElementById('history-clear');
+      const enabled = window.historyService ? window.historyService.enabled() : true;
+      if(toggle) toggle.checked = enabled;
+      if(toggle) toggle.addEventListener('change', function(){
+        try{ localStorage.setItem('pakstream.user.history.enabled', this.checked ? '1':'0'); }catch(e){}
+      });
+      if(btn) btn.addEventListener('click', function(){
+        if(confirm('Clear local history?')){
+          if(window.historyService) window.historyService.clear();
+          if(window.trendingService) window.trendingService.clear();
+        }
+      });
+    });
+  </script>
+  <script defer src="/js/discovery.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement client-side history and trending services backed by localStorage
- surface Continue Watching/Listening and Trending Now rails on Home and Media Hub
- add privacy controls to enable/clear local history

## Testing
- ⚠️ `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57df8b15c8320905f9c04f8a7f9e3