### PR TITLE
Add PWA support and consent dialog with install prompt

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -10,8 +10,10 @@
     <a href="/contact.html">Contact</a>
     <a href="/privacy.html">Privacy</a>
     <a href="/terms.html">Terms</a>
+    <a href="#" data-open-consent>Privacy &amp; Ads settings</a>
   </nav>
   <a href="https://buymeacoffee.com/pakstream" class="bmc-button" target="_blank" rel="noopener">Buy me a coffee ☕</a>
+  <button id="install-btn" class="install-btn" hidden>Install</button>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   <label for="nav-toggle" class="nav-overlay"></label>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,9 @@
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}">
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#0F5132" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#7EE2B8" media="(prefers-color-scheme: dark)">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -72,10 +75,15 @@
       <a href="/contact.html">Contact</a>
       <a href="/privacy.html">Privacy Policy</a>
       <a href="/terms.html">Terms</a>
+      <a href="#" data-open-consent>Privacy &amp; Ads settings</a>
     </nav>
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script defer src="/js/ad-config.js"></script>
+  <script defer src="/js/ad-slot.js"></script>
+  <script defer src="/js/consent.js"></script>
+  <script defer src="/js/pwa.js"></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -1378,3 +1378,70 @@ footer nav a:hover {
   background: var(--primary);
   border-radius: 2px;
 }
+
+.consent-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.consent-dialog {
+  background: var(--bg, #fff);
+  color: var(--text, #000);
+  padding: 1rem;
+  border-radius: 6px;
+  max-width: 320px;
+  outline: none;
+}
+.consent-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.consent-actions button {
+  flex: 1;
+  padding: 0.5rem;
+  min-height: 44px;
+}
+
+.install-btn {
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--primary);
+  color: var(--on-primary);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.install-banner,
+.sw-toast,
+.cache-label {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface);
+  color: var(--on-surface);
+  box-shadow: var(--shadow-md);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  z-index: 1000;
+}
+
+.install-banner { top: 0.5rem; }
+.sw-toast { bottom: 0.5rem; }
+.cache-label {
+  top: 0.5rem;
+  right: 0.5rem;
+  left: auto;
+  transform: none;
+  font-size: 0.8rem;
+  opacity: 0.85;
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#0F5132" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#7EE2B8" media="(prefers-color-scheme: dark)">
 
   <link rel="preload" as="image"
     href="/images/pakistan-abstract-380.webp"
@@ -334,6 +337,10 @@
       loadNext();
     });
   </script>
+  <script defer src="/js/ad-config.js"></script>
+  <script defer src="/js/ad-slot.js"></script>
+  <script defer src="/js/consent.js"></script>
+  <script defer src="/js/pwa.js"></script>
   <script defer src="/js/discovery.js"></script>
   <script defer src="/js/main.js"></script>
 </body>

--- a/js/ad-config.js
+++ b/js/ad-config.js
@@ -1,0 +1,1 @@
+// Ad configuration placeholder

--- a/js/ad-slot.js
+++ b/js/ad-slot.js
@@ -1,0 +1,1 @@
+// Ad slot logic placeholder

