### PR TITLE
feat: add feature-gated palette switch

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,6 +88,8 @@
   {% unless page.no_ads %}
   <script defer src="/js/maintenance.js"></script>
   <script defer src="/js/error-overlay.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
   <script src="/js/ads/config.js"></script>
   <script src="/js/ads/ads.js"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -144,6 +144,8 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -93,6 +93,8 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -93,6 +93,8 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/creators.html
+++ b/creators.html
@@ -477,6 +477,8 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/css/theme.css
+++ b/css/theme.css
@@ -98,6 +98,39 @@
   --shadow-xxl: 0 8px 20px rgba(0,0,0,0.4);
 }
 
+/* New palette (scoped): activated by [data-theme="new"] or JS applying .theme-new */
+:root.theme-new,
+html[data-theme="new"],
+body[data-theme="new"] {
+  /* Primary */
+  --primary: #0F5132;
+  --on-primary: #FFFFFF;
+  --primary-container: #D1E7DD;
+  --on-primary-container: #0A3622;
+
+  /* Secondary / Accent */
+  --secondary: #E0B100;
+  --on-secondary: #1A1A1A;
+
+  /* Background / Surface */
+  --background: #F7F9FC;
+  --on-background: #263238;
+  --surface: #FFFFFF;
+  --on-surface: #263238;
+
+  /* Error (unchanged or updated if needed) */
+  --error: #D32F2F;
+  --on-error: #FFFFFF;
+
+  /* Variants */
+  --outline: #CBD5E1;
+  --surface-variant: #EEF2F7;
+  --on-surface-variant: #4B5563;
+
+  /* Accents */
+  --accent-live: #1E88E5;
+}
+
 /* Accessible, high-contrast focus ring */
 :where(a, button, input, select, textarea, [tabindex]):focus-visible {
   outline: 3px solid var(--accent-link);

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -552,6 +552,8 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/freepress.html
+++ b/freepress.html
@@ -563,6 +563,8 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -346,6 +346,8 @@
   </script>
   <script defer src="/js/discovery.js"></script>
   <script defer src="/assets/js/carousel.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
   <script src="/js/ads/config.js"></script>
   <script src="/js/ads/ads.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -362,3 +362,24 @@ if ('serviceWorker' in navigator) {
     });
   });
 }
+
+(() => {
+  const FLAGS = window.__PAKSTREAM_FLAGS || {};
+  const root = document.documentElement;
+
+  function applyThemeFlag() {
+    if (FLAGS.newPalette) {
+      root.classList.add('theme-new');
+    } else {
+      root.classList.remove('theme-new');
+    }
+  }
+
+  // Run once and on rerenders
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyThemeFlag, { once: true });
+  } else {
+    applyThemeFlag();
+  }
+  window.addEventListener('pakstream:rerender', applyThemeFlag);
+})();

--- a/js/utils/flags.js
+++ b/js/utils/flags.js
@@ -1,0 +1,4 @@
+// Feature flags: baseline defaults
+window.__PAKSTREAM_FLAGS = Object.assign({
+  newPalette: false
+}, window.__PAKSTREAM_FLAGS || {});

--- a/livetv.html
+++ b/livetv.html
@@ -468,6 +468,8 @@
   </script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -85,6 +85,8 @@
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub.html
+++ b/media-hub.html
@@ -145,6 +145,8 @@
   <!-- 4) Site-wide scripts (may listen to hub events) -->
   <script src="/js/youtube.js"></script>
   <script src="/js/radio.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script src="/js/main.js"></script>
   <script src="/js/ads/config.js"></script>
   <script src="/js/ads/ads.js"></script>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -183,6 +183,8 @@
       navigator.clipboard.writeText(text);
     });
   </script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -119,6 +119,8 @@
     });
   </script>
   <script defer src="/js/discovery.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -599,6 +599,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   </script>
   <script src="/js/leftmenu.js"></script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -98,6 +98,8 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -344,6 +344,8 @@
       document.getElementById('themeStylesheet').href = this.value;
     });
   </script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -155,6 +155,8 @@
       }
     });
   </script>
+  <script src="/js/utils/flags.js"></script>
+
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add baseline flag with `newPalette` toggle
- allow auto theme switching when flag or data attribute active
- include new palette token overrides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a616e8ff1c8320a461523f0c4faa4d