### PR TITLE
Fix media hub script collisions and SW asset path

### DIFF
--- a/assets/js/mh-channels.js
+++ b/assets/js/mh-channels.js
@@ -1,6 +1,6 @@
-const __mh = (() => {
+(() => {
   // Avoid redefining across modules
-  if (window.__PAKSTREAM_MH_UTILS__) return window.__PAKSTREAM_MH_UTILS__;
+  if (window.__mh) return;
 
   const qs  = (sel, root=document) => root.querySelector(sel);
   const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
@@ -35,11 +35,11 @@ const __mh = (() => {
     document.dispatchEvent(new CustomEvent(name, { detail }));
   }
 
-  return (window.__PAKSTREAM_MH_UTILS__ = { qs, qsa, on, required, emptyState, clearContainer, emit });
+  window.__mh = { qs, qsa, on, required, emptyState, clearContainer, emit };
 })();
 
 window.PAKSTREAM_MH_CHANNELS = (function () {
-  const { qs, qsa, on, required, emptyState, clearContainer } = __mh;
+  const { qs, qsa, on, required, emptyState, clearContainer } = window.__mh;
 
   // Adjust to your actual data source(s)
   const DATA_URL = '/channels.json'; // or read from a data-* attribute on root

--- a/assets/js/mh-search.js
+++ b/assets/js/mh-search.js
@@ -1,6 +1,6 @@
-const __mh = (() => {
+(() => {
   // Avoid redefining across modules
-  if (window.__PAKSTREAM_MH_UTILS__) return window.__PAKSTREAM_MH_UTILS__;
+  if (window.__mh) return;
 
   const qs  = (sel, root=document) => root.querySelector(sel);
   const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
@@ -35,11 +35,11 @@ const __mh = (() => {
     document.dispatchEvent(new CustomEvent(name, { detail }));
   }
 
-  return (window.__PAKSTREAM_MH_UTILS__ = { qs, qsa, on, required, emptyState, clearContainer, emit });
+  window.__mh = { qs, qsa, on, required, emptyState, clearContainer, emit };
 })();
 
 window.PAKSTREAM_MH_SEARCH = (function () {
-  const { qs, on, emit } = __mh;
+  const { qs, on, emit } = window.__mh;
 
   function init({ root, search }) {
     if (!root || !search) return;

--- a/assets/js/mh-tabs.js
+++ b/assets/js/mh-tabs.js
@@ -1,6 +1,6 @@
-const __mh = (() => {
+(() => {
   // Avoid redefining across modules
-  if (window.__PAKSTREAM_MH_UTILS__) return window.__PAKSTREAM_MH_UTILS__;
+  if (window.__mh) return;
 
   const qs  = (sel, root=document) => root.querySelector(sel);
   const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
@@ -35,11 +35,11 @@ const __mh = (() => {
     document.dispatchEvent(new CustomEvent(name, { detail }));
   }
 
-  return (window.__PAKSTREAM_MH_UTILS__ = { qs, qsa, on, required, emptyState, clearContainer, emit });
+  window.__mh = { qs, qsa, on, required, emptyState, clearContainer, emit };
 })();
 
 window.PAKSTREAM_MH_TABS = (function () {
-  const { qs, qsa, on, required, emit } = __mh;
+  const { qs, qsa, on, required, emit } = window.__mh;
 
   function init({ root, tabs }) {
     if (!root) return;

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -1,6 +1,6 @@
-const __mh = (() => {
+(() => {
   // Avoid redefining across modules
-  if (window.__PAKSTREAM_MH_UTILS__) return window.__PAKSTREAM_MH_UTILS__;
+  if (window.__mh) return;
 
   const qs  = (sel, root=document) => root.querySelector(sel);
   const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
@@ -35,14 +35,14 @@ const __mh = (() => {
     document.dispatchEvent(new CustomEvent(name, { detail }));
   }
 
-  return (window.__PAKSTREAM_MH_UTILS__ = { qs, qsa, on, required, emptyState, clearContainer, emit });
+  window.__mh = { qs, qsa, on, required, emptyState, clearContainer, emit };
 })();
 
 (() => {
   if (window.__MH_BOOT_WIRED__) return;
   window.__MH_BOOT_WIRED__ = true;
 
-  const { qs, required, emit } = __mh;
+  const { qs, required, emit } = window.__mh;
 
   // Required top-level containers (adjust selectors to your DOM)
   const SEL = {

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@ const SHELL_ASSETS = [
   '/images/icons/icon-192-maskable.png',
   '/images/icons/icon-256-maskable.png',
   '/images/icons/icon-384-maskable.png',
-  '/images/icons/icon-512-maskable.png'
+  '/icon-512-maskable.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- Guard Media Hub helper against multiple declarations and rely on a shared `window.__mh`
- Update hub modules to consume the shared helper
- Correct service worker asset list to use existing 512px maskable icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a613ac57448320adad170d06ea57ee