--- a/js/consent.js
+++ b/js/consent.js
@@ -1,0 +1,77 @@
+(function () {
+  const KEY = 'pak-consent';
+
+  function save(consent) {
+    localStorage.setItem(KEY, JSON.stringify(consent));
+    window.pakstreamConsent = consent;
+  }
+
+  function openDialog() {
+    if (document.getElementById('consent-overlay')) return;
+    const overlay = document.createElement('div');
+    overlay.id = 'consent-overlay';
+    overlay.className = 'consent-overlay';
+    overlay.innerHTML = `
+      <div class="consent-dialog" role="dialog" aria-modal="true" aria-labelledby="consent-title" tabindex="-1">
+        <h2 id="consent-title">Privacy & Ads</h2>
+        <p>We use cookies and local storage to personalise ads. You can accept or reject.</p>
+        <div class="consent-actions">
+          <button id="consent-accept">Accept all</button>
+          <button id="consent-reject">Reject all</button>
+          <button id="consent-manage">Manage choices</button>
+          <button id="consent-install" hidden>Install PakStream</button>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+    const dialog = overlay.querySelector('.consent-dialog');
+    dialog.focus();
+
+    function close() {
+      overlay.remove();
+    }
+    overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+    overlay.addEventListener('keydown', e => { if (e.key === 'Escape') close(); });
+    overlay.querySelector('#consent-accept').addEventListener('click', () => {
+      save({ personalizedAds: true });
+      close();
+      window.initAdSlots && window.initAdSlots();
+    });
+    overlay.querySelector('#consent-reject').addEventListener('click', () => {
+      save({ personalizedAds: false });
+      close();
+    });
+    overlay.querySelector('#consent-manage').addEventListener('click', () => {
+      // For now manage behaves same as reopen; keeping placeholder
+      close();
+      openDialog();
+    });
+    const installBtn = overlay.querySelector('#consent-install');
+    if (installBtn) {
+      installBtn.addEventListener('click', () => {
+        if (window.promptInstall) {
+          window.promptInstall();
+        } else {
+          alert('To install, use your browser menu and choose "Add to Home screen".');
+        }
+      });
+    }
+  }
+
+  function init() {
+    const stored = localStorage.getItem(KEY);
+    if (stored) {
+      window.pakstreamConsent = JSON.parse(stored);
+    } else {
+      openDialog();
+    }
+    document.querySelectorAll('[data-open-consent]').forEach(el => {
+      el.addEventListener('click', function (e) {
+        e.preventDefault();
+        openDialog();
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+  window.openConsentSettings = openDialog;
+})();

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,131 @@
+(function () {
+  let deferredPrompt = null;
+  const installBtn = document.getElementById('install-btn');
+
+  function showInstallUI() {
+    if (installBtn) installBtn.hidden = false;
+    document.querySelectorAll('#consent-install').forEach(btn => btn.hidden = false);
+    document.dispatchEvent(new Event('pwa-install-available'));
+    maybeShowBanner();
+    window.dataLayer && window.dataLayer.push({ event: 'pwa_install_prompt_shown' });
+  }
+
+  function maybeShowBanner() {
+    if (localStorage.getItem('pwa-banner-dismissed')) return;
+    const banner = document.createElement('div');
+    banner.id = 'install-banner';
+    banner.className = 'install-banner';
+    banner.innerHTML = '<span>Install PakStream?</span> <button id="banner-install">Install</button> <button id="banner-dismiss">Dismiss</button>';
+    document.body.appendChild(banner);
+    document.getElementById('banner-install').addEventListener('click', () => {
+      promptInstall();
+      dismiss();
+    });
+    document.getElementById('banner-dismiss').addEventListener('click', dismiss);
+    function dismiss() {
+      banner.remove();
+      localStorage.setItem('pwa-banner-dismissed', 'yes');
+    }
+  }
+
+  function promptInstall() {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    deferredPrompt.userChoice.finally(() => {
+      deferredPrompt = null;
+    });
+  }
+  window.promptInstall = promptInstall;
+
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    showInstallUI();
+  });
+
+  if (installBtn) {
+    installBtn.addEventListener('click', promptInstall);
+  }
+
+  window.addEventListener('appinstalled', () => {
+    if (installBtn) installBtn.hidden = true;
+    window.dataLayer && window.dataLayer.push({ event: 'pwa_installed' });
+  });
+
+  // Service Worker registration and updates
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js').then(reg => {
+      if (reg.waiting) {
+        showUpdateToast(reg);
+        window.dataLayer && window.dataLayer.push({ event: 'sw_update_available' });
+      }
+      reg.addEventListener('updatefound', () => {
+        const nw = reg.installing;
+        if (!nw) return;
+        nw.addEventListener('statechange', () => {
+          if (nw.state === 'installed' && navigator.serviceWorker.controller) {
+            showUpdateToast(reg);
+            window.dataLayer && window.dataLayer.push({ event: 'sw_update_available' });
+          }
+        });
+      });
+    });
+
+    let refreshing;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      if (refreshing) return;
+      refreshing = true;
+      window.location.reload();
+      window.dataLayer && window.dataLayer.push({ event: 'sw_updated' });
+    });
+
+    navigator.serviceWorker.addEventListener('message', event => {
+      if (event.data && event.data.type === 'json-fallback') {
+        showCacheLabel();
+      }
+    });
+  }
+
+  function showUpdateToast(reg) {
+    const toast = document.createElement('div');
+    toast.className = 'sw-toast';
+    toast.innerHTML = '<span>Update available</span> <button id="sw-update">Reload</button>';
+    document.body.appendChild(toast);
+    document.getElementById('sw-update').addEventListener('click', () => {
+      reg.waiting && reg.waiting.postMessage('skipWaiting');
+      toast.remove();
+    });
+  }
+
+  function updateOnline() {
+    const offline = !navigator.onLine;
+    document.querySelectorAll('button.play-pause-btn').forEach(btn => {
+      if (offline) {
+        if (!btn.dataset.offText) btn.dataset.offText = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = 'Connect to play';
+      } else {
+        btn.disabled = false;
+        if (btn.dataset.offText) btn.textContent = btn.dataset.offText;
+      }
+    });
+  }
+  window.addEventListener('online', updateOnline);
+  window.addEventListener('offline', updateOnline);
+  document.addEventListener('DOMContentLoaded', updateOnline);
+
+  if ((navigator.connection && navigator.connection.saveData) || window.matchMedia('(prefers-reduced-data: reduce)').matches) {
+    document.querySelectorAll('link[rel="prefetch"]').forEach(l => l.remove());
+  }
+
+  function showCacheLabel() {
+    let el = document.getElementById('cache-label');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'cache-label';
+      el.className = 'cache-label';
+      el.textContent = 'from cache';
+      document.body.appendChild(el);
+    }
+  }
+})();

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "PakStream",
+  "short_name": "PakStream",
+  "description": "Your gateway to Pakistani TV, Radio & Free Press",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#0F5132",
+  "background_color": "#FAFAFA",
+  "icons": [
+    {"src": "/images/icons/icon-192-maskable.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable"},
+    {"src": "/images/icons/icon-256-maskable.png", "sizes": "256x256", "type": "image/png", "purpose": "any maskable"},
+    {"src": "/images/icons/icon-384-maskable.png", "sizes": "384x384", "type": "image/png", "purpose": "any maskable"},
+    {"src": "/images/icons/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable"}
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,28 +1,96 @@
-const CACHE_NAME = 'pakstream-image-cache-v1';
+const SHELL_CACHE = 'ps-shell-v1';
+const JSON_CACHE = 'ps-json-v1';
+const SHELL_ASSETS = [
+  '/',
+  '/index.html',
+  '/css/style.css',
+  '/css/theme.css',
+  '/js/main.js',
+  '/js/consent.js',
+  '/js/pwa.js',
+  '/favicon.ico',
+  '/manifest.webmanifest',
+  '/images/icons/icon-192-maskable.png',
+  '/images/icons/icon-256-maskable.png',
+  '/images/icons/icon-384-maskable.png',
+  '/images/icons/icon-512-maskable.png'
+];
 
 self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then(cache => cache.addAll(SHELL_ASSETS))
+  );
   self.skipWaiting();
 });
 
 self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => ![SHELL_CACHE, JSON_CACHE].includes(k)).map(k => caches.delete(k))
+    )).then(() => self.clients.claim())
+  );
 });
 
 self.addEventListener('fetch', event => {
   const req = event.request;
-  if (req.destination === 'image') {
-    event.respondWith(
-      caches.open(CACHE_NAME).then(cache =>
-        cache.match(req).then(resp => {
-          if (resp) return resp;
-          return fetch(req).then(networkResp => {
-            if (networkResp && networkResp.status === 200) {
-              cache.put(req, networkResp.clone());
-            }
-            return networkResp;
-          });
-        })
-      )
-    );
+  if (req.method !== 'GET') return;
+  const url = new URL(req.url);
+
+  if (req.destination === 'video' || req.destination === 'audio' ||
+      url.hostname.includes('youtube.com') || url.hostname.includes('ytimg.com') || url.hostname.includes('googlevideo.com')) {
+    return;
+  }
+
+  if (req.destination === 'style' || req.destination === 'script' || req.destination === 'font') {
+    event.respondWith(cacheFirst(req, SHELL_CACHE));
+    return;
+  }
+
+  if (url.pathname.endsWith('.json')) {
+    event.respondWith(networkFirst(req, JSON_CACHE));
+    return;
+  }
+});
+
+function cacheFirst(req, cacheName) {
+  return caches.open(cacheName).then(cache =>
+    cache.match(req).then(cached => {
+      if (cached) return cached;
+      return fetch(req).then(res => {
+        if (res && res.status === 200) {
+          cache.put(req, res.clone());
+        }
+        return res;
+      });
+    })
+  );
+}
+
+function networkFirst(req, cacheName) {
+  return Promise.race([
+    fetch(req).then(res => {
+      if (res && res.status === 200) {
+        const copy = res.clone();
+        caches.open(cacheName).then(cache => cache.put(req, copy));
+        return res;
+      }
+      throw new Error('Bad response');
+    }),
+    new Promise((_, reject) => setTimeout(reject, 3000))
+  ]).catch(() => {
+    return caches.open(cacheName).then(cache => cache.match(req)).then(res => {
+      if (res) {
+        self.clients.matchAll().then(clients => {
+          clients.forEach(client => client.postMessage({ type: 'json-fallback', url: req.url }));
+        });
+      }
+      return res;
+    });
+  });
+}
+
+self.addEventListener('message', event => {
+  if (event.data === 'skipWaiting') {
+    self.skipWaiting();
   }
 });


### PR DESCRIPTION
## Summary
- add Privacy & Ads settings link and install button in header
- integrate PWA assets, manifest and service worker caching
- introduce consent dialog and install handling scripts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a48871948320a8ab51423296541b