### PR TITLE
feat: add global accessibility focus styles

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -1,3 +1,4 @@
+<a href="#main-content" class="skip-link">Skip to content</a>
 <header class="top-bar">
   <input type="checkbox" id="nav-toggle">
   <label for="nav-toggle" class="nav-toggle-label">☰</label>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,10 +59,10 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
-  
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
+
 </head>
 <body>
-<a href="#main-content" class="skip-link">Skip to content</a>
 <div id="maintenance-banner" class="maintenance-banner" role="status" hidden></div>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -68,13 +68,14 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
   
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
-  <main class="post-container">
+  <main id="main-content" class="post-container">
     <article class="post">
       <h1>{{ page.title }}</h1>
 

--- a/about.html
+++ b/about.html
@@ -59,13 +59,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
   <!-- About section describing the mission of PakStream -->
-  <section>
+  <section id="main-content">
     <h2>About PakStream</h2>
     <p>Hi, I'm Atif, a Pakistani living in Sweden and a lifelong software nerd. PakStream started as a small side project built late at night, during what I like to call "vibe coding" sessions, the kind where you're not chasing deadlines, just chasing the feeling of home.</p>
     <p>Like many Pakistanis abroad, I missed the sound of FM radio, the drama of live TV news, and the honest voices of independent YouTubers. So I built a platform to bring all that together in one clean, ad-free space, just for people like me (and maybe you too).</p>

--- a/assets/css/a11y-focus.css
+++ b/assets/css/a11y-focus.css
@@ -1,0 +1,11 @@
+:where(a, button, [role="button"], input, select, textarea):where(:focus-visible){
+  outline: 2px solid var(--focus-ring, #1e88e5);
+  outline-offset: 3px;
+}
+
+.skip-link{position:absolute;left:-9999px}
+.skip-link:focus{left:1rem;top:1rem;z-index:9999;background:var(--surface-elevated);padding:.5rem 1rem;border-radius:.5rem}
+
+:where(button,[role="button"]){min-width:44px;min-height:44px}
+
+:where(p,li) > a:where(:hover,:focus){text-decoration:underline}

--- a/contact.html
+++ b/contact.html
@@ -59,6 +59,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
@@ -66,7 +67,7 @@
   {% include top-bar.html %}
 
   <!-- Contact section with instructions to reach us -->
-<section>
+<section id="main-content">
   <h2>Contact</h2>
   <p>Have a suggestion for a radio station, TV channel, or YouTube anchor you’d like to see on PakStream? Found a bug or broken link? Or just want to share your feedback or story?</p>
   <p>I'd love to hear from you! This project is personal and community-driven, and your input genuinely helps shape it.</p>

--- a/creators.html
+++ b/creators.html
@@ -40,13 +40,14 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
   <!-- Creators section with channel list and video player -->
-  <section class="youtube-section">
+  <section id="main-content" class="youtube-section">
     <div class="channel-list"></div>
 
     <div class="video-section">

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -55,12 +55,13 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
-  <section class="youtube-section">
+  <section id="main-content" class="youtube-section">
     <div class="channel-list"></div>
     <div class="video-section">
       <div class="button-row">

--- a/freepress.html
+++ b/freepress.html
@@ -55,12 +55,13 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
-  <section class="youtube-section">
+  <section id="main-content" class="youtube-section">
     <div class="channel-list"></div>
     <div class="video-section">
       <div class="button-row">

--- a/index.html
+++ b/index.html
@@ -66,13 +66,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
   <!-- Hero section with image and tagline -->
-  <section class="hero-banner">
+  <section id="main-content" class="hero-banner">
     <picture>
       <source
         type="image/webp"

--- a/livetv.html
+++ b/livetv.html
@@ -56,6 +56,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
@@ -63,7 +64,7 @@
 
 
   <!-- TV Livestream section -->
-  <section class="youtube-section">
+  <section id="main-content" class="youtube-section">
     <div class="channel-list"></div>
     <div class="video-section">
       <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()" aria-label="Toggle channel list">

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -13,9 +13,11 @@
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
-  <section class="youtube-section media-hub-section">
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <section id="main-content" class="youtube-section media-hub-section">
     <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">
         <div class="search-wrap">

--- a/media-hub.html
+++ b/media-hub.html
@@ -18,10 +18,9 @@
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
-<body>
-  <a href="#main-content" class="skip-link">Skip to content</a>
-  <div id="maintenance-banner" class="maintenance-banner" role="status" hidden></div>
+<body>  <div id="maintenance-banner" class="maintenance-banner" role="status" hidden></div>
   <!-- Top bar (same as site) -->
 {% include top-bar.html %}
 

--- a/nav.html
+++ b/nav.html
@@ -9,9 +9,11 @@
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
+  <main id="main-content"></main>
 </body>
 </html>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -18,12 +18,13 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
   {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
-  <main class="container">
+  <main id="main-content" class="container">
     <h2>Onboard YouTube Channel</h2>
     <p>Enter a YouTube channel URL to generate a JSON snippet for <code>all_streams.json</code>.</p>
     <label for="channel-url">Channel URL</label>

--- a/privacy.html
+++ b/privacy.html
@@ -59,6 +59,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
@@ -66,7 +67,7 @@
   {% include top-bar.html %}
 
   <!-- Privacy policy content -->
-<section>
+<section id="main-content">
   <h2>Privacy &amp; History</h2>
   <p>At PakStream, your privacy is important. This website uses cookies to deliver and improve the service. We use Google Analytics to understand how visitors interact with the site, and we plan to integrate Google Ads which may also use cookies for ad personalisation.</p>
   <p>PakStream uses YouTube API Services to retrieve and display channel and video information. By using PakStream, you agree to be bound by the <a href="https://www.youtube.com/t/terms">YouTube Terms of Service</a>. PakStream does not store or collect personal information from these services. For details on how Google collects and processes data, please see the <a href="https://www.google.com/policies/privacy">Google Privacy Policy</a>.</p>

--- a/radio.html
+++ b/radio.html
@@ -57,12 +57,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body class="radio-list">
   {% include top-bar.html %}
 
   <!-- Radio station listing -->
-  <section class="youtube-section">
+  <section id="main-content" class="youtube-section">
     <div class="channel-list"></div>
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle station list">

--- a/terms.html
+++ b/terms.html
@@ -59,6 +59,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
@@ -66,7 +67,7 @@
   {% include top-bar.html %}
 
   <!-- Terms and conditions content -->
-<section>
+<section id="main-content">
   <h2>Terms & Conditions</h2>
   <p>By using PakStream, you agree to the <a href="https://www.youtube.com/t/terms">YouTube Terms of Service</a> and the following:</p>
   <ul>

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -63,6 +63,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
@@ -82,7 +83,7 @@
   </div>
 
   <!-- Hero section with image and tagline -->
-  <section class="hero-banner">
+  <section id="main-content" class="hero-banner">
     <picture>
       <source
         type="image/webp"

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -18,6 +18,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
@@ -25,7 +26,7 @@
 
   <main class="container">
     <h2>YouTube Playground</h2>
-    <section>
+    <section id="main-content">
       <h3>Find Channel ID</h3>
       <p>Enter channel handle(s) separated by commas to get their channel IDs.</p>
         <label for="channel-handles">Channel handles</label>


### PR DESCRIPTION
## Summary
- add global a11y-focus stylesheet with focus rings, touch targets, and link underline
- move skip link into top bar and load new stylesheet on every page
- anchor main content sections for working skip links across pages

## Testing
- `npx --yes htmlhint '**/*.html'`

------
https://chatgpt.com/codex/tasks/task_e_68a6046b288c83208477be0704d8f81c