### PR TITLE
feat(player): add docked mini-player with PiP support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,6 +54,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -76,6 +77,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/creators.html
+++ b/creators.html
@@ -41,6 +41,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -477,6 +478,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/css/mini-player.css
+++ b/css/mini-player.css
@@ -1,0 +1,62 @@
+#mini-player {
+  position: fixed;
+  bottom: calc(16px + env(safe-area-inset-bottom));
+  right: 16px;
+  width: 320px;
+  max-width: 90vw;
+  background: var(--color-bg, #000);
+  color: var(--color-text, #fff);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  border-radius: 8px;
+  z-index: 1000;
+  display: none;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+#mini-player .mini-media {
+  width: 100%;
+  background: #000;
+}
+#mini-player:not(.mini-radio) .mini-media {
+  height: 180px;
+}
+#mini-player.mini-radio {
+  height: 88px;
+}
+#mini-player .mini-media iframe,
+#mini-player .mini-media video,
+#mini-player .mini-media audio {
+  width: 100%;
+  height: 100%;
+}
+#mini-player .mini-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(0,0,0,0.7);
+}
+#mini-player button {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 8px;
+  cursor: pointer;
+  font-size: 16px;
+}
+#mini-player .mini-title {
+  padding: 4px 8px;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+@media (max-width: 768px) {
+  #mini-player {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    border-radius: 0;
+  }
+}

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -56,6 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -548,6 +549,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/freepress.html
+++ b/freepress.html
@@ -56,6 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -559,6 +560,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -330,6 +331,7 @@
     });
   </script>
   <script defer src="/js/discovery.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/mini-player.js
