### PR TITLE
feat(blog+seo): add card grid and Article JSON-LD

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,27 +11,28 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <meta name="title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
-  <meta name="description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
-  <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
-  <meta name="author" content="PakStream by Chatdroid AB" />
+  <meta name="description" content="{{ page.description | default: page.excerpt | strip_html | truncate: 160 }}" />
+  <meta name="author" content="{{ page.author | default: 'PakStream by Chatdroid AB' }}" />
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}" />
-  <link rel="canonical" href="{{ page.url | absolute_url }}" />
+  <link rel="canonical" href="{{ page.canonical_url | default: page.url | absolute_url }}" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ page.url | absolute_url }}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="{{ page.canonical_url | default: page.url | absolute_url }}" />
   <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
-  <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
-  <meta property="og:image" content="/assets/pakstream-banner.jpg" />
+  <meta property="og:description" content="{{ page.description | default: page.excerpt | strip_html | truncate: 160 }}" />
+  <meta property="og:image" content="{{ page.image | default: '/images/blog-banner.png' | absolute_url }}" />
   <meta property="og:site_name" content="PakStream" />
+  <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+  {% if page.updated %}<meta property="article:modified_time" content="{{ page.updated | date_to_xmlschema }}" />{% endif %}
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="{{ page.url | absolute_url }}" />
+  <meta name="twitter:url" content="{{ page.canonical_url | default: page.url | absolute_url }}" />
   <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
-  <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
-  <meta name="twitter:image" content="/assets/pakstream-banner.jpg" />
+  <meta name="twitter:description" content="{{ page.description | default: page.excerpt | strip_html | truncate: 160 }}" />
+  <meta name="twitter:image" content="{{ page.image | default: '/images/blog-banner.png' | absolute_url }}" />
   <meta name="twitter:site" content="@PakStream" />
   <meta name="twitter:creator" content="@PakStream" />
 
@@ -39,14 +40,28 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "NewsMediaOrganization",
-    "name": "PakStream",
-    "url": "https://pakstream.com/",
-    "logo": "/assets/logo.png",
-    "sameAs": [
-      "https://facebook.com/PakStream",
-      "https://twitter.com/PakStream"
-    ]
+    "@type": "Article",
+    "headline": "{{ page.title }}",
+    "image": ["{{ page.image | default: '/images/blog-banner.png' | absolute_url }}"],
+    "datePublished": "{{ page.date | date_to_xmlschema }}",
+    {% if page.updated %}"dateModified": "{{ page.updated | date_to_xmlschema }}",
+    {% endif %}
+    "author": {
+      "@type": "Person",
+      "name": "{{ page.author | default: 'PakStream' }}"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "PakStream",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "{{ '/assets/logo.png' | absolute_url }}"
+      }
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "{{ page.canonical_url | default: page.url | absolute_url }}"
+    }
   }
   </script>
 
@@ -66,22 +81,18 @@
     <article class="post">
       <h1>{{ page.title }}</h1>
 
-      {% if page.date %}
-        <p class="post-meta">
-          📅 {{ page.date | date: "%B %d, %Y" }} 
-          · 🕓 {% assign words = content | number_of_words %}
-          {% assign read_time = words | divided_by: 200 | ceil %}
-          {{ read_time }} min read
-        </p>
-      {% endif %}
+      {% assign words = content | number_of_words %}
+      {% assign read_time = words | divided_by: 200 | ceil %}
+      <p class="post-meta">
+        {% if page.category %}<span class="post-category">{{ page.category }}</span> · {% endif %}
+        📅 {{ page.date | date: "%B %d, %Y" }}
+        {% if page.updated %}· Updated {{ page.updated | date: "%B %d, %Y" }}{% endif %}
+        · 🕓 {{ read_time }} min read
+        {% if page.author %}· {{ page.author }}{% endif %}
+      </p>
 
-      {% if page.author %}
-        <p class="post-author">By {{ page.author }}</p>
-      {% endif %}
-
-      {% if page.image %}
-        <img src="{{ page.image }}" alt="Featured image" class="post-featured-image" loading="lazy" />
-      {% endif %}
+      {% assign feature_img = page.image | default: '/images/blog-banner.png' %}
+      <img src="{{ feature_img }}" alt="Featured image" class="post-featured-image" loading="lazy" />
 
       <div class="post-content">
         {{ content }}
@@ -94,6 +105,20 @@
         <a href="https://twitter.com/intent/tweet?url={{ page.url | absolute_url }}&text={{ page.title }}" target="_blank">Twitter</a> |
         <a href="https://wa.me/?text={{ page.title }}%20{{ page.url | absolute_url }}" target="_blank">WhatsApp</a>
       </div>
+      <div class="related-posts">
+        <h2>Related Posts</h2>
+        <ul>
+          {% assign related = site.posts | where: 'category', page.category | where_exp: 'post', 'post.url != page.url' | limit: 3 %}
+          {% for post in related %}
+          <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      <nav class="post-nav">
+        {% if page.previous %}<a class="prev-post" href="{{ page.previous.url | relative_url }}">&larr; {{ page.previous.title }}</a>{% endif %}
+        {% if page.next %}<a class="next-post" href="{{ page.next.url | relative_url }}">{{ page.next.title }} &rarr;</a>{% endif %}
+      </nav>
 
       <!-- Cusdis Comments -->
       <div id="cusdis_thread"
