### PR TITLE
Centralize CookieYes banner in default layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}</title>

--- a/about.html
+++ b/about.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - About</title>

--- a/contact.html
+++ b/contact.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - Contact</title>

--- a/creators.html
+++ b/creators.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Creators - Watch Popular Pakistani YouTubers</title>

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Free Press - Watch Independent Pakistani News Voices</title>

--- a/freepress.html
+++ b/freepress.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Free Press - Watch Independent Pakistani News Voices</title>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press</title>

--- a/livetv.html
+++ b/livetv.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Live TV - Watch Pakistani TV Channels Live</title>

--- a/media-hub.html
+++ b/media-hub.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <meta charset="UTF-8" />

--- a/nav.html
+++ b/nav.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <meta charset="UTF-8">
   <title>Navigation</title>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
   {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <title>PakStream - Onboard YouTube Channel</title>
   <meta charset="UTF-8">

--- a/privacy.html
+++ b/privacy.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - Privacy &amp; History</title>

--- a/radio.html
+++ b/radio.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream Radio - Listen to Pakistani Radio Stations Online</title>

--- a/terms.html
+++ b/terms.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Basic Meta Tags -->
   <title>PakStream - Terms &amp; Conditions</title>

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <!-- Standard Meta -->
   <title>PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press</title>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -4,9 +4,6 @@
 <html lang="en">
 <head>
 {% include google-tag-manager-head.html %}
-  <!-- Start cookieyes banner -->
-  <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
-  <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <title>PakStream - YouTube Playground</title>
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- keep CookieYes script in `_layouts/default.html`
- drop duplicate cookie banner snippets from individual HTML pages

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `gem install jekyll --no-document` *(fails: ERROR: Failed to build gem native extension)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b025529c832092d2e8928f6341b8