### PR TITLE
feat: establish color tokens and migrate core components

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -64,6 +64,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/about.html
+++ b/about.html
@@ -54,6 +54,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -1,0 +1,40 @@
+:root{
+  /* Brand */
+  --color-brand: #0F5132;        /* deep Pakistan green */
+  --color-brand-contrast: #FFFFFF;
+
+  /* Surfaces */
+  --surface-0: #FFFFFF;
+  --surface-1: #F7F9FC;
+  --surface-2: #EEF3F8;
+
+  /* Text */
+  --text-strong: #1A1F24;
+  --text-default: #232A2F;
+  --text-muted: #5A6B7A;
+
+  /* Accents */
+  --accent: #1E88E5;
+  --accent-contrast: #FFFFFF;
+
+  /* States */
+  --ok: #43A047; --warn: #FB8C00; --danger: #E53935;
+}
+
+/* Legacy variable mapping
+   --primary -> --color-brand
+   --on-primary -> --color-brand-contrast
+   --background -> --surface-0
+   --surface -> --surface-1
+   --surface-variant -> --surface-2
+   --on-surface -> --text-default
+   --on-surface-variant -> --text-muted
+   --accent-link -> --accent
+   --accent-link-visited -> --accent
+*/
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --surface-0:#101418; --surface-1:#121821; --text-default:#E6EDF3;
+  }
+}

