### PR TITLE
feat(player): add docked mini-player with PiP for video & radio

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,6 +54,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -76,6 +77,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/creators.html
+++ b/creators.html
@@ -41,6 +41,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -477,6 +478,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/css/mini-player.css
+++ b/css/mini-player.css
@@ -1,0 +1,77 @@
+#mini-player {
+  position: fixed;
+  bottom: calc(16px + env(safe-area-inset-bottom));
+  right: 16px;
+  width: 320px;
+  max-width: 90vw;
+  background: var(--color-bg, #000);
+  color: var(--color-text, #fff);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  border-radius: 8px;
+  z-index: 1000;
+  display: none;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: all .3s ease;
+}
+#mini-player .mini-media {
+  width: 100%;
+  background: #000;
+}
+#mini-player:not(.mini-radio) .mini-media {
+  height: 180px;
+}
+#mini-player.mini-radio {
+  height: 88px;
+}
+#mini-player.mini-radio .mini-media {
+  display: none;
+}
+#mini-player .mini-media iframe,
+#mini-player .mini-media video,
+#mini-player .mini-media audio {
+  width: 100%;
+  height: 100%;
+}
+#mini-player .mini-progress {
+  height: 4px;
+  background: rgba(255,255,255,0.2);
+}
+#mini-player .mini-progress .mini-bar {
+  height: 100%;
+  width: 0;
+  background: var(--color-accent, #f00);
+}
+#mini-player .mini-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(0,0,0,0.7);
+}
+#mini-player button {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 8px;
+  cursor: pointer;
+  font-size: 16px;
+  min-width: 44px;
+  min-height: 44px;
+}
+#mini-player .mini-title {
+  padding: 4px 8px;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+@media (max-width: 768px) {
+  #mini-player {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    border-radius: 0;
+  }
+}

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -56,6 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -548,6 +549,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/freepress.html
+++ b/freepress.html
@@ -56,6 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -559,6 +560,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -330,6 +331,7 @@
     });
   </script>
   <script defer src="/js/discovery.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/mini-player.js
