### PR TITLE
Remove trending now feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,6 @@
     </div>
   </section>
 
-  <section id="trending-rail" class="rail-section lazy-rail" aria-label="Trending Now"></section>
   <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
   <section class="station-scroller-wrap" aria-label="Trending channels">

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -831,9 +831,6 @@ async function renderLatestVideosRSS(channelId) {
         poster: thumbOf(item)
       });
     }
-    if (window.trendingService) {
-      window.trendingService.recordClick({ id: item.key, type: modeOfItem(item) });
-    }
   }
 
   // ---- Radio playback ----
@@ -883,10 +880,6 @@ async function renderLatestVideosRSS(channelId) {
         url: '/media-hub.html?m=radio&c=' + encodeURIComponent(id),
         poster: logoUrl || thumbOf(item)
       });
-    }
-    if (window.trendingService) {
-      const id = item.ids?.internal_id || item.key;
-      window.trendingService.recordClick({ id, type: 'radio' });
     }
 
     if (mainPlayer) {

--- a/media-hub.html
+++ b/media-hub.html
@@ -26,8 +26,7 @@
   <!-- Top bar (same as site) -->
 {% include top-bar.html %}
 
-  <section id="trending-rail" class="rail-section lazy-rail" aria-label="Trending Now"></section>
-  <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
+    <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
   <section class="youtube-section media-hub-section">
     <div class="mode-tabs">

--- a/privacy.html
+++ b/privacy.html
@@ -114,7 +114,6 @@
       if(btn) btn.addEventListener('click', function(){
         if(confirm('Clear local history?')){
           if(window.historyService) window.historyService.clear();
-          if(window.trendingService) window.trendingService.clear();
         }
       });
     });


### PR DESCRIPTION
## Summary
- Drop the "Trending Now" rail from the homepage and media hub.
- Remove client-side trending tracking logic and references.
- Clean up privacy page and media hub scripts to stop using trending storage.

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a62f9889d08320b3c1bb8d9b0af76e