--- a/contact.html
+++ b/contact.html
@@ -54,6 +54,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/creators.html
+++ b/creators.html
@@ -36,6 +36,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -278,13 +278,13 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  background: var(--surface);
+  background: var(--surface-1);
   border-radius: 14px;
   margin-bottom: 10px;
   box-shadow: var(--card-shadow, var(--shadow-xs));
 }
 .channel-card.active {
-  outline: 2px solid var(--primary);
+  outline: 2px solid var(--color-brand);
 }
 .channel-thumb {
   width: 40px;
@@ -306,7 +306,7 @@
 }
 .player-container .audio-wrap {
   padding: 14px;
-  background: var(--surface);
+  background: var(--surface-1);
 }
 
 .details-list {

--- a/css/style.css
+++ b/css/style.css
@@ -204,8 +204,8 @@ section {
   .hero {
     text-align: center;
     padding: 40px 20px;
-    background: var(--primary);
-    color: var(--on-primary);
+    background: var(--color-brand);
+    color: var(--color-brand-contrast);
     border-radius: 12px;
     box-shadow: var(--shadow-lg);
     margin: 20px auto;
@@ -240,7 +240,7 @@ section {
   left: 50%;
   transform: translate(-50%, -50%);
   background: var(--overlay-strong);
-  color: var(--on-primary);
+  color: var(--color-brand-contrast);
   padding: 24px;
   border-radius: 8px;
   font-size: 1.1rem;
@@ -268,15 +268,15 @@ section {
 .scroller-title {
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--on-surface);
+  color: var(--text-strong);
 }
 
 .scroller-toggle {
   padding: .4rem .75rem;
   border-radius: .5rem;
-  background: var(--surface-variant);
-  color: var(--on-surface-variant);
-  border: 1px solid var(--outline);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  border: 1px solid var(--surface-2);
   cursor: pointer;
 }
 
@@ -307,12 +307,12 @@ section {
 
 .station-scroller::before {
   left: 0;
-  background: linear-gradient(to right, var(--surface), transparent);
+  background: linear-gradient(to right, var(--surface-1), transparent);
 }
 
 .station-scroller::after {
   right: 0;
-  background: linear-gradient(to left, var(--surface), transparent);
+  background: linear-gradient(to left, var(--surface-1), transparent);
 }
 
 .station-scroller .scroller-track {
@@ -355,8 +355,8 @@ section {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  background: var(--surface-variant);
-  color: var(--on-surface-variant);
+  background: var(--surface-2);
+  color: var(--text-muted);
   z-index: 2;
   opacity: 0.6;
   transition: opacity 0.3s;
@@ -386,7 +386,7 @@ section {
 }
 
 .feature-card {
-  background: var(--surface);
+  background: var(--surface-1);
   border-radius: 12px;
   padding: 20px;
   box-shadow: var(--shadow-md);
@@ -414,7 +414,7 @@ section {
 
 .feature-card .material-symbols-outlined {
   font-size: 48px;
-  color: var(--primary);
+  color: var(--color-brand);
   margin-bottom: 10px;
 }
 
@@ -436,15 +436,15 @@ section {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   font-weight: 500;
-  background: var(--primary);
-  color: var(--on-primary);
+  background: var(--color-brand);
+  color: var(--color-brand-contrast);
   border-radius: 0.5rem;
   text-decoration: none;
   transition: background 0.2s ease;
 }
 
 .feature-card .cta-btn:hover {
-  background: color-mix(in srgb, var(--primary) 85%, black);
+  background: color-mix(in srgb, var(--color-brand) 85%, black);
 }
 
 /* Blog list card grid */
@@ -457,8 +457,8 @@ section {
 }
 
 .blog-card {
-  background: var(--surface);
-  border: 1px solid var(--surface-variant);
+  background: var(--surface-1);
+  border: 1px solid var(--surface-2);
   border-radius: 8px;
   overflow: hidden;
   display: flex;
@@ -480,7 +480,7 @@ section {
 
 .blog-card .card-category {
   font-size: 0.85rem;
-  color: var(--on-surface-variant);
+  color: var(--text-muted);
   text-transform: uppercase;
   margin: 0 0 4px;
 }
@@ -492,7 +492,7 @@ section {
 
 .blog-card .card-title a {
   text-decoration: none;
-  color: var(--on-surface);
+  color: var(--text-strong);
 }
 
 .blog-card .card-title a:hover {
@@ -502,13 +502,13 @@ section {
 .blog-card .card-excerpt {
   flex-grow: 1;
   font-size: 0.95rem;
-  color: var(--on-surface-variant);
+  color: var(--text-muted);
   margin: 0 0 8px;
 }
 
 .blog-card .card-meta {
   font-size: 0.85rem;
-  color: var(--on-surface-variant);
+  color: var(--text-muted);
 }
 
 /* Channel navigation layout */
@@ -559,7 +559,7 @@ section {
 .media-hub-section .channel-card,
 .youtube-section .detail-item,
 .media-hub-section .detail-item {
-  background: var(--surface);
+  background: var(--surface-1);
   padding: 8px 16px;
   min-height: 56px;
   border-radius: 20px;
@@ -616,18 +616,18 @@ section {
 
 .youtube-section .channel-card.active,
 .media-hub-section .channel-card.active {
-  background: var(--primary);
-  color: var(--on-primary);
+  background: var(--color-brand);
+  color: var(--color-brand-contrast);
 }
 
 .youtube-section .channel-card.favorite,
 .media-hub-section .channel-card.favorite {
   background: var(--favorite-row);
-  color: var(--on-primary);
+  color: var(--color-brand-contrast);
 }
 
 .channel-card.favorite .fav-btn {
-  color: var(--on-primary);
+  color: var(--color-brand-contrast);
 }
 
 .video-section {
@@ -1440,7 +1440,7 @@ footer nav a:hover {
 }
 .rail-card {
   flex: 0 0 160px;
-  background: var(--surface);
+  background: var(--surface-1);
   border-radius: 8px;
   box-shadow: var(--shadow-sm);
   text-decoration: none;

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -51,6 +51,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/freepress.html
+++ b/freepress.html
@@ -51,6 +51,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/livetv.html
+++ b/livetv.html
@@ -51,6 +51,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -8,8 +8,9 @@
   <title>PakStream Media Hub Embed</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="/assets/css/tokens.css" />
   <link rel="stylesheet" href="/css/theme.css" />
+  <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">

--- a/media-hub.html
+++ b/media-hub.html
@@ -13,8 +13,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="/assets/css/tokens.css" />
   <link rel="stylesheet" href="/css/theme.css" />
+  <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">

--- a/nav.html
+++ b/nav.html
@@ -8,6 +8,7 @@
   <meta charset="UTF-8">
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
 </head>
 <body>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -12,6 +12,7 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="canonical" href="https://pakstream.com/onboard-channel.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>

--- a/privacy.html
+++ b/privacy.html
@@ -54,6 +54,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/radio.html
+++ b/radio.html
@@ -52,6 +52,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/sw.js
+++ b/sw.js
@@ -3,6 +3,7 @@ const JSON_CACHE = 'ps-json-v1';
 const SHELL_ASSETS = [
   '/',
   '/index.html',
+  '/assets/css/tokens.css',
   '/css/style.css',
   '/css/theme.css',
   '/js/main.js',

--- a/terms.html
+++ b/terms.html
@@ -54,6 +54,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -58,6 +58,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link id="themeStylesheet" rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -12,6 +12,7 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="canonical" href="https://pakstream.com/youtube-playground.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>


### PR DESCRIPTION
## Summary
- add canonical color tokens and dark-mode seeds
- load color tokens before existing stylesheets
- migrate hero, carousel scroller, and card components to new tokens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a604852d9c8320a664989dcbbf5121