### PR TITLE
Fix Media Hub root selector and service worker protocol handling

### DIFF
--- a/media-hub.html
+++ b/media-hub.html
@@ -35,13 +35,13 @@
 
   <div class="ad-slot" data-ad-preset="hub_inline"></div>
 
-  <section id="mh-panel" class="youtube-section media-hub-section" role="tabpanel">
+  <section id="mh-panel" class="youtube-section media-hub media-hub-section" role="tabpanel">
     <div id="hub-controls" class="hub-controls">
-      <div id="mh-tabs" class="mode-tabs" role="tablist">
-        <button class="tab-btn" id="mh-tab-all" role="tab" data-tab="all" aria-controls="mh-panel" aria-selected="true" tabindex="0">All</button>
-        <button class="tab-btn" id="mh-tab-tv" role="tab" data-tab="tv" aria-controls="mh-panel" aria-selected="false" tabindex="-1">TV</button>
-        <button class="tab-btn" id="mh-tab-radio" role="tab" data-tab="radio" aria-controls="mh-panel" aria-selected="false" tabindex="-1">Radio</button>
-        <button class="tab-btn" id="mh-tab-creators" role="tab" data-tab="creators" aria-controls="mh-panel" aria-selected="false" tabindex="-1">Creators</button>
+      <div id="mh-tabs" class="mode-tabs mh-tabs" role="tablist">
+        <button class="tab-btn is-active" id="mh-tab-all" role="tab" data-mh-tab="all" aria-controls="mh-panel" aria-selected="true" tabindex="0">All</button>
+        <button class="tab-btn" id="mh-tab-tv" role="tab" data-mh-tab="tv" aria-controls="mh-panel" aria-selected="false" tabindex="-1">TV</button>
+        <button class="tab-btn" id="mh-tab-radio" role="tab" data-mh-tab="radio" aria-controls="mh-panel" aria-selected="false" tabindex="-1">Radio</button>
+        <button class="tab-btn" id="mh-tab-creators" role="tab" data-mh-tab="creators" aria-controls="mh-panel" aria-selected="false" tabindex="-1">Creators</button>
       </div>
       <div class="filters-row">
         <select id="topic-filter" multiple aria-label="Filter by topic"></select>
@@ -58,17 +58,17 @@
       <div id="selected-filters" class="selected-filters" aria-live="polite"></div>
       <div id="results-count" class="results-count" aria-live="polite"></div>
     </div>
-    <div id="mh-search" role="search">
+    <div id="mh-search" class="mh-search" role="search">
       <input type="search" placeholder="Search channels…" aria-label="Search channels">
       <button type="button" class="clear-btn" aria-label="Clear search" hidden>×</button>
     </div>
     <!-- LEFT RAIL -->
-    <div id="mh-channels" class="channel-list" aria-label="Channel list">
+    <div id="mh-channels" class="channel-list mh-list" aria-label="Channel list">
       <div class="mh-channels-inner"></div>
     </div>
 
     <!-- CENTER -->
-    <div class="video-section">
+    <div class="video-section mh-video">
       <div class="button-row">
         <div class="spacer"></div>
         <button id="mh-channels-toggle" class="channel-toggle" aria-label="Toggle channel list" aria-controls="mh-channels">
@@ -87,7 +87,7 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
-        <div id="audioWrap" class="audio-wrap" style="display:none;">
+        <div id="audioWrap" class="audio-wrap mh-audio" style="display:none;">
           <div id="player-container" class="radio-player">
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">

--- a/sw.js
+++ b/sw.js
@@ -37,6 +37,11 @@ self.addEventListener('fetch', event => {
   if (req.method !== 'GET') return;
   const url = new URL(req.url);
 
+  // Only handle http(s) requests; skip browser-extension or other schemes
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return;
+  }
+
   if (req.destination === 'video' || req.destination === 'audio' ||
       url.hostname.includes('youtube.com') || url.hostname.includes('ytimg.com') || url.hostname.includes('googlevideo.com')) {
     return;


### PR DESCRIPTION
## Summary
- ensure service worker ignores non-http requests to avoid cache errors
- add missing Media Hub root and module class hooks for tabs, search, and channel list

## Testing
- `npm test >/tmp/unit.log 2>&1 ; tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a616350c548320a0843e341337000c