### PR TITLE
Fix spacing for embedded video sections

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -1,4 +1,15 @@
 /* Layout: mode tabs on top, channel list and video section below */
+
+/* Embed mode: strip section chrome */
+.is-embed section.youtube-section.media-hub-section {
+  margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  max-width: none !important;
+}
+
 .media-hub-section {
   display: grid;
   grid-template-columns: 220px 1fr 300px;

--- a/css/style.css
+++ b/css/style.css
@@ -398,6 +398,16 @@ section {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+/* Remove global section spacing for inline video sections */
+.feature-card > section.youtube-section.media-hub-section {
+  margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  max-width: none !important;
+}
+
 .feature-card:hover,
 .feature-card:focus-within {
   transform: translateY(-4px) scale(1.02);


### PR DESCRIPTION
## Summary
- remove global section spacing within feature card YouTube embeds
- strip section spacing in embedded media hub mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c83188b083209dddb34c570a85ea