### PR TITLE
Fix unclosed Liquid tag in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,5 +89,6 @@
   <script defer src="/js/maintenance.js"></script>
   <script defer src="/js/error-overlay.js"></script>
   <script defer src="/js/main.js"></script>
+  {% endunless %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- close `{% unless %}` block in default layout so page scripts render correctly

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a5cd3677c083209ee80a4afd4c6a6c