### PR TITLE
feat: add responsive accessible navigation

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -1,19 +1,26 @@
 <header class="top-bar">
-  <input type="checkbox" id="nav-toggle">
-  <label for="nav-toggle" class="nav-toggle-label">☰</label>
-  <h1 class="logo-title">PakStream</h1>
-  <nav class="nav-links">
-    <a href="/">Home</a>
-    <a href="/media-hub.html">Media Hub</a>
-    <a href="/blog.html">Blog</a>
-    <a href="/about.html">About</a>
-    <a href="/contact.html">Contact</a>
-    <a href="/privacy.html">Privacy</a>
-    <a href="/terms.html">Terms</a>
-    <a href="#" data-open-consent>Privacy &amp; Ads settings</a>
+  <a class="logo" href="/">PakStream</a>
+
+  <input id="nav-toggle" class="nav-toggle" type="checkbox" aria-controls="primary-navigation" aria-expanded="false">
+  <label for="nav-toggle" class="nav-toggle-label" aria-label="Open menu" aria-controls="primary-navigation">
+    <span class="material-symbols-outlined">menu</span>
+  </label>
+
+  <div class="nav-overlay" hidden></div>
+
+  <nav id="primary-navigation" class="top-nav" role="navigation">
+    <ul class="nav-links">
+      <li><a href="/">Home</a></li>
+      <li><a href="/media-hub.html">Media Hub</a></li>
+      <li><a href="/blog.html">Blog</a></li>
+      <li><a href="/about.html">About</a></li>
+      <li><a href="/contact.html">Contact</a></li>
+      <li><a href="/privacy.html">Privacy</a></li>
+      <li><a href="/terms.html">Terms</a></li>
+      <li><a href="#" data-open-consent>Privacy &amp; Ads settings</a></li>
+    </ul>
+    <a href="https://buymeacoffee.com/pakstream" class="bmc-button" target="_blank" rel="noopener">Buy me a coffee ☕</a>
+    <button id="install-btn" class="install-btn" hidden>Install</button>
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   </nav>
-  <a href="https://buymeacoffee.com/pakstream" class="bmc-button" target="_blank" rel="noopener">Buy me a coffee ☕</a>
-  <button id="install-btn" class="install-btn" hidden>Install</button>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
-  <label for="nav-toggle" class="nav-overlay"></label>
 </header>

--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,15 @@ a:visited {
   color: var(--accent-link-visited);
 }
 
