### PR TITLE
Remove deprecated trending feature

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,7 +27,6 @@ no_ads: true
 </section>
 <section class="nf-suggestions">
   <h2>Suggestions</h2>
-  <div id="nf-trending" class="nf-trending"></div>
   <div id="nf-recent" class="nf-recent"></div>
   <div class="nf-cats">
     <a class="chip" href="/media-hub.html?topic=news" data-analytics="suggestion">News</a>

--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -93,14 +93,14 @@
 .empty-state .suggestions .btn {
   margin: 4px;
 }
-.empty-state .trending-cards {
+.suggestion-cards {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 8px;
   margin-top: 16px;
 }
-.empty-state .trending-cards a {
+.suggestion-cards a {
   width: 120px;
   text-align: center;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1627,7 +1627,6 @@ body.maintenance-on .top-bar {
 .nf-suggestions {
   padding: 20px;
 }
-.nf-trending ul,
 .nf-recent ul {
   list-style: none;
   padding: 0;

--- a/index.html
+++ b/index.html
@@ -93,12 +93,11 @@
     </div>
   </section>
 
-  <section id="trending-rail" class="rail-section lazy-rail" aria-label="Trending Now"></section>
   <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
-  <section class="station-scroller-wrap" aria-label="Trending channels">
+  <section class="station-scroller-wrap" aria-label="Popular channels">
     <div class="scroller-header">
-      <h2 class="scroller-title">Trending Channels</h2>
+      <h2 class="scroller-title">Popular Channels</h2>
       <button class="scroller-toggle" type="button" aria-pressed="false" aria-label="Pause scrolling">Pause</button>
     </div>
 
@@ -127,7 +126,7 @@
     <div class="feature-card" data-m="radio" data-c="audio35">
       <span class="material-symbols-outlined">radio</span>
       <h3>Popular Radio Stations</h3>
-      <p>Listen to trending Pakistani radio.</p>
+      <p>Listen to Pakistani radio.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -144,7 +143,7 @@
     </div>
     <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
       <span class="material-symbols-outlined">person</span>
-      <h3>Trending Creators</h3>
+      <h3>Featured Creators</h3>
       <p>Watch the latest from Pakistani creators.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/js/404.js
+++ b/js/404.js
@@ -3,30 +3,6 @@ document.addEventListener('DOMContentLoaded', function(){
   if(title) title.focus();
   if(window.analytics) analytics('page_404_view');
 
-  // trending suggestions
-  fetch('/all_streams.json').then(function(r){return r.json();}).then(function(data){
-    if(!window.trendingService) return;
-    var items = window.trendingService.getRanking(data.items || []).slice(0,5);
-    var container = document.getElementById('nf-trending');
-    if(!container || items.length===0) return;
-    var h = document.createElement('h3');
-    h.textContent = 'Trending Now';
-    container.appendChild(h);
-    var ul = document.createElement('ul');
-    items.forEach(function(it){
-      var id = (it.ids && it.ids.internal_id) ? it.ids.internal_id : it.key;
-      var mode = (it.category || it.type || '').toLowerCase();
-      var li = document.createElement('li');
-      var a = document.createElement('a');
-      a.href = '/media-hub.html?c=' + encodeURIComponent(id) + '&m=' + mode;
-      a.textContent = it.name || it.title || id;
-      a.setAttribute('data-analytics','suggestion');
-      li.appendChild(a);
-      ul.appendChild(li);
-    });
-    container.appendChild(ul);
-  }).catch(function(){});
-
   // recently visited
   if(window.historyService){
     var recent = window.historyService.get().slice(0,5);

--- a/js/error-overlay.js
+++ b/js/error-overlay.js
@@ -39,7 +39,7 @@
     overlay.appendChild(actions);
     if(opts && Array.isArray(opts.suggestions) && opts.suggestions.length){
       var sugg = document.createElement('div');
-      sugg.className = 'trending-cards';
+      sugg.className = 'suggestion-cards';
       opts.suggestions.forEach(function(it){
         var a = document.createElement('a');
         a.href = it.url;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -13,7 +13,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     languages: [],
     regions: [],
     live: false,
-    sort: 'trending',
+    sort: 'az',
     q: ''
   };
   if (params.toString()) {
@@ -22,7 +22,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     state.languages = (params.get('lang') || '').split(',').filter(Boolean);
     state.regions = (params.get('region') || '').split(',').filter(Boolean);
     state.live = params.get('live') === '1';
-    state.sort = params.get('sort') || 'trending';
+    state.sort = params.get('sort') || 'az';
     state.q = params.get('q') || '';
   } else {
     Object.assign(state, loadState());
@@ -632,12 +632,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if(state.languages.length) arr = arr.filter(i => state.languages.includes(i.language));
     if(state.regions.length) arr = arr.filter(i => state.regions.includes(i.region));
     if(state.live) arr = arr.filter(i => i.isLive);
-    if(state.sort === 'trending' && window.trendingService){
-      const ranked = window.trendingService.getRanking(arr);
-      const ids = new Set(ranked.map(r => r.key));
-      const rest = arr.filter(i => !ids.has(i.key));
-      arr = ranked.concat(rest.sort((a,b)=>displayName(a).localeCompare(displayName(b))));
-    } else if(state.sort === 'recent'){
+    if(state.sort === 'recent'){
       arr.sort((a,b)=> new Date(b.firstSeen||0) - new Date(a.firstSeen||0));
     } else if(state.sort === 'played' && window.historyService){
       const hist = window.historyService.get();
@@ -686,7 +681,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         state.languages = [];
         state.regions = [];
         state.live = false;
-        state.sort = 'trending';
+        state.sort = 'az';
         state.q = '';
         updateState();
         if(window.analytics) analytics('empty_state_action',{action:'clear_all'});
@@ -725,22 +720,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       sugg.appendChild(nonlive);
       sugg.appendChild(allLang);
       empty.appendChild(sugg);
-      const trend = document.createElement('div');
-      trend.className = 'trending-cards';
-      if(window.trendingService){
-        const tItems = window.trendingService.getRanking(items).slice(0,6);
-        tItems.forEach(it => {
-          const id = (it.ids && it.ids.internal_id) ? it.ids.internal_id : it.key;
-          const modeIt = modeOfItem(it);
-          const a = document.createElement('a');
-          a.href = '/media-hub.html?c=' + encodeURIComponent(id) + '&m=' + modeIt;
-          a.className = 'btn';
-          a.textContent = displayName(it);
-          a.addEventListener('click', function(){ if(window.analytics) analytics('empty_state_action',{action:'suggestion_click'}); });
-          trend.appendChild(a);
-        });
-      }
-      empty.appendChild(trend);
       const cats = document.createElement('div');
       cats.className = 'nf-cats';
       ['news','music','talk','drama','sports'].forEach(cat => {
@@ -1012,9 +991,6 @@ async function renderLatestVideosRSS(channelId) {
         poster: thumbOf(item)
       });
     }
-    if (window.trendingService) {
-      window.trendingService.recordClick({ id: item.key, type: modeOfItem(item) });
-    }
   }
 
   // ---- Radio playback ----
@@ -1092,10 +1068,6 @@ async function renderLatestVideosRSS(channelId) {
         url: '/media-hub.html?m=radio&c=' + encodeURIComponent(id),
         poster: logoUrl || thumbOf(item)
       });
-    }
-    if (window.trendingService) {
-      const id = item.ids?.internal_id || item.key;
-      window.trendingService.recordClick({ id, type: 'radio' });
     }
 
     if (mainPlayer) {
@@ -1267,7 +1239,7 @@ async function renderLatestVideosRSS(channelId) {
     if(state.languages.length) p.set('lang', state.languages.join(','));
     if(state.regions.length) p.set('region', state.regions.join(','));
     if(state.live) p.set('live','1');
-    if(state.sort && state.sort !== 'trending') p.set('sort', state.sort);
+    if(state.sort && state.sort !== 'az') p.set('sort', state.sort);
     if(state.q) p.set('q', state.q);
     history.replaceState(null,'','?'+p.toString());
   }
@@ -1303,7 +1275,7 @@ async function renderLatestVideosRSS(channelId) {
     state.languages = [];
     state.regions = [];
     state.live = false;
-    state.sort = 'trending';
+    state.sort = 'az';
     state.q = '';
     updateState();
   });

--- a/media-hub.html
+++ b/media-hub.html
@@ -26,7 +26,6 @@
 {% include top-bar.html %}
 
   <main id="main-content">
-  <section id="trending-rail" class="rail-section lazy-rail" aria-label="Trending Now"></section>
   <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
   <section class="youtube-section media-hub-section">
@@ -43,9 +42,8 @@
         <select id="region-filter" multiple aria-label="Filter by region"></select>
         <label class="live-filter"><input type="checkbox" id="live-filter"> Live Now</label>
         <select id="sort-select" aria-label="Sort results">
-          <option value="trending">Trending</option>
-          <option value="recent">Most Recent</option>
           <option value="az">A → Z</option>
+          <option value="recent">Most Recent</option>
           <option value="played">Recently Played</option>
         </select>
         <input id="mh-search-input" type="text" placeholder="Search…" aria-label="Search media" />

--- a/privacy.html
+++ b/privacy.html
@@ -111,7 +111,6 @@
       if(btn) btn.addEventListener('click', function(){
         if(confirm('Clear local history?')){
           if(window.historyService) window.historyService.clear();
-          if(window.trendingService) window.trendingService.clear();
         }
       });
     });

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -103,9 +103,9 @@
     </div>
   </section>
 
-  <section class="station-scroller-wrap" aria-label="Trending channels">
+  <section class="station-scroller-wrap" aria-label="Popular channels">
     <div class="scroller-header">
-      <h2 class="scroller-title">Trending Channels</h2>
+      <h2 class="scroller-title">Popular Channels</h2>
       <button class="scroller-toggle" type="button" aria-pressed="false" aria-label="Pause scrolling">Pause</button>
     </div>
 
@@ -134,7 +134,7 @@
     <div class="feature-card" data-m="radio" data-c="audio35">
       <span class="material-symbols-outlined">radio</span>
       <h3>Popular Radio Stations</h3>
-      <p>Listen to trending Pakistani radio.</p>
+      <p>Listen to Pakistani radio.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -151,7 +151,7 @@
     </div>
     <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
       <span class="material-symbols-outlined">person</span>
-      <h3>Trending Creators</h3>
+      <h3>Featured Creators</h3>
       <p>Watch the latest from Pakistani creators.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- remove client-side trending service and all related tracking
- drop "Trending Now" rails and update labels to "Popular" or "Featured"
- simplify Media Hub sorting and suggestion styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c70cfc24832091343e3bcf928283