+++ b/js/mini-player.js
@@ -1,0 +1,214 @@
+(function(){
+  const events = {
+    start: new Event('session:start'),
+    pause: new Event('session:pause'),
+    resume: new Event('session:resume'),
+    end: new Event('session:end')
+  };
+
+  function dispatch(type){
+    document.dispatchEvent(events[type]);
+  }
+
+  let bound = false;
+  function init(){
+    attachWhenReady();
+  }
+
+  function attachWhenReady(){
+    if(bound) return;
+    bound = true;
+    const playHandler = e => {
+      const el = e.target;
+      if(!el.matches('video, audio#radio-player')) return;
+      attach(el);
+    };
+    document.addEventListener('play', playHandler, true);
+
+    const iframe = document.querySelector('iframe#playerFrame');
+    if(iframe){
+      const handle = ()=>{
+        if(iframe.src && iframe.src !== 'about:blank') attach(iframe);
+      };
+      handle();
+      iframe.addEventListener('load', handle);
+    }
+  }
+
+  function attach(media){
+    const container = media.closest('#player-container') || media;
+    const isRadio = media.tagName.toLowerCase() === 'audio';
+
+    const mini = document.getElementById('mini-player') || (()=>{
+      const el = document.createElement('div');
+      el.id = 'mini-player';
+      el.setAttribute('role','region');
+      el.setAttribute('aria-label','Mini player');
+      el.innerHTML = `
+        <div class="mini-media"></div>
+        <div class="mini-title"></div>
+        <div class="mini-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="mini-bar"></div></div>
+        <div class="mini-controls">
+          <button class="mini-play" aria-label="Play/Pause">⏯</button>
+          <button class="mini-mute" aria-label="Mute">🔇</button>
+          <button class="mini-pip" aria-label="Picture-in-Picture" hidden>🗖</button>
+          <button class="mini-expand" aria-label="Expand">⬆️</button>
+          <button class="mini-close" aria-label="Close">✕</button>
+        </div>`;
+      document.body.appendChild(el);
+      return el;
+    })();
+
+    const miniMedia = mini.querySelector('.mini-media');
+    const playBtn = mini.querySelector('.mini-play');
+    const muteBtn = mini.querySelector('.mini-mute');
+    const pipBtn = mini.querySelector('.mini-pip');
+    const expandBtn = mini.querySelector('.mini-expand');
+    const closeBtn = mini.querySelector('.mini-close');
+    const titleEl = mini.querySelector('.mini-title');
+    const progress = mini.querySelector('.mini-progress');
+    const bar = mini.querySelector('.mini-bar');
+
+    const placeholder = document.createElement('div');
+    let docked = false;
+
+    function placeMini(){
+      mini.style.top='';
+      mini.style.bottom='calc(16px + env(safe-area-inset-bottom))';
+      const ads = Array.from(document.querySelectorAll('.ad-container')).find(el=>{
+        const style = window.getComputedStyle(el);
+        if(style.position !== 'fixed') return false;
+        const r = el.getBoundingClientRect();
+        return r.bottom >= window.innerHeight - 50;
+      });
+      if(ads){ mini.style.right='auto'; mini.style.left='16px'; }
+      else { mini.style.left='auto'; mini.style.right='16px'; }
+    }
+
+    function dock(reason){
+      if(docked) return;
+      const rect = container.getBoundingClientRect();
+      placeholder.style.display='block';
+      placeholder.style.width = rect.width + 'px';
+      placeholder.style.height = rect.height + 'px';
+      container.parentNode.insertBefore(placeholder, container);
+      miniMedia.appendChild(container);
+      const t = media.currentTime || 0;
+      if(isRadio) mini.classList.add('mini-radio');
+      mini.style.width = rect.width + 'px';
+      mini.style.height = rect.height + 'px';
+      mini.style.top = rect.top + 'px';
+      mini.style.left = rect.left + 'px';
+      mini.style.display='block';
+      requestAnimationFrame(()=>{
+        placeMini();
+        mini.style.width = '320px';
+        mini.style.height = isRadio ? '88px' : '180px';
+      });
+      docked = true;
+      if(!isNaN(t)) media.currentTime = t;
+      dispatch('start');
+      console.log('mini_player_shown', {reason});
+      window.addEventListener('scroll', onScroll, {passive:true});
+    }
+
+    function undock(){
+      if(!docked) return;
+      placeholder.parentNode.insertBefore(container, placeholder);
+      placeholder.remove();
+      mini.style.display='none';
+      mini.style.top=''; mini.style.left=''; mini.style.right=''; mini.style.bottom='';
+      mini.style.width=''; mini.style.height='';
+      docked = false;
+      dispatch('end');
+      console.log('mini_player_hidden');
+      window.removeEventListener('scroll', onScroll);
+    }
+
+    function onScroll(){
+      if(docked && isInViewport(placeholder)) undock();
+    }
+
+    const obs = new IntersectionObserver(entries=>{
+      const e = entries[0];
+      if(!docked && e.intersectionRatio < 0.2 && !isInViewport(container)) dock('scroll');
+    }, {threshold:[0,0.25]});
+
+    function startObserver(){
+      obs.observe(container);
+    }
+
+    if(media.tagName.toLowerCase() === 'iframe'){
+      if(media.src && media.src !== 'about:blank') startObserver();
+      media.addEventListener('load',()=>{
+        if(media.src && media.src !== 'about:blank') startObserver();
+      });
+    } else {
+      media.addEventListener('play', function onPlay(){
+        startObserver();
+        media.removeEventListener('play', onPlay);
+      });
+    }
+
+    playBtn.addEventListener('click', ()=>{
+      if(media.paused) { media.play(); dispatch('resume'); console.log('mini_player_action',{action:'play'}); }
+      else { media.pause(); dispatch('pause'); console.log('mini_player_action',{action:'pause'}); }
+    });
+
+    muteBtn.addEventListener('click', ()=>{
+      media.muted = !media.muted;
+      muteBtn.textContent = media.muted ? '🔈' : '🔇';
+      console.log('mini_player_action',{action:media.muted?'mute':'unmute'});
+    });
+
+    expandBtn.addEventListener('click', ()=>{ undock(); window.scrollTo({top:0,behavior:'smooth'}); console.log('mini_player_action',{action:'expand'});});
+
+    closeBtn.addEventListener('click', ()=>{ undock(); console.log('mini_player_action',{action:'close'});});
+
+
+    if(media.requestPictureInPicture){
+      pipBtn.hidden = false;
+      pipBtn.addEventListener('click', async ()=>{
+        try{
+          if(document.pictureInPictureElement){
+            await document.exitPictureInPicture();
+            console.log('mini_player_action',{action:'pip_exit'});
+          }else{
+            await media.requestPictureInPicture();
+            console.log('mini_player_action',{action:'pip_enter'});
+          }
+        }catch(e){}
+      });
+      media.addEventListener('enterpictureinpicture', ()=>{ mini.style.display='none'; });
+      media.addEventListener('leavepictureinpicture', ()=>{ if(!isInViewport(container)) mini.style.display='block'; });
+    }
+
+    function isInViewport(el){
+      const r = el.getBoundingClientRect();
+      return r.height > 0 && r.bottom > 0 && r.top < window.innerHeight;
+    }
+
+    document.addEventListener('keydown', e=>{
+      if(e.key === 'Escape' && docked){ undock(); }
+    });
+
+    titleEl.textContent = media.getAttribute('title') || document.title;
+
+    if(!isRadio && media.tagName.toLowerCase()==='video'){
+      media.addEventListener('timeupdate', ()=>{
+        if(media.duration){
+          const p = (media.currentTime/media.duration)*100;
+          bar.style.width = p + '%';
+          progress.setAttribute('aria-valuenow', p.toFixed(0));
+        }
+      });
+    } else {
+      progress.style.display='none';
+    }
+
+    media.addEventListener('playing', ()=>{ dispatch('resume'); });
+    media.addEventListener('pause', ()=>{ dispatch('pause'); });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/livetv.html
+++ b/livetv.html
@@ -56,6 +56,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -468,6 +469,7 @@
   </script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub.html
+++ b/media-hub.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/css/mini-player.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -119,6 +120,7 @@
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/discovery.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -57,6 +57,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/mini-player.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -599,6 +600,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   </script>
   <script src="/js/leftmenu.js"></script>
+  <script defer src="/js/mini-player.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add progress bar and larger touch targets to mini-player UI
- dock active video or radio element without hiding the main player
- initialize mini-player when playback begins and support Picture-in-Picture
- animate dock transition and keep radio controls visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5809a3e488320899e8b1ffd0b153f