### PR TITLE
feat: add minimal flagged service worker

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -87,11 +87,11 @@
   {% unless page.no_ads %}
   <script defer src="/js/ad-config.js"></script>
   <script defer src="/js/ad-slot.js"></script>
-  <script defer src="/js/pwa.js"></script>
   <script defer src="/js/maintenance.js"></script>
   <script defer src="/js/error-overlay.js"></script>
   <script defer src="/js/main.js"></script>
   <script src="/js/diagnostics.js"></script>
   {% endunless %}
+  <script src="/js/pwa.js"></script>
 </body>
 </html>

--- a/js/ad-config.js
+++ b/js/ad-config.js
@@ -1,1 +1,7 @@
 // Ad configuration placeholder
+
+// Feature flags for PakStream
+window.__PAKSTREAM_FLAGS = Object.assign({
+  sw: false,
+  swDebug: false
+}, window.__PAKSTREAM_FLAGS || {});

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,131 +1,35 @@
-(function () {
-  let deferredPrompt = null;
-  const installBtn = document.getElementById('install-btn');
+(() => {
+  if (!('serviceWorker' in navigator)) return;
 
-  function showInstallUI() {
-    if (installBtn) installBtn.hidden = false;
-    document.querySelectorAll('#consent-install').forEach(btn => btn.hidden = false);
-    document.dispatchEvent(new Event('pwa-install-available'));
-    maybeShowBanner();
-    window.dataLayer && window.dataLayer.push({ event: 'pwa_install_prompt_shown' });
-  }
+  const FLAGS = window.__PAKSTREAM_FLAGS || {};
+  const SW_PATH = '/sw.js';
 
-  function maybeShowBanner() {
-    if (localStorage.getItem('pwa-banner-dismissed')) return;
-    const banner = document.createElement('div');
-    banner.id = 'install-banner';
-    banner.className = 'install-banner';
-    banner.innerHTML = '<span>Install PakStream?</span> <button id="banner-install">Install</button> <button id="banner-dismiss">Dismiss</button>';
-    document.body.appendChild(banner);
-    document.getElementById('banner-install').addEventListener('click', () => {
-      promptInstall();
-      dismiss();
+  // Console helper to unregister and clear caches
+  window.PAKSTREAM_SW_RESET = async function () {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(regs.map(r => r.unregister()));
+    const keys = await caches.keys();
+    await Promise.all(keys.map(k => caches.delete(k)));
+    console.log('[pwa] service workers unregistered and caches cleared');
+  };
+
+  if (!FLAGS.sw) {
+    // If a SW exists but flag is off, unregister it (dev convenience)
+    navigator.serviceWorker.getRegistrations().then(regs => {
+      if (regs.length && FLAGS.swDebug) console.log('[pwa] flag off → unregister existing SW');
+      regs.forEach(r => r.unregister());
     });
-    document.getElementById('banner-dismiss').addEventListener('click', dismiss);
-    function dismiss() {
-      banner.remove();
-      localStorage.setItem('pwa-banner-dismissed', 'yes');
-    }
+    return;
   }
 
-  function promptInstall() {
-    if (!deferredPrompt) return;
-    deferredPrompt.prompt();
-    deferredPrompt.userChoice.finally(() => {
-      deferredPrompt = null;
-    });
-  }
-  window.promptInstall = promptInstall;
-
-  window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferredPrompt = e;
-    showInstallUI();
-  });
-
-  if (installBtn) {
-    installBtn.addEventListener('click', promptInstall);
-  }
-
-  window.addEventListener('appinstalled', () => {
-    if (installBtn) installBtn.hidden = true;
-    window.dataLayer && window.dataLayer.push({ event: 'pwa_installed' });
-  });
-
-  // Service Worker registration and updates
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js').then(reg => {
-      if (reg.waiting) {
-        showUpdateToast(reg);
-        window.dataLayer && window.dataLayer.push({ event: 'sw_update_available' });
-      }
-      reg.addEventListener('updatefound', () => {
-        const nw = reg.installing;
-        if (!nw) return;
-        nw.addEventListener('statechange', () => {
-          if (nw.state === 'installed' && navigator.serviceWorker.controller) {
-            showUpdateToast(reg);
-            window.dataLayer && window.dataLayer.push({ event: 'sw_update_available' });
-          }
-        });
+  // Register the minimal SW
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register(SW_PATH)
+      .then(reg => {
+        if (FLAGS.swDebug) console.log('[pwa] registered', reg);
+      })
+      .catch(err => {
+        console.warn('[pwa] registration failed', err);
       });
-    });
-
-    let refreshing;
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      if (refreshing) return;
-      refreshing = true;
-      window.location.reload();
-      window.dataLayer && window.dataLayer.push({ event: 'sw_updated' });
-    });
-
-    navigator.serviceWorker.addEventListener('message', event => {
-      if (event.data && event.data.type === 'json-fallback') {
-        showCacheLabel();
-      }
-    });
-  }
-
-  function showUpdateToast(reg) {
-    const toast = document.createElement('div');
-    toast.className = 'sw-toast';
-    toast.innerHTML = '<span>Update available</span> <button id="sw-update">Reload</button>';
-    document.body.appendChild(toast);
-    document.getElementById('sw-update').addEventListener('click', () => {
-      reg.waiting && reg.waiting.postMessage('skipWaiting');
-      toast.remove();
-    });
-  }
-
-  function updateOnline() {
-    const offline = !navigator.onLine;
-    document.querySelectorAll('button.play-pause-btn').forEach(btn => {
-      if (offline) {
-        if (!btn.dataset.offText) btn.dataset.offText = btn.textContent;
-        btn.disabled = true;
-        btn.textContent = 'Connect to play';
-      } else {
-        btn.disabled = false;
-        if (btn.dataset.offText) btn.textContent = btn.dataset.offText;
-      }
-    });
-  }
-  window.addEventListener('online', updateOnline);
-  window.addEventListener('offline', updateOnline);
-  document.addEventListener('DOMContentLoaded', updateOnline);
-
-  if ((navigator.connection && navigator.connection.saveData) || window.matchMedia('(prefers-reduced-data: reduce)').matches) {
-    document.querySelectorAll('link[rel="prefetch"]').forEach(l => l.remove());
-  }
-
-  function showCacheLabel() {
-    let el = document.getElementById('cache-label');
-    if (!el) {
-      el = document.createElement('div');
-      el.id = 'cache-label';
-      el.className = 'cache-label';
-      el.textContent = 'from cache';
-      document.body.appendChild(el);
-    }
-  }
+  });
 })();