+++ b/js/mini-player.js
@@ -1,0 +1,178 @@
+(function(){
+  const events = {
+    start: new Event('session:start'),
+    pause: new Event('session:pause'),
+    resume: new Event('session:resume'),
+    end: new Event('session:end')
+  };
+
+  function dispatch(type){
+    document.dispatchEvent(events[type]);
+  }
+
+  function init(){
+    attachWhenReady();
+  }
+
+  function attachWhenReady(){
+    let media = document.querySelector('video, iframe#playerFrame, audio#radio-player');
+    if(media){
+      attach(media);
+      return;
+    }
+    const mo = new MutationObserver(()=>{
+      media = document.querySelector('video, iframe#playerFrame, audio#radio-player');
+      if(media){
+        mo.disconnect();
+        attach(media);
+      }
+    });
+    mo.observe(document.body,{childList:true,subtree:true});
+  }
+
+  function attach(media){
+    const container = media.closest('#player-container') || media.parentElement;
+    const isRadio = media.tagName.toLowerCase() === 'audio';
+
+    const mini = document.createElement('div');
+    mini.id = 'mini-player';
+    mini.setAttribute('role','region');
+    mini.setAttribute('aria-label','Mini player');
+    mini.innerHTML = `
+      <div class="mini-media"></div>
+      <div class="mini-title"></div>
+      <div class="mini-controls">
+        <button class="mini-play" aria-label="Play/Pause">⏯</button>
+        <button class="mini-mute" aria-label="Mute">🔇</button>
+        <button class="mini-pip" aria-label="Picture-in-Picture" hidden>🗖</button>
+        <button class="mini-expand" aria-label="Expand">⬆️</button>
+        <button class="mini-close" aria-label="Close">✕</button>
+      </div>`;
+    document.body.appendChild(mini);
+
+    const miniMedia = mini.querySelector('.mini-media');
+    const playBtn = mini.querySelector('.mini-play');
+    const muteBtn = mini.querySelector('.mini-mute');
+    const pipBtn = mini.querySelector('.mini-pip');
+    const expandBtn = mini.querySelector('.mini-expand');
+    const closeBtn = mini.querySelector('.mini-close');
+    const titleEl = mini.querySelector('.mini-title');
+
+    const placeholder = document.createElement('div');
+    let docked = false;
+
+    function placeMini(){
+      const ads = Array.from(document.querySelectorAll('.ad-container')).find(el=>{
+        const style = window.getComputedStyle(el);
+        if(style.position !== 'fixed') return false;
+        const r = el.getBoundingClientRect();
+        return r.bottom >= window.innerHeight - 50;
+      });
+      if(ads){ mini.style.right='auto'; mini.style.left='16px'; }
+      else { mini.style.left='auto'; mini.style.right='16px'; }
+    }
+
+    function dock(reason){
+      if(docked) return;
+      placeholder.style.display='block';
+      placeholder.style.width = container.offsetWidth + 'px';
+      placeholder.style.height = container.offsetHeight + 'px';
+      container.parentNode.insertBefore(placeholder, container);
+      miniMedia.appendChild(container);
+      container.style.width = '100%';
+      container.style.height = '100%';
+      if(isRadio) mini.classList.add('mini-radio');
+      placeMini();
+      mini.style.display='block';
+      docked = true;
+      dispatch('start');
+      console.log('mini_player_shown', {reason});
+      window.addEventListener('scroll', onScroll, {passive:true});
+    }
+
+    function undock(){
+      if(!docked) return;
+      placeholder.parentNode.insertBefore(container, placeholder);
+      placeholder.remove();
+      mini.style.display='none';
+      docked = false;
+      dispatch('end');
+      console.log('mini_player_hidden');
+      window.removeEventListener('scroll', onScroll);
+    }
+
+    function onScroll(){
+      if(docked && isInViewport(placeholder)) undock();
+    }
+
+    const obs = new IntersectionObserver(entries=>{
+      const e = entries[0];
+      if(!docked && e.intersectionRatio < 0.2 && !isInViewport(container)) dock('scroll');
+    }, {threshold:[0,0.25]});
+
+    function startObserver(){
+      obs.observe(container);
+    }
+
+    if(media.tagName.toLowerCase() === 'iframe'){
+      if(media.src && media.src !== 'about:blank') startObserver();
+      media.addEventListener('load',()=>{
+        if(media.src && media.src !== 'about:blank') startObserver();
+      });
+    } else {
+      media.addEventListener('play', function onPlay(){
+        startObserver();
+        media.removeEventListener('play', onPlay);
+      });
+    }
+
+    playBtn.addEventListener('click', ()=>{
+      if(media.paused) { media.play(); dispatch('resume'); console.log('mini_player_action',{action:'play'}); }
+      else { media.pause(); dispatch('pause'); console.log('mini_player_action',{action:'pause'}); }
+    });
+
+    muteBtn.addEventListener('click', ()=>{
+      media.muted = !media.muted;
+      muteBtn.textContent = media.muted ? '🔈' : '🔇';
+      console.log('mini_player_action',{action:media.muted?'mute':'unmute'});
+    });
+
+    expandBtn.addEventListener('click', ()=>{ undock(); window.scrollTo({top:0,behavior:'smooth'}); console.log('mini_player_action',{action:'expand'});});
+
+    closeBtn.addEventListener('click', ()=>{ undock(); console.log('mini_player_action',{action:'close'});});
+
+
+    if(media.requestPictureInPicture){
+      pipBtn.hidden = false;
+      pipBtn.addEventListener('click', async ()=>{
+        try{
+          if(document.pictureInPictureElement){
+            await document.exitPictureInPicture();
+            console.log('mini_player_action',{action:'pip_exit'});
+          }else{
+            await media.requestPictureInPicture();
+            console.log('mini_player_action',{action:'pip_enter'});
+          }
+        }catch(e){}
+      });
+      media.addEventListener('enterpictureinpicture', ()=>{ mini.style.display='none'; });
+      media.addEventListener('leavepictureinpicture', ()=>{ if(!isInViewport(container)) mini.style.display='block'; });
+    }
+
+    function isInViewport(el){
+      const r = el.getBoundingClientRect();
+      return r.height > 0 && r.bottom > 0 && r.top < window.innerHeight;
+    }
+
+    document.addEventListener('keydown', e=>{
+      if(e.key === 'Escape' && docked){ undock(); }
+    });
+
+    titleEl.textContent = document.title;
+
+    media.addEventListener('playing', ()=>{ dispatch('resume'); });
+    media.addEventListener('pause', ()=>{ dispatch('pause'); });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/livetv.html
+++ b/livetv.html
@@ -56,6 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -468,6 +469,7 @@
   </script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub.html
+++ b/media-hub.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/css/mini-player.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -119,6 +120,7 @@
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/discovery.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -57,6 +57,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -599,6 +600,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   </script>
   <script src="/js/leftmenu.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure mini-player detects YouTube iframe and waits for playback before docking
- display mini-player controls with flexible layout for video or radio
- load mini-player assets on home, creators, free press and live TV pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5809a3e488320899e8b1ffd0b153f