### PR TITLE
Fix media hub embed spacing

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -422,3 +422,54 @@
 .stream-error-overlay .actions button {
   margin: 8px;
 }
+
+/* ===== Embed Mode: remove all extra spacing and side chrome ===== */
+.is-embed, .is-embed html, .is-embed body {
+  margin: 0 !important;
+  padding: 0 !important;
+  box-sizing: border-box;
+}
+
+.is-embed .youtube-section.media-hub-section {
+  margin: 0 !important;
+  padding: 0 !important;
+  row-gap: 0 !important;
+  column-gap: 0 !important;
+}
+
+/* Hide all non-video UI in the embed */
+.is-embed .hub-controls,
+.is-embed .button-row,
+.is-embed #left-rail,
+.is-embed .right-rail,
+.is-embed .page-header,
+.is-embed .page-footer,
+.is-embed .details-container {
+  display: none !important;
+}
+
+/* Let the center/video area take all the space */
+.is-embed .media-hub-section {
+  grid-template-columns: 1fr !important;
+  grid-template-areas: "center" !important;
+}
+
+.is-embed .video-section {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.is-embed .live-player {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Ensure the inner iframe fills correctly and has no border radius conflicts */
+.is-embed #playerFrame {
+  display: block !important;
+  width: 100% !important;
+  aspect-ratio: 16 / 9 !important;
+  height: auto !important;
+  border: 0 !important;
+  background: transparent !important;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -414,12 +414,19 @@ section {
   min-height: 3rem;
 }
 
+.media-hub-embed-wrap {
+  line-height: 0;          /* neutralize inline gaps in some engines */
+}
+
 .media-hub-embed {
   width: 100%;
   aspect-ratio: 16 / 9;
   height: auto;
   border: none;
   border-radius: 0.75rem;
+  display: block;           /* removes baseline gap */
+  vertical-align: top;
+  background: transparent;
 }
 
 .feature-card .cta-btn {

--- a/index.html
+++ b/index.html
@@ -120,7 +120,9 @@
       <h3>Free Press</h3>
       <p>Stay updated with the latest new from Independent Voices.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div class="media-hub-embed-wrap">
+          <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
       </section>
       <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
     </div>
@@ -129,7 +131,9 @@
       <h3>Popular Radio Stations</h3>
       <p>Listen to trending Pakistani radio.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div class="media-hub-embed-wrap">
+          <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
       </section>
       <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
     </div>
@@ -138,7 +142,9 @@
       <h3>Live TV Channels</h3>
       <p>Watch the most viewed live TV streams.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div class="media-hub-embed-wrap">
+          <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
       </section>
       <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
     </div>
@@ -147,7 +153,9 @@
       <h3>Trending Creators</h3>
       <p>Watch the latest from Pakistani creators.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div class="media-hub-embed-wrap">
+          <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
       </section>
       <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
     </div>
@@ -156,7 +164,9 @@
       <h3>All Streams</h3>
       <p>Browse every channel in one place.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div class="media-hub-embed-wrap">
+          <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
       </section>
       <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
     </div>
@@ -165,7 +175,9 @@
       <h3>Your Favorites</h3>
       <p>Quick access to your saved channels.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <div class="media-hub-embed-wrap">
+          <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
       </section>
       <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
     </div>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -14,7 +14,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
-<body>
+<body class="is-embed">
   <section class="youtube-section media-hub-section">
     <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">


### PR DESCRIPTION
## Summary
- Wrap homepage media hub iframes in `.media-hub-embed-wrap` to eliminate baseline gaps
- Add CSS rules to enforce block-level 16:9 embeds and neutralize inline spacing
- Enable `is-embed` mode and strip UI chrome in embedded media hub pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a5be8a19dc8320941958820075c999