### PR TITLE
feat(discoverability): add faceted filters and shareable URLs

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -22,8 +22,64 @@
   grid-template-columns: 72px 1fr 24px;
   column-gap: 0;
 }
-.media-hub-section .mode-tabs {
+.media-hub-section .hub-controls {
   grid-area: tabs;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--surface);
+  padding: 8px 0 10px;
+  border-bottom: 1px solid var(--outline);
+}
+.hub-controls .mode-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  margin-bottom: 8px;
+}
+.hub-controls .filters-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.hub-controls select,
+.hub-controls input[type="text"] {
+  padding: 6px 8px;
+  border: 1px solid var(--outline);
+  background: var(--surface);
+  color: var(--on-surface);
+  border-radius: 8px;
+}
+.hub-controls .live-filter {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.selected-filters {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.selected-filters .chip {
+  background: var(--surface-variant);
+  border-radius: 16px;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.selected-filters .chip button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  font-size: 16px;
+}
+.results-count {
+  margin-top: 4px;
 }
 .media-hub-section #left-rail {
   grid-area: left;

--- a/media-hub.html
+++ b/media-hub.html
@@ -31,22 +31,32 @@
   <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
   <section class="youtube-section media-hub-section">
-    <div class="mode-tabs">
-      <button class="tab-btn" data-mode="all">All</button>
-      <button class="tab-btn" data-mode="favorites">Favorites</button>
-      <button class="tab-btn" data-mode="tv">Live TV</button>
-      <button class="tab-btn" data-mode="freepress">Free Press</button>
-      <button class="tab-btn" data-mode="creator">Creators</button>
-      <button class="tab-btn" data-mode="radio">Radio</button>
+    <div id="hub-controls" class="hub-controls">
+      <div class="mode-tabs" role="tablist">
+        <button class="tab-btn" data-mode="all" role="tab">All</button>
+        <button class="tab-btn" data-mode="tv" role="tab">TV</button>
+        <button class="tab-btn" data-mode="radio" role="tab">Radio</button>
+        <button class="tab-btn" data-mode="creator" role="tab">Creators</button>
+      </div>
+      <div class="filters-row">
+        <select id="topic-filter" multiple aria-label="Filter by topic"></select>
+        <select id="lang-filter" multiple aria-label="Filter by language"></select>
+        <select id="region-filter" multiple aria-label="Filter by region"></select>
+        <label class="live-filter"><input type="checkbox" id="live-filter"> Live Now</label>
+        <select id="sort-select" aria-label="Sort results">
+          <option value="trending">Trending</option>
+          <option value="recent">Most Recent</option>
+          <option value="az">A → Z</option>
+          <option value="played">Recently Played</option>
+        </select>
+        <input id="mh-search-input" type="text" placeholder="Search…" aria-label="Search media" />
+        <button id="reset-filters" type="button">Reset</button>
+      </div>
+      <div id="selected-filters" class="selected-filters" aria-live="polite"></div>
+      <div id="results-count" class="results-count" aria-live="polite"></div>
     </div>
     <!-- LEFT RAIL -->
     <div class="channel-list open" id="left-rail">
-      <!-- NEW: search at the top of left menu -->
-      <div class="left-rail-header">
-        <div class="search-wrap">
-          <input id="mh-search-input" type="text" placeholder="Search…" />
-        </div>
-      </div>
       <!-- list gets injected here -->
     </div>
 


### PR DESCRIPTION
## Summary
- add Media Hub controls bar with tabs, filters, sort, search and reset
- derive lightweight facets client side and filter results with URL + localStorage persistence
- render chips and result count with sticky controls for mobile

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/media-hub.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5822c1aec832095413238d82d50b9