### PR TITLE
Load feature card iframes sequentially

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
       <h3>Free Press</h3>
       <p>Stay updated with the latest new from Independent Voices.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
     </div>
@@ -131,7 +131,7 @@
       <h3>Popular Radio Stations</h3>
       <p>Listen to trending Pakistani radio.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
     </div>
@@ -140,7 +140,7 @@
       <h3>Live TV Channels</h3>
       <p>Watch the most viewed live TV streams.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
     </div>
@@ -149,7 +149,7 @@
       <h3>Trending Creators</h3>
       <p>Watch the latest from Pakistani creators.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
     </div>
@@ -158,7 +158,7 @@
       <h3>All Streams</h3>
       <p>Browse every channel in one place.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
     </div>
@@ -167,7 +167,7 @@
       <h3>Your Favorites</h3>
       <p>Quick access to your saved channels.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
     </div>
@@ -270,28 +270,12 @@
 
       const canHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches && navigator.maxTouchPoints === 0;
       const isLaptop = canHover && window.matchMedia('(min-width: 1024px)').matches;
+      const cardArray = Array.from(cards);
 
       if (canHover) {
-        let freepressCard = null;
-        let fpIframe = null;
-        if (isLaptop) {
-          freepressCard = document.querySelector('.feature-card[data-m="freepress"]');
-          if (freepressCard) {
-            fpIframe = freepressCard.querySelector('iframe');
-            if (fpIframe) {
-              const unmute = () => sendMuteMessage(fpIframe, false);
-              fpIframe.addEventListener('load', unmute);
-              unmute();
-            }
-          }
-        }
-
-        const cardArray = Array.from(cards);
         cardArray.forEach(card => {
           const iframe = card.querySelector('iframe');
           if (!iframe) return;
-          const isFreepress = isLaptop && card === freepressCard;
-          sendPlayMessage(iframe, isFreepress);
           card.addEventListener('mouseenter', () => {
             cardArray.forEach(c => {
               const ifr = c.querySelector('iframe');
@@ -307,7 +291,7 @@
           });
         });
       } else if ('IntersectionObserver' in window) {
-        cards.forEach(card => {
+        cardArray.forEach(card => {
           const iframe = card.querySelector('iframe');
           if (!iframe) return;
 
@@ -330,6 +314,27 @@
           iframe.addEventListener('load', applyState);
         });
       }
+
+      // Load iframes sequentially to avoid simultaneous autoplay
+      const iframes = cardArray.map(card => card.querySelector('iframe')).filter(Boolean);
+      let idx = 0;
+      const loadNext = () => {
+        if (idx >= iframes.length) return;
+        const iframe = iframes[idx];
+        const src = iframe.dataset.src;
+        if (src) iframe.src = src;
+        iframe.addEventListener('load', () => {
+          if (canHover) {
+            const play = idx === 0;
+            const unmute = play && isLaptop;
+            sendPlayMessage(iframe, play);
+            sendMuteMessage(iframe, !unmute);
+          }
+          idx++;
+          loadNext();
+        }, { once: true });
+      };
+      loadNext();
     });
   </script>
   <script defer src="/js/ad-config.js"></script>


### PR DESCRIPTION
## Summary
- Prevent simultaneous autoplay by loading home page feature card iframes one-by-one
- Start only the first feature card playing while muting the rest

## Testing
- `npx --yes htmlhint index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a593a0d2e483208ec9a66d8462668e