### PR TITLE
Hide top bar logo text on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,6 +144,9 @@ footer nav a:hover {
     margin-left: 8px;
     max-width: none;
   }
+  .logo-title {
+    display: none;
+  }
 }
 
 .search-results {


### PR DESCRIPTION
## Summary
- hide site logo text in the top bar on screens 600px wide or smaller

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a631461758832085e32e5093d82ceb