### PR TITLE
feat(stream-reliability): add unified stream state bus, smart retries with circuit breaker, backups/external fallbacks, and in-player error overlay wiring

### DIFF
--- a/js/stream-state.js
+++ b/js/stream-state.js
@@ -57,7 +57,8 @@
       const extBtn = overlay.querySelector('.open-external');
       retryBtn.addEventListener('click', () => {
         overlay.style.display = 'none';
-        bus.emit('retry');
+        // Manual retry resets attempt counter
+        bus.emit('retry', { manual: true });
       });
       extBtn.addEventListener('click', () => {
         bus.emit('open_external');
@@ -68,6 +69,81 @@
     bus.on('end', () => { overlay.style.display = 'none'; });
   }
 
+  // ---- Reliability helpers ----
+  const CB_KEY = 'stream.circuit';
+
+  function isCircuitOpen(id, url){
+    try {
+      const map = JSON.parse(localStorage.getItem(CB_KEY) || '{}');
+      const key = id + '|' + url;
+      const ts = map[key];
+      if (!ts) return false;
+      return Date.now() - ts < 15 * 60 * 1000; // 15 minutes
+    } catch(e){
+      return false;
+    }
+  }
+
+  function markCircuit(meta){
+    try {
+      const map = JSON.parse(localStorage.getItem(CB_KEY) || '{}');
+      const key = meta.id + '|' + meta.sourceUrl;
+      map[key] = Date.now();
+      localStorage.setItem(CB_KEY, JSON.stringify(map));
+    } catch(e){ }
+  }
+
+  function initStreamAutoRetry(bus, opts){
+    if (!bus) return;
+    const maxAttempts = (opts && opts.maxAttempts) || 4;
+    const base = (opts && opts.baseDelay) || 2000;
+    let retryTimer = null;
+
+    function schedule(reason){
+      if (bus.meta.attemptNo >= maxAttempts){
+        markCircuit(bus.meta);
+        return;
+      }
+      const delay = Math.min(base * Math.pow(2, bus.meta.attemptNo - 1), base * Math.pow(2, maxAttempts - 1));
+      const jitter = Math.random() * 1000;
+      retryTimer = setTimeout(() => {
+        bus.emit('retry', { reason });
+      }, delay + jitter);
+    }
+
+    bus.on('attempt', () => {
+      if (isCircuitOpen(bus.meta.id, bus.meta.sourceUrl)) {
+        bus.emit('error', { errorCode: 'circuit_open' });
+      }
+    });
+
+    bus.on('error', () => schedule('error'));
+    bus.on('stall', () => schedule('stall'));
+    bus.on('recover', () => { if (retryTimer) clearTimeout(retryTimer); });
+    bus.on('start', () => { if (retryTimer) clearTimeout(retryTimer); });
+    bus.on('end', () => { if (retryTimer) clearTimeout(retryTimer); });
+  }
+
+  function watchMediaStalls(media, bus, opts){
+    if (!media || !bus) return;
+    const limit = (opts && opts.stallMs) || 8000;
+    let timer, stalled = false;
+    function reset(){
+      if (timer) clearTimeout(timer);
+      if (stalled) { bus.emit('recover'); stalled = false; }
+      timer = setTimeout(() => {
+        if (media.readyState < 2) { stalled = true; bus.emit('stall', { reason: 'timeupdate' }); }
+      }, limit);
+    }
+    media.addEventListener('timeupdate', reset);
+    media.addEventListener('playing', reset);
+    media.addEventListener('stalled', () => { stalled = true; bus.emit('stall', { reason: 'stalled' }); reset(); });
+    bus.on('end', () => { if (timer) clearTimeout(timer); });
+    bus.on('error', () => { if (timer) clearTimeout(timer); });
+  }
+
   window.createStreamStateBus = createStreamStateBus;
   window.attachStreamErrorOverlay = attachStreamErrorOverlay;
+  window.initStreamAutoRetry = initStreamAutoRetry;
+  window.watchMediaStalls = watchMediaStalls;
 })();


### PR DESCRIPTION
## Summary
- enhance stream-state bus with manual retry flag, auto retry with jittered exponential backoff, and a simple circuit breaker
- monitor media elements for stalls and recoveries, emitting normalized events
- wire media-hub to use new helpers for YouTube and radio playback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ca091b8c83209315463903e24d33