### PR TITLE
Improve hero readability with overlay and responsive type

### DIFF
--- a/assets/css/hero.css
+++ b/assets/css/hero.css
@@ -1,0 +1,67 @@
+#ps-hero {
+  --hero-overlay: rgba(0,0,0,.45);
+  position: relative;
+  margin: 20px auto;
+  max-width: 960px;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  color: #fff;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 1rem;
+}
+
+#ps-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(var(--hero-overlay), var(--hero-overlay));
+  z-index: 0;
+}
+
+#ps-hero picture {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+}
+
+#ps-hero picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+#ps-hero.low-contrast {
+  --hero-overlay: rgba(0,0,0,.65);
+}
+
+#ps-hero .hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+#ps-hero h1 {
+  font-size: clamp(1.75rem, 2.5vw + 1rem, 3rem);
+  margin: 0 0 0.5rem;
+}
+
+#ps-hero .subheading {
+  font-size: clamp(1rem, 1.2vw + .5rem, 1.375rem);
+  margin: 0 0 1rem;
+}
+
+#ps-hero .hero-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 1rem;
+  background: var(--primary-container, #0F5132);
+  color: var(--on-primary-container, #fff);
+  text-decoration: none;
+  border-radius: 4px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -218,40 +218,6 @@ section {
 }
 
 /* Hero banner with image overlay */
-.hero-banner {
-  position: relative;
-  text-align: center;
-  margin: 20px auto;
-  max-width: 960px;
-  border-radius: 4px;
-  overflow: hidden;
-  box-shadow: var(--shadow-sm);
-}
-
-.hero-banner img {
-  width: 100%;
-  height: 300px;
-  object-fit: cover;
-}
-
-.hero-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: var(--overlay-strong);
-  color: var(--on-primary);
-  padding: 24px;
-  border-radius: 8px;
-  font-size: 1.1rem;
-  line-height: 1.6;
-}
-
-/* Improve contrast for tagline in dark mode */
-[data-theme="dark"] .hero-text {
-  color: var(--on-primary-container);
-}
-
 .station-scroller-wrap {
   margin-block: 1.5rem;
   max-width: 960px;

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/hero.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -72,8 +73,8 @@
   {% include top-bar.html %}
 
   <!-- Hero section with image and tagline -->
-  <section class="hero-banner">
-    <picture>
+  <section id="ps-hero" class="hero-banner">
+    <picture role="img" aria-hidden="true">
       <source
         type="image/webp"
         srcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
@@ -82,14 +83,14 @@
         src="/images/pakistan-abstract-380.webp"
         width="380"
         height="380"
-        alt="Abstract Pakistan crescent and star"
+        alt=""
         decoding="async"
-        fetchpriority="high"
-        style="aspect-ratio: 1 / 1; object-fit: cover;" />
+        fetchpriority="high" />
     </picture>
-    <div class="hero-text">
-      <h2>Your Gateway to Pakistani Media</h2>
-      <p>Stay Connected to Pakistan — News, Radio &amp; More</p>
+    <div class="hero-content">
+      <h1>Your Gateway to Pakistani Media</h1>
+      <p class="subheading">Stay Connected to Pakistan — News, Radio &amp; More</p>
+      <a class="hero-cta" href="/media-hub.html">Browse Streams</a>
     </div>
   </section>
 

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -60,6 +60,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link id="themeStylesheet" rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/hero.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -82,8 +83,8 @@
   </div>
 
   <!-- Hero section with image and tagline -->
-  <section class="hero-banner">
-    <picture>
+  <section id="ps-hero" class="hero-banner">
+    <picture role="img" aria-hidden="true">
       <source
         type="image/webp"
         srcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
@@ -92,14 +93,14 @@
         src="/images/pakistan-abstract-380.webp"
         width="380"
         height="380"
-        alt="Abstract Pakistan crescent and star"
+        alt=""
         decoding="async"
-        fetchpriority="high"
-        style="aspect-ratio: 1 / 1; object-fit: cover;" />
+        fetchpriority="high" />
     </picture>
-    <div class="hero-text">
-      <h2>Your Gateway to Pakistani Media</h2>
-      <p>Stay Connected to Pakistan — News, Radio &amp; More</p>
+    <div class="hero-content">
+      <h1>Your Gateway to Pakistani Media</h1>
+      <p class="subheading">Stay Connected to Pakistan — News, Radio &amp; More</p>
+      <a class="hero-cta" href="/media-hub.html">Browse Streams</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add dedicated hero stylesheet with overlay and responsive typography
- make hero image decorative and include CTA with accessible tap targets
- remove legacy hero styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60429c44c83208ab5a2c061f36302