### PR TITLE
fix: streamline media hub embeds

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -422,3 +422,23 @@
 .stream-error-overlay .actions button {
   margin: 8px;
 }
+
+/* Embed mode overrides */
+.is-embed .hub-controls {
+  padding: 0;
+  border-bottom: 0;
+}
+
+.is-embed .media-hub-section {
+  row-gap: 0;
+}
+
+.is-embed .channel-list,
+.is-embed .details-container {
+  display: none !important;
+}
+
+.is-embed .media-hub-section {
+  grid-template-columns: 1fr !important;
+  grid-template-areas: "center";
+}

--- a/css/style.css
+++ b/css/style.css
@@ -420,6 +420,8 @@ section {
   height: auto;
   border: none;
   border-radius: 0.75rem;
+  display: block;
+  vertical-align: top;
 }
 
 .feature-card .cta-btn {

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -14,7 +14,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
-<body>
+<body class="is-embed">
   <section class="youtube-section media-hub-section">
     <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">


### PR DESCRIPTION
## Summary
- ensure `.media-hub-embed` iframes render flush by forcing block display and top alignment
- add `is-embed` layout overrides to hide padding and side panels for clean embeds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5baf51d3c8320af5610aae51a098e