### PR TITLE
feat: improve homepage feature cards

### DIFF
--- a/assets/css/cards.css
+++ b/assets/css/cards.css
@@ -1,0 +1,75 @@
+#ps-feature-cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin: 40px auto;
+  max-width: 960px;
+}
+
+.ps-card {
+  display: block;
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: var(--shadow-md);
+  text-align: center;
+  flex: 1 1 250px;
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ps-card:hover,
+.ps-card:focus-visible {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: var(--shadow-lg);
+}
+
+.ps-card:focus-visible {
+  outline: 3px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.ps-card .material-symbols-outlined {
+  font-size: 48px;
+  color: var(--primary);
+  margin-bottom: 10px;
+}
+
+.ps-card p {
+  min-height: 3rem;
+}
+
+.ps-card__media {
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  margin: 1rem 0;
+  position: relative;
+}
+
+.ps-card__media iframe,
+.ps-card__media img {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+
+.ps-card__poster {
+  position: absolute;
+  inset: 0;
+  object-fit: cover;
+}
+
+.ps-card__cta {
+  display: inline-block;
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: var(--primary);
+  color: var(--on-primary);
+  border-radius: 0.5rem;
+}

--- a/assets/js/iframeloader.js
+++ b/assets/js/iframeloader.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', function () {
+  if (!('IntersectionObserver' in window)) {
+    document.querySelectorAll('#ps-feature-cards iframe[data-src]').forEach(function (iframe) {
+      iframe.src = iframe.dataset.src;
+    });
+    return;
+  }
+
+  const observer = new IntersectionObserver(function (entries, obs) {
+    entries.forEach(function (entry) {
+      if (entry.isIntersecting) {
+        const iframe = entry.target;
+        iframe.src = iframe.dataset.src;
+        iframe.addEventListener('load', function () {
+          const poster = iframe.parentElement.querySelector('.ps-card__poster');
+          if (poster) poster.style.display = 'none';
+        });
+        obs.unobserve(iframe);
+      }
+    });
+  }, { rootMargin: '200px 0px' });
+
+  document.querySelectorAll('#ps-feature-cards iframe[data-src]').forEach(function (iframe) {
+    observer.observe(iframe);
+  });
+});

--- a/css/style.css
+++ b/css/style.css
@@ -376,51 +376,6 @@ section {
 }
 
 /* Featured card layout */
-.feature-cards {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 20px;
-  margin: 40px auto;
-  max-width: 960px;
-}
-
-.feature-card {
-  background: var(--surface);
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: var(--shadow-md);
-  text-align: center;
-  flex: 1 1 250px;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-/* Remove global section spacing for inline video sections */
-.feature-card > section.youtube-section.media-hub-section {
-  margin: 0 !important;
-  padding: 0 !important;
-  background: transparent !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  max-width: none !important;
-}
-
-.feature-card:hover,
-.feature-card:focus-within {
-  transform: translateY(-4px) scale(1.02);
-  box-shadow: var(--shadow-lg);
-}
-
-.feature-card .material-symbols-outlined {
-  font-size: 48px;
-  color: var(--primary);
-  margin-bottom: 10px;
-}
-
-.feature-card p {
-  min-height: 3rem;
-}
 
 .media-hub-embed {
   width: 100%;
@@ -430,22 +385,6 @@ section {
   border-radius: 0.75rem;
 }
 
-.feature-card .cta-btn {
-  display: inline-block;
-  margin-top: 0.75rem;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  background: var(--primary);
-  color: var(--on-primary);
-  border-radius: 0.5rem;
-  text-decoration: none;
-  transition: background 0.2s ease;
-}
-
-.feature-card .cta-btn:hover {
-  background: color-mix(in srgb, var(--primary) 85%, black);
-}
 
 /* Blog list card grid */
 .blog-grid {

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/cards.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -113,61 +114,67 @@
   </section>
 
   <!-- Featured cards -->
-  <section class="feature-cards">
-    <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">
+  <section id="ps-feature-cards">
+    <a class="ps-card" href="/media-hub.html?m=freepress&c=wajahatsaeedkhan">
       <span class="material-symbols-outlined">article</span>
       <h3>Free Press</h3>
       <p>Stay updated with the latest new from Independent Voices.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
-    </div>
-    <div class="feature-card" data-m="radio" data-c="audio35">
+      <div class="ps-card__media">
+        <iframe data-src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen tabindex="-1"></iframe>
+        <img class="ps-card__poster" src="/images/pakistan-abstract-380.webp" alt="">
+      </div>
+      <span class="ps-card__cta">Watch Now</span>
+    </a>
+    <a class="ps-card" href="/media-hub.html?m=radio&c=audio35">
       <span class="material-symbols-outlined">radio</span>
       <h3>Popular Radio Stations</h3>
       <p>Listen to Pakistani radio.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
-    </div>
-    <div class="feature-card" data-m="tv" data-c="24news">
+      <div class="ps-card__media">
+        <iframe data-src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen tabindex="-1"></iframe>
+        <img class="ps-card__poster" src="/images/pakistan-abstract-380.webp" alt="">
+      </div>
+      <span class="ps-card__cta">Listen</span>
+    </a>
+    <a class="ps-card" href="/media-hub.html?m=tv&c=24news">
       <span class="material-symbols-outlined">live_tv</span>
       <h3>Live TV Channels</h3>
       <p>Watch the most viewed live TV streams.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
-    </div>
-    <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
+      <div class="ps-card__media">
+        <iframe data-src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen tabindex="-1"></iframe>
+        <img class="ps-card__poster" src="/images/pakistan-abstract-380.webp" alt="">
+      </div>
+      <span class="ps-card__cta">Watch Now</span>
+    </a>
+    <a class="ps-card" href="/media-hub.html?m=creator&c=zeeshanusmani">
       <span class="material-symbols-outlined">person</span>
       <h3>Featured Creators</h3>
       <p>Watch the latest from Pakistani creators.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
-    </div>
-    <div class="feature-card" data-m="all" data-c="geo">
+      <div class="ps-card__media">
+        <iframe data-src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen tabindex="-1"></iframe>
+        <img class="ps-card__poster" src="/images/pakistan-abstract-380.webp" alt="">
+      </div>
+      <span class="ps-card__cta">Watch Now</span>
+    </a>
+    <a class="ps-card" href="/media-hub.html?m=all&c=geo">
       <span class="material-symbols-outlined">apps</span>
       <h3>All Streams</h3>
       <p>Browse every channel in one place.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
-    </div>
-    <div class="feature-card" data-m="favorites" data-c="wajahatsaeedkhan">
+      <div class="ps-card__media">
+        <iframe data-src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen tabindex="-1"></iframe>
+        <img class="ps-card__poster" src="/images/pakistan-abstract-380.webp" alt="">
+      </div>
+      <span class="ps-card__cta">Browse</span>
+    </a>
+    <a class="ps-card" href="/media-hub.html?m=favorites&c=wajahatsaeedkhan">
       <span class="material-symbols-outlined">favorite</span>
       <h3>Your Favorites</h3>
       <p>Quick access to your saved channels.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" data-src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
-    </div>
+      <div class="ps-card__media">
+        <iframe data-src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen tabindex="-1"></iframe>
+        <img class="ps-card__poster" src="/images/pakistan-abstract-380.webp" alt="">
+      </div>
+      <span class="ps-card__cta">View</span>
+    </a>
   </section>
 
   <!-- Main content sections -->
@@ -238,105 +245,11 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const cards = document.querySelectorAll('.feature-card');
-      cards.forEach(card => {
-        const mode = card.dataset.m;
-        const channel = card.dataset.c;
-        card.addEventListener('click', () => {
-          if (!mode) return;
-          let url = `/media-hub.html?m=${encodeURIComponent(mode)}`;
-          if (channel) {
-            url += `&c=${encodeURIComponent(channel)}`;
-          }
-          window.location.href = url;
-        });
-      });
-      const sendMuteMessage = (iframe, muted) => {
-        if (iframe.contentWindow) {
-          iframe.contentWindow.postMessage({ type: 'media-hub-set-muted', muted }, '*');
-        }
-      };
-      const sendPlayMessage = (iframe, playing) => {
-        if (iframe.contentWindow) {
-          iframe.contentWindow.postMessage({ type: 'media-hub-set-playing', playing }, '*');
-        }
-      };
-
-      const canHover = window.matchMedia('(hover: hover) and (pointer: fine)').matches && navigator.maxTouchPoints === 0;
-      const isLaptop = canHover && window.matchMedia('(min-width: 1024px)').matches;
-      const cardArray = Array.from(cards);
-
-      if (canHover) {
-        cardArray.forEach(card => {
-          const iframe = card.querySelector('iframe');
-          if (!iframe) return;
-          card.addEventListener('mouseenter', () => {
-            cardArray.forEach(c => {
-              const ifr = c.querySelector('iframe');
-              if (!ifr) return;
-              const isCurrent = c === card;
-              sendMuteMessage(ifr, !isCurrent);
-              sendPlayMessage(ifr, isCurrent);
-            });
-          });
-          card.addEventListener('mouseleave', () => {
-            sendMuteMessage(iframe, true);
-            sendPlayMessage(iframe, false);
-          });
-        });
-      } else if ('IntersectionObserver' in window) {
-        cardArray.forEach(card => {
-          const iframe = card.querySelector('iframe');
-          if (!iframe) return;
-
-          let inView = false;
-          const applyState = () => {
-            sendMuteMessage(iframe, !inView);
-            sendPlayMessage(iframe, inView);
-          };
-
-          const observer = new IntersectionObserver(entries => {
-            entries.forEach(entry => {
-              if (entry.target !== card) return;
-              inView = entry.isIntersecting;
-              applyState();
-            });
-          }, { threshold: 0.5 });
-
-          observer.observe(card);
-
-          iframe.addEventListener('load', applyState);
-        });
-      }
-
-      // Load iframes sequentially to avoid simultaneous autoplay
-      const iframes = cardArray.map(card => card.querySelector('iframe')).filter(Boolean);
-      let idx = 0;
-      const loadNext = () => {
-        if (idx >= iframes.length) return;
-        const iframe = iframes[idx];
-        const src = iframe.dataset.src;
-        if (src) iframe.src = src;
-        iframe.addEventListener('load', () => {
-          if (canHover) {
-            const play = idx === 0;
-            const unmute = play && isLaptop;
-            sendPlayMessage(iframe, play);
-            sendMuteMessage(iframe, !unmute);
-          }
-          idx++;
-          loadNext();
-        }, { once: true });
-      };
-      loadNext();
-    });
-  </script>
   <script defer src="/js/ad-config.js"></script>
   <script defer src="/js/ad-slot.js"></script>
   <script defer src="/js/pwa.js"></script>
   <script defer src="/js/discovery.js"></script>
   <script defer src="/js/main.js"></script>
+  <script defer src="/assets/js/iframeloader.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -355,22 +355,22 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   if ('IntersectionObserver' in window) {
-    const lazyElements = document.querySelectorAll('img[data-src], iframe[data-src]');
+    const lazyImages = document.querySelectorAll('img[data-src]');
     const observer = new IntersectionObserver((entries, obs) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
-          const el = entry.target;
-          el.src = el.dataset.src;
-          el.removeAttribute('data-src');
-          obs.unobserve(el);
+          const img = entry.target;
+          img.src = img.dataset.src;
+          img.removeAttribute('data-src');
+          obs.unobserve(img);
         }
       });
     });
-    lazyElements.forEach(el => observer.observe(el));
+    lazyImages.forEach(img => observer.observe(img));
   } else {
-    document.querySelectorAll('img[data-src], iframe[data-src]').forEach(el => {
-      el.src = el.dataset.src;
-      el.removeAttribute('data-src');
+    document.querySelectorAll('img[data-src]').forEach(img => {
+      img.src = img.dataset.src;
+      img.removeAttribute('data-src');
     });
   }
 });


### PR DESCRIPTION
## Summary
- make homepage feature cards fully clickable links with lazy iframe previews
- add cards.css and iframeloader.js for styles and IntersectionObserver loading
- simplify main.js lazy loader to handle images only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60435f50c8320ae41b58b8df00cb9