--- a/sw.js
+++ b/sw.js
@@ -1,97 +1,56 @@
-const SHELL_CACHE = 'ps-shell-v1';
-const JSON_CACHE = 'ps-json-v1';
-const SHELL_ASSETS = [
-  '/',
-  '/index.html',
-  '/assets/css/tokens.css',
+/* Minimal Service Worker: explicit tiny precache, no runtime routing */
+const CACHE_VERSION = 'v1.0.0'; // bump to invalidate
+const CACHE_NAME = `pakstream-${CACHE_VERSION}`;
+
+// EXPLICIT file list only; keep this tiny and only first-party assets
+const PRECACHE_URLS = [
+  '/',                     // or '/index.html' if your host requires
   '/css/theme.css',
-  '/css/z-layers.css',
   '/css/style.css',
+  '/css/z-layers.css',
   '/js/main.js',
-  '/js/pwa.js',
-  '/favicon.ico',
-  '/manifest.webmanifest',
-  '/images/icons/icon-192-maskable.png',
-  '/images/icons/icon-256-maskable.png',
-  '/images/icons/icon-384-maskable.png',
-  '/images/icons/icon-512-maskable.png'
+  '/js/youtube.js',
+  '/js/radio.js',
+  '/js/diagnostics.js',
+  '/js/ad-config.js',
+  '/js/ad-slot.js'
+  // DO NOT add JSON/data/media endpoints here
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(SHELL_CACHE).then(cache => cache.addAll(SHELL_ASSETS))
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
   );
+  // Activate immediately on first install
   self.skipWaiting();
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then(keys => Promise.all(
-      keys.filter(k => ![SHELL_CACHE, JSON_CACHE].includes(k)).map(k => caches.delete(k))
-    )).then(() => self.clients.claim())
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(k => k.startsWith('pakstream-') && k !== CACHE_NAME)
+            .map(k => caches.delete(k))
+      )
+    )
   );
+  self.clients.claim();
 });
 
-self.addEventListener('fetch', event => {
-  const req = event.request;
-  if (req.method !== 'GET') return;
-  const url = new URL(req.url);
+// ONLY serve from precache for those exact URLs; no runtime caching
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
 
-  if (req.destination === 'video' || req.destination === 'audio' ||
-      url.hostname.includes('youtube.com') || url.hostname.includes('ytimg.com') || url.hostname.includes('googlevideo.com')) {
-    return;
-  }
+  // Same-origin only
+  if (url.origin !== location.origin) return;
 
-  if (req.destination === 'style' || req.destination === 'script' || req.destination === 'font') {
-    event.respondWith(cacheFirst(req, SHELL_CACHE));
-    return;
-  }
+  // Only respond for explicit precache URLs
+  if (!PRECACHE_URLS.includes(url.pathname)) return;
 
-  if (url.pathname.endsWith('.json') && url.pathname !== '/config.json') {
-    event.respondWith(networkFirst(req, JSON_CACHE));
-    return;
-  }
-});
-
-function cacheFirst(req, cacheName) {
-  return caches.open(cacheName).then(cache =>
-    cache.match(req).then(cached => {
-      if (cached) return cached;
-      return fetch(req).then(res => {
-        if (res && res.status === 200) {
-          cache.put(req, res.clone());
-        }
-        return res;
-      });
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cached = await cache.match(event.request);
+      return cached || fetch(event.request);
     })
   );
-}
-
-function networkFirst(req, cacheName) {
-  return Promise.race([
-    fetch(req).then(res => {
-      if (res && res.status === 200) {
-        const copy = res.clone();
-        caches.open(cacheName).then(cache => cache.put(req, copy));
-        return res;
-      }
-      throw new Error('Bad response');
-    }),
-    new Promise((_, reject) => setTimeout(reject, 3000))
-  ]).catch(() => {
-    return caches.open(cacheName).then(cache => cache.match(req)).then(res => {
-      if (res) {
-        self.clients.matchAll().then(clients => {
-          clients.forEach(client => client.postMessage({ type: 'json-fallback', url: req.url }));
-        });
-      }
-      return res;
-    });
-  });
-}
-
-self.addEventListener('message', event => {
-  if (event.data === 'skipWaiting') {
-    self.skipWaiting();
-  }
 });


### PR DESCRIPTION
## Summary
- add feature flags to configure service worker
- register service worker only when flag enabled and provide reset helper
- replace service worker with tiny explicit precache and no runtime routing
- load service worker script after other scripts in layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a614858d74832099a5a9d2c862a682