### PR TITLE
feat: add reusable media hub filters

### DIFF
--- a/assets/css/mh-filters.css
+++ b/assets/css/mh-filters.css
@@ -1,0 +1,62 @@
+#mh-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+#mh-filters .mh-live {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  border: 1px solid var(--outline);
+  border-radius: 8px;
+  min-height: 44px;
+  cursor: pointer;
+}
+#mh-filters .mh-live input {
+  width: 20px;
+  height: 20px;
+}
+
+#mh-filters .mh-sort {
+  display: flex;
+  border: 1px solid var(--outline);
+  border-radius: 8px;
+  overflow: hidden;
+}
+#mh-filters .mh-sort button {
+  background: var(--surface);
+  color: var(--on-surface);
+  border: none;
+  border-right: 1px solid var(--outline);
+  padding: 0 12px;
+  min-width: 44px;
+  min-height: 44px;
+  cursor: pointer;
+}
+#mh-filters .mh-sort button:last-child {
+  border-right: none;
+}
+#mh-filters .mh-sort button.active {
+  background: var(--primary);
+  color: var(--on-primary);
+}
+
+#mh-filters #mh-filter-reset {
+  border: 1px solid var(--outline);
+  background: var(--surface);
+  color: var(--on-surface);
+  border-radius: 8px;
+  padding: 0 12px;
+  min-width: 44px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+#mh-filters button:focus-visible,
+#mh-filters .mh-live input:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}

--- a/assets/js/mh-filters.js
+++ b/assets/js/mh-filters.js
@@ -1,0 +1,99 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const container = document.getElementById('mh-filters');
+    if(!container) return;
+
+    container.innerHTML = `
+      <label class="mh-live"><input type="checkbox" id="mh-filter-live" /> <span>Live Now</span></label>
+      <div class="mh-sort" role="radiogroup" aria-label="Sort results">
+        <button type="button" role="radio" aria-checked="false" data-sort="alpha">A \u2192 Z</button>
+        <button type="button" role="radio" aria-checked="false" data-sort="recent">Most Recent</button>
+        <button type="button" role="radio" aria-checked="false" data-sort="played">Recently Played</button>
+      </div>
+      <button type="button" id="mh-filter-reset">Reset</button>
+    `;
+
+    const liveEl = container.querySelector('#mh-filter-live');
+    const sortButtons = Array.from(container.querySelectorAll('.mh-sort button'));
+    const resetBtn = container.querySelector('#mh-filter-reset');
+
+    const state = {
+      liveNow: false,
+      sort: 'alpha'
+    };
+
+    const params = new URLSearchParams(location.search);
+    state.liveNow = params.get('live') === '1';
+    const sortParam = params.get('sort');
+    if(sortParam && ['alpha','recent','played'].includes(sortParam)) state.sort = sortParam;
+
+    function render(){
+      liveEl.checked = state.liveNow;
+      sortButtons.forEach((btn, i) => {
+        const active = btn.dataset.sort === state.sort;
+        btn.classList.toggle('active', active);
+        btn.setAttribute('aria-checked', active);
+        btn.setAttribute('tabindex', active ? '0' : '-1');
+      });
+    }
+
+    function syncURL(){
+      const p = new URLSearchParams(location.search);
+      if(state.liveNow) p.set('live','1'); else p.delete('live');
+      if(state.sort && state.sort !== 'alpha') p.set('sort', state.sort); else p.delete('sort');
+      const query = p.toString();
+      const newUrl = query ? `?${query}` : location.pathname;
+      history.replaceState(null, '', newUrl);
+    }
+
+    function emit(){
+      syncURL();
+      window.dispatchEvent(new CustomEvent('mh:filters:changed', {
+        detail: { liveNow: state.liveNow, sort: state.sort }
+      }));
+    }
+
+    liveEl.addEventListener('change', () => {
+      state.liveNow = liveEl.checked;
+      render();
+      emit();
+    });
+
+    function selectSort(btn){
+      state.sort = btn.dataset.sort;
+      render();
+      emit();
+    }
+
+    sortButtons.forEach((btn, idx) => {
+      btn.addEventListener('click', () => selectSort(btn));
+      btn.addEventListener('keydown', e => {
+        const { key } = e;
+        if(key === ' ' || key === 'Enter'){
+          e.preventDefault();
+          selectSort(btn);
+        } else if(key === 'ArrowRight' || key === 'ArrowDown'){
+          e.preventDefault();
+          const next = sortButtons[(idx + 1) % sortButtons.length];
+          selectSort(next);
+          next.focus();
+        } else if(key === 'ArrowLeft' || key === 'ArrowUp'){
+          e.preventDefault();
+          const prev = sortButtons[(idx - 1 + sortButtons.length) % sortButtons.length];
+          selectSort(prev);
+          prev.focus();
+        }
+      });
+    });
+
+    resetBtn.addEventListener('click', () => {
+      state.liveNow = false;
+      state.sort = 'alpha';
+      render();
+      emit();
+    });
+
+    render();
+    emit();
+  });
+})();

--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -63,11 +63,6 @@
   color: var(--on-surface);
   border-radius: 8px;
 }
-.hub-controls .live-filter {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
 .selected-filters {
   margin-top: 8px;
   display: flex;

--- a/media-hub.html
+++ b/media-hub.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/assets/css/mh-filters.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -40,14 +41,8 @@
         <select id="topic-filter" multiple aria-label="Filter by topic"></select>
         <select id="lang-filter" multiple aria-label="Filter by language"></select>
         <select id="region-filter" multiple aria-label="Filter by region"></select>
-        <label class="live-filter"><input type="checkbox" id="live-filter"> Live Now</label>
-        <select id="sort-select" aria-label="Sort results">
-          <option value="az">A → Z</option>
-          <option value="recent">Most Recent</option>
-          <option value="played">Recently Played</option>
-        </select>
+        <div id="mh-filters"></div>
         <input id="mh-search-input" type="text" placeholder="Search…" aria-label="Search media" />
-        <button id="reset-filters" type="button">Reset</button>
       </div>
       <div id="selected-filters" class="selected-filters" aria-live="polite"></div>
       <div id="results-count" class="results-count" aria-live="polite"></div>
@@ -126,6 +121,7 @@
   <!-- Keep order to preserve swipe/lock behavior from your site -->
   <script src="/js/stream-state.js"></script>
   <script src="/js/media-hub.js"></script>
+  <script src="/assets/js/mh-filters.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/discovery.js"></script>


### PR DESCRIPTION
## Summary
- add `mh-filters` module to control Live Now, sort modes, and reset
- broadcast filter changes via `mh:filters:changed`
- improve sort control accessibility and URL syncing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6044bab5c83208004def65db5898f