@@ -103,7 +128,7 @@
            data-page-url="{{ site.url }}{{ page.url }}"
            data-page-title="{{ page.title }}">
       </div>
-      
+
       <script async defer src="https://cusdis.com/js/cusdis.es.js"></script>
 
     </article>

--- a/_posts/2025-07-29-welcome-to-blog.md
+++ b/_posts/2025-07-29-welcome-to-blog.md
@@ -1,8 +1,12 @@
 ---
 layout: post
 title: "Welcome to PakStream Blog"
+description: "Introducing the PakStream blog and the story behind building a home for overseas Pakistanis."
 date: 2025-07-29
+updated: 2025-07-29
 author: Atif Waqar
+category: Announcements
+tags: [pakstream, introduction]
 image: /images/blog-banner.png  # optional
 ---
 

--- a/blog.html
+++ b/blog.html
@@ -5,13 +5,25 @@ description: Insightful blogs covering Pakistani media, culture, and diaspora li
 ---
 <section class="blog-list">
   <h1>Latest Blog Posts</h1>
-
-  <ul>
+  <div class="blog-grid">
     {% for post in site.posts %}
-      <li class="blog-post-item">
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        <span class="post-date">{{ post.date | date: "%B %d, %Y" }}</span>
-      </li>
+      <article class="blog-card">
+        <a href="{{ post.url | relative_url }}" class="card-image">
+          <img src="{{ post.image | default: '/images/blog-banner.png' }}" alt="{{ post.title }}" loading="lazy">
+        </a>
+        <div class="card-content">
+          <p class="card-category">{{ post.category | default: 'General' }}</p>
+          <h2 class="card-title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+          <p class="card-excerpt">{{ post.description | default: post.excerpt | strip_html | truncate: 120 }}</p>
+          <p class="card-meta">
+            {{ post.date | date: "%B %d, %Y" }} ·
+            {% assign words = post.content | number_of_words %}
+            {% assign read_time = words | divided_by: 200 | ceil %}
+            {{ read_time }} min read ·
+            {{ post.author | default: 'PakStream' }}
+          </p>
+        </div>
+      </article>
     {% endfor %}
-  </ul>
+  </div>
 </section>

--- a/css/style.css
+++ b/css/style.css
@@ -439,37 +439,67 @@ section {
   background: color-mix(in srgb, var(--primary) 85%, black);
 }
 
-/* Blog list styling */
-.blog-list ul {
-  list-style: none;
+/* Blog list card grid */
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
   margin: 0;
   padding: 0;
 }
 
-.blog-post-item {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--surface-variant);
+.blog-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-variant);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
-.blog-post-item:last-child {
-  border-bottom: none;
+.blog-card img {
+  width: 100%;
+  aspect-ratio: 16/9;
+  object-fit: cover;
 }
 
-.blog-post-item a {
-  color: var(--primary);
+.blog-card .card-content {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.blog-card .card-category {
+  font-size: 0.85rem;
+  color: var(--on-surface-variant);
+  text-transform: uppercase;
+  margin: 0 0 4px;
+}
+
+.blog-card .card-title {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+}
+
+.blog-card .card-title a {
   text-decoration: none;
-  font-weight: 500;
+  color: var(--on-surface);
 }
 
-.blog-post-item a:hover {
+.blog-card .card-title a:hover {
   text-decoration: underline;
-  color: var(--hover-link);
 }
 
-.blog-post-item .post-date {
-  display: block;
-  margin-top: 4px;
+.blog-card .card-excerpt {
+  flex-grow: 1;
   font-size: 0.95rem;
+  color: var(--on-surface-variant);
+  margin: 0 0 8px;
+}
+
+.blog-card .card-meta {
+  font-size: 0.85rem;
   color: var(--on-surface-variant);
 }
 
@@ -1115,6 +1145,31 @@ table tbody tr.favorite {
   color: var(--on-surface);
 }
 
+.post-content p:first-of-type {
+  font-size: 1.125rem;
+  font-weight: 500;
+}
+
+.post-content blockquote {
+  border-left: 4px solid var(--primary);
+  margin: 16px 0;
+  padding-left: 16px;
+  color: var(--on-surface-variant);
+}
+
+.post-content pre {
+  background: var(--surface-variant);
+  padding: 12px;
+  overflow: auto;
+  border-radius: 6px;
+}
+
+.post-content code {
+  background: var(--surface-variant);
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
 .post-share {
   margin-top: 30px;
   font-size: 0.9em;
@@ -1126,6 +1181,42 @@ table tbody tr.favorite {
   text-decoration: none;
   margin-right: 10px;
   color: var(--accent-link);
+}
+
+.post-category {
+  text-transform: uppercase;
+  color: var(--on-surface-variant);
+}
+
+.related-posts {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid var(--outline);
+}
+
+.related-posts ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.related-posts li + li {
+  margin-top: 8px;
+}
+
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.post-nav a {
+  color: var(--accent-link);
+  text-decoration: none;
+}
+
+.post-nav a:hover {
+  text-decoration: underline;
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
## Summary
- convert blog index to responsive card grid with reading time and author details
- enhance post layout with SEO meta tags and Article JSON-LD
- add related posts, navigation, and richer typography styles

## Testing
- `npx -y htmlhint blog.html _layouts/post.html`
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a5abf5d93c8320ad0d8e96d5589e49