### PR TITLE
Add diagnostic sanity checklist

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,6 +91,7 @@
   <script defer src="/js/maintenance.js"></script>
   <script defer src="/js/error-overlay.js"></script>
   <script defer src="/js/main.js"></script>
+  <script src="/js/diagnostics.js"></script>
   {% endunless %}
 </body>
 </html>

--- a/js/diagnostics.js
+++ b/js/diagnostics.js
@@ -1,0 +1,61 @@
+(() => {
+  if (window.__DIAG_WIRED__) return;
+  window.__DIAG_WIRED__ = true;
+
+  const log = (ok, msg) => {
+    const styleOk  = 'color: #2E7D32; font-weight: bold';
+    const styleBad = 'color: #C62828; font-weight: bold';
+    const styleWarn= 'color: #FB8C00; font-weight: bold';
+    if (ok === true)   console.log('%c\u2714 PASS%c ' + msg, styleOk, '');
+    else if (ok === false) console.log('%c\u2718 FAIL%c ' + msg, styleBad, '');
+    else               console.log('%c\u26A0 WARN%c ' + msg, styleWarn, '');
+  };
+
+  function checkNav() {
+    const opener = document.querySelector('#nav-toggle, .nav-toggle');
+    const menu   = document.querySelector('#primary-navigation, .primary-navigation');
+    if (opener && menu) log(true, 'Nav elements present');
+    else log(false, 'Nav toggle or menu missing');
+  }
+
+  function checkOverlay() {
+    const overlay = document.querySelector('.nav-overlay, .error-overlay, .stream-error-overlay');
+    if (!overlay) return log('warn', 'No overlay element found (ok on some pages)');
+    const hiddenByDefault = window.getComputedStyle(overlay).display === 'none';
+    log(hiddenByDefault, 'Overlay hidden by default');
+  }
+
+  function checkYouTube() {
+    if (window.__YT_WIRED__) log(true, 'YouTube init wired');
+    else log('warn', 'YouTube module not initialized (ok if no YT embeds)');
+  }
+
+  function checkAudio() {
+    if (window.__RADIO_WIRED__) log(true, 'Radio/audio init wired');
+    else log('warn', 'Radio/audio module not initialized (ok if no audio)');
+  }
+
+  function checkMediaHub() {
+    const hub = document.querySelector('.media-hub');
+    if (!hub) return log('warn', 'Media Hub not present on this page');
+    const list = hub.querySelector('.mh-list');
+    if (list) log(true, 'Media Hub containers present');
+    else log(false, 'Media Hub list missing');
+  }
+
+  function runChecks() {
+    console.groupCollapsed('%cPakStream Sanity Checklist', 'color:#1E88E5;font-weight:bold');
+    checkNav();
+    checkOverlay();
+    checkYouTube();
+    checkAudio();
+    checkMediaHub();
+    console.groupEnd();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runChecks, { once: true });
+  } else {
+    runChecks();
+  }
+})();


### PR DESCRIPTION
## Summary
- add browser diagnostic checks for nav, overlays, players and media hub
- include diagnostics script in default layout after main.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61327020c832092f114c27386688b