+a:focus,
+button:focus,
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 2px solid var(--accent-link);
+  outline-offset: 3px;
+}
+
 
 /* Scrollbar styling */
 ::-webkit-scrollbar {
@@ -45,7 +54,7 @@ body {
   transition: background 0.3s, color 0.3s;
 }
 
-body.no-scroll {
+body.scroll-locked {
   overflow: hidden;
 }
 
@@ -63,11 +72,12 @@ body.no-scroll {
   z-index: 1002;
 }
 
-.logo-title {
+.logo {
   font-size: 1.25rem;
   margin: 0;
   line-height: 56px;
   color: var(--on-primary);
+  text-decoration: none;
 }
 
 .nav-toggle-label {
@@ -77,6 +87,11 @@ body.no-scroll {
   cursor: pointer;
 }
 
+.nav-toggle-label:focus {
+  outline: 2px solid var(--accent-link);
+  outline-offset: 3px;
+}
+
 .back-button {
   color: var(--on-primary);
   font-size: 1.25rem;
@@ -84,39 +99,56 @@ body.no-scroll {
   text-decoration: none;
 }
 
-.top-bar nav {
-  flex-grow: 1;
+ .top-nav {
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: min(85vw, 360px);
+  height: 100vh;
+  background: var(--surface);
+  color: var(--on-surface);
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
   display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  transition: transform 0.4s ease-in-out;
+  flex-direction: column;
+  padding: 16px;
+  gap: 8px;
+  z-index: 1004;
 }
 
-.top-bar nav a {
-  color: var(--on-primary);
+.nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-links a {
+  color: var(--on-surface);
   text-decoration: none;
   font-weight: 500;
   padding: 12px 14px;
   border-radius: 10px;
 }
 
-.top-bar nav a:hover,
+.nav-links a:hover,
 .post-share a:hover,
 footer nav a:hover {
   color: var(--accent-link);
   text-decoration: underline;
 }
 
-.top-bar nav a:hover,
-.top-bar nav a:focus {
-  color: var(--on-primary);
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--accent-link);
   text-decoration: underline;
 }
 
-  .top-bar nav a.active,
-  .top-bar nav a[aria-current="page"] {
-    background: color-mix(in oklab, var(--primary) 12%, transparent);
-  }
+.nav-links a.active,
+.nav-links a[aria-current="page"] {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+}
 
 
 .search-form {
@@ -181,16 +213,27 @@ footer nav a:hover {
 }
 
 .nav-overlay {
-  display: none;
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg);
+  z-index: 1003;
+}
+
+#nav-toggle:checked ~ .nav-overlay {
+  display: block;
+}
+
+#nav-toggle:checked ~ .top-nav {
+  transform: translateX(0);
 }
 
 .theme-toggle {
   background: none;
   border: none;
-  color: var(--on-primary);
+  color: inherit;
   cursor: pointer;
   font-size: 1.25rem;
-  margin-left: 16px;
+  margin-left: 0;
 }
 
 /* Generic sections */
@@ -1245,67 +1288,47 @@ table tbody tr.favorite {
     margin: 15px 0;
   }
 
-  .top-bar nav {
-    position: fixed;
-    top: 56px;
-    left: 0;
-    bottom: 0;
-    width: 250px;
-    background: var(--surface);
-    color: var(--on-surface);
-    transform: translateX(-100%);
-    transition: transform 0.3s ease-in-out;
-    will-change: transform;
-    box-shadow: var(--shadow-side-right);
-    z-index: 1004;
-    flex-direction: column;
-    padding: 16px;
-    gap: 8px;
-  }
-
-  #nav-toggle:checked ~ nav {
-    transform: translateX(0);
-  }
-
-  .top-bar nav a {
-    color: var(--on-surface);
-    display: block;
-    padding: 12px 14px;
-    border-radius: 10px;
-  }
-
-  .top-bar nav a:hover,
-  .top-bar nav a:focus {
-    color: var(--accent-link);
-  }
-
-  .nav-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: var(--overlay-bg);
-    display: none;
-    z-index: 1003;
-  }
-
-  .nav-overlay.active {
-    display: block;
-  }
 }
 
 @media (min-width: 601px) {
-  .nav-toggle-label {
+  .nav-toggle-label,
+  .nav-overlay {
     display: none;
   }
   .back-button {
     display: none;
   }
-  .top-bar nav {
+  .top-nav {
+    position: static;
+    inset: auto;
+    transform: none;
+    height: auto;
+    background: transparent;
+    color: var(--on-primary);
+    flex-direction: row;
+    align-items: center;
+    padding: 0;
+    gap: 16px;
     margin-left: auto;
-    justify-content: flex-end;
-    flex-wrap: nowrap;
+  }
+  .nav-links {
+    flex-direction: row;
+    gap: 16px;
+  }
+  .nav-links a {
+    color: var(--on-primary);
+  }
+  .nav-links a:hover,
+  .nav-links a:focus {
+    color: var(--on-primary);
+    text-decoration: underline;
+  }
+  .top-nav .bmc-button {
+    margin-left: 16px;
+    margin-top: 0;
+  }
+  .theme-toggle {
+    margin-left: 16px;
   }
 }
 
@@ -1406,10 +1429,6 @@ footer nav a:hover {
   background-color: color-mix(in srgb, var(--secondary) 85%, var(--on-secondary));
 }
 
-.top-bar .bmc-button {
-  margin-left: 16px;
-  margin-top: 0;
-}
 
 .ad-container {
   margin: 20px 0;

--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,11 @@
 document.addEventListener('DOMContentLoaded', function () {
   var navToggle = document.getElementById('nav-toggle');
-  var nav = document.querySelector('nav');
-  var label = document.querySelector('.nav-toggle-label');
+  var navLabel = document.querySelector('.nav-toggle-label');
+  var overlay = document.querySelector('.nav-overlay');
   var topBar = document.querySelector('.top-bar');
   var themeToggle = document.getElementById('theme-toggle');
-  var overlay = document.querySelector('.nav-overlay');
-  if (!navToggle || !nav || !label) return;
-  var touchStartX = null;
-  var touchStartY = null;
+  var navigation = document.getElementById('primary-navigation');
+  if (!navToggle || !navLabel || !overlay || !navigation) return;
 
   function updateScrollLock() {
     var navOpen = navToggle && navToggle.checked;
@@ -15,13 +13,12 @@ document.addEventListener('DOMContentLoaded', function () {
     var detailsOpen = document.querySelector('.details-list.open');
     var sideOpen = window.innerWidth <= 768 && (channelOpen || detailsOpen);
     var anyOpen = navOpen || sideOpen;
-    document.body.classList.toggle('no-scroll', anyOpen);
-    if (overlay) overlay.classList.toggle('active', anyOpen);
+    document.body.classList.toggle('scroll-locked', anyOpen);
   }
   window.updateScrollLock = updateScrollLock;
 
   var currentPath = window.location.pathname;
-  var links = document.querySelectorAll('.nav-links a');
+  var links = navigation.querySelectorAll('.nav-links a');
   links.forEach(function (link) {
     if (link.getAttribute('href') === currentPath) {
       link.classList.add('active');
@@ -30,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   var homePaths = ['/', '/'];
-  if (topBar && label && homePaths.indexOf(currentPath) === -1) {
+  if (topBar && navLabel && homePaths.indexOf(currentPath) === -1) {
     var backBtn = document.createElement('a');
     backBtn.href = '/';
     backBtn.className = 'back-button';
@@ -43,13 +40,13 @@ document.addEventListener('DOMContentLoaded', function () {
         window.location.href = '/';
       }
     });
-    topBar.insertBefore(backBtn, label.nextSibling);
+    topBar.insertBefore(backBtn, navLabel.nextSibling);
   }
 
   // Add top-bar search on all pages, including the media hub.
   if (topBar) {
     var themeBtn = themeToggle;
-    var logoTitle = document.querySelector('.logo-title');
+    var logoTitle = document.querySelector('.logo');
     var searchForm = document.createElement('form');
     searchForm.id = 'search-form';
     searchForm.className = 'search-form';
@@ -153,52 +150,59 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
 
-    if (themeBtn) {
-      topBar.insertBefore(searchForm, themeBtn);
-    } else {
-      topBar.appendChild(searchForm);
+    if (navigation && themeBtn) {
+      navigation.insertBefore(searchForm, themeBtn);
+    } else if (navigation) {
+      navigation.appendChild(searchForm);
     }
   }
 
-  label.addEventListener('click', function (e) {
-    e.preventDefault();
-    navToggle.checked = !navToggle.checked;
+  navToggle.addEventListener('change', function () {
+    var isOpen = navToggle.checked;
+    navToggle.setAttribute('aria-expanded', String(isOpen));
+    navLabel.setAttribute('aria-label', isOpen ? 'Close menu' : 'Open menu');
+    var icon = navLabel.querySelector('.material-symbols-outlined');
+    if (icon) icon.textContent = isOpen ? 'close' : 'menu';
+    overlay.hidden = !isOpen;
+    if (isOpen) {
+      var focusable = navigation.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])');
+      if (focusable.length) focusable[0].focus();
+    } else {
+      navLabel.focus();
+    }
     updateScrollLock();
   });
 
-  document.addEventListener('click', function (e) {
-    if (navToggle.checked && !nav.contains(e.target) && !label.contains(e.target)) {
-      navToggle.checked = false;
-      updateScrollLock();
-    }
+  overlay.addEventListener('click', function () {
+    navToggle.checked = false;
+    navToggle.dispatchEvent(new Event('change'));
   });
 
-  if (overlay) {
-    overlay.addEventListener('click', function (e) {
-      e.preventDefault();
-      if (navToggle) navToggle.checked = false;
-      updateScrollLock();
-    });
-  }
-
-  document.addEventListener('touchstart', function (e) {
+  document.addEventListener('keydown', function (e) {
     if (!navToggle.checked) return;
-    var t = e.touches[0];
-    touchStartX = t.clientX;
-    touchStartY = t.clientY;
+    if (e.key === 'Escape') {
+      navToggle.checked = false;
+      navToggle.dispatchEvent(new Event('change'));
+    } else if (e.key === 'Tab') {
+      var focusable = navigation.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])');
+      if (!focusable.length) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
   });
 
-  document.addEventListener('touchend', function (e) {
-    if (!navToggle.checked || touchStartX === null) return;
-    var t = e.changedTouches[0];
-    var dx = t.clientX - touchStartX;
-    var dy = Math.abs(t.clientY - touchStartY);
-    if (dx < -50 && dy < 30) {
+  window.addEventListener('resize', function () {
+    if (window.innerWidth > 600 && navToggle.checked) {
       navToggle.checked = false;
-      updateScrollLock();
+      navToggle.dispatchEvent(new Event('change'));
     }
-    touchStartX = null;
-    touchStartY = null;
   });
 
   if (themeToggle) {


### PR DESCRIPTION
## Summary
- redesign header markup with accessible hamburger, overlay, and slide-in nav
- add mobile-first/off-canvas nav styles with desktop fallback
- implement JS toggle with aria updates, focus trap, and scroll lock

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60300cb8c8320bb6da14e545157b6