### PR TITLE
feat: add feature flags and diagnostics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>
+  // Safe to edit per-environment without touching versioned JS files
+  window.__PAKSTREAM_FLAGS = {
+    // flip to true only when ready
+    newPalette: false,
+    adsEnabled: false,
+    mediaHubV2: false,
+    debugDiagnostics: true
+  };
+  </script>
 {% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
@@ -76,6 +86,8 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/utils/flags.js" defer></script>
+  <script src="/js/diagnostics.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/ads/ads.js
+++ b/js/ads/ads.js
@@ -2,7 +2,8 @@
   if (window.__ADS_WIRED__) return;
   window.__ADS_WIRED__ = true;
 
-  const FLAGS = window.__PAKSTREAM_FLAGS || {};
+  const F = (window.PAKSTREAM && window.PAKSTREAM.Flags) || { isOn: () => false, all: () => ({}) };
+  const FLAGS = F.all();
   const PRESETS = window.__PAKSTREAM_AD_PRESETS || {};
   const log = (...a) => FLAGS.adsDebug && console.log('[ads]', ...a);
 
@@ -55,7 +56,7 @@
     // Always reserve to prevent CLS, even when ads are disabled
     slots.forEach(el => { applyPreset(el); reserve(el); });
 
-    if (!FLAGS.ads) {
+    if (!F.isOn('adsEnabled')) {
       log('ads disabled; reserved only');
       return;
     }

--- a/js/ads/config.js
+++ b/js/ads/config.js
@@ -1,6 +1,6 @@
 // Feature flags: merge into existing flags object if present
 window.__PAKSTREAM_FLAGS = Object.assign({
-  ads: false,            // default off (safe)
+  adsEnabled: false,     // default off (safe)
   adsDebug: false,       // optional debug logging
   sw: false,             // minimal service worker (off by default)
   swDebug: false         // debug logging for service worker

--- a/js/diagnostics.js
+++ b/js/diagnostics.js
@@ -1,70 +1,42 @@
-(() => {
-  if (window.__DIAG_WIRED__) return;
-  window.__DIAG_WIRED__ = true;
+(function () {
+  const F = (window.PAKSTREAM && window.PAKSTREAM.Flags) || { isOn: () => false };
+  if (!F.isOn('debugDiagnostics')) return;
 
-  const log = (ok, msg) => {
-    const styleOk  = 'color: #2E7D32; font-weight: bold';
-    const styleBad = 'color: #C62828; font-weight: bold';
-    const styleWarn= 'color: #FB8C00; font-weight: bold';
-    if (ok === true)   console.log('%c\u2714 PASS%c ' + msg, styleOk, '');
-    else if (ok === false) console.log('%c\u2718 FAIL%c ' + msg, styleBad, '');
-    else               console.log('%c\u26A0 WARN%c ' + msg, styleWarn, '');
-  };
+  const out = [];
+  const ok = (k, pass, extra = '') => out.push({ k, pass, extra });
 
-  function checkNav() {
-    const opener = document.querySelector('#nav-toggle, .nav-toggle');
-    const menu   = document.querySelector('#primary-navigation, .primary-navigation');
-    if (opener && menu) log(true, 'Nav elements present');
-    else log(false, 'Nav toggle or menu missing');
-  }
+  // Check critical hooks
+  ok('document readyState', /interactive|complete/.test(document.readyState));
+  ok('manifest link', !!document.querySelector('link[rel="manifest"]'));
+  ok('service worker support', 'serviceWorker' in navigator);
 
-  function checkOverlay() {
-    const overlay = document.querySelector('.nav-overlay, .error-overlay, .stream-error-overlay');
-    if (!overlay) return log('warn', 'No overlay element found (ok on some pages)');
-    const hiddenByDefault = window.getComputedStyle(overlay).display === 'none';
-    log(hiddenByDefault, 'Overlay hidden by default');
-  }
+  // Overlay/menu hooks (harmless if missing)
+  ok('[data-overlay] exists', !!document.querySelector('[data-overlay]'));
+  ok('[data-nav-toggle] exists', !!document.querySelector('[data-nav-toggle]'));
+  ok('#site-nav exists', !!document.getElementById('site-nav'));
 
-  function checkYouTube() {
-    if (window.__YT_WIRED__) log(true, 'YouTube init wired');
-    else log('warn', 'YouTube module not initialized (ok if no YT embeds)');
-  }
+  // Stream modules (harmless if not yet added)
+  ok('StreamState loaded', !!(window.PAKSTREAM && window.PAKSTREAM.StreamState));
+  ok('ErrorOverlay loaded', !!(window.PAKSTREAM && window.PAKSTREAM.ErrorOverlay));
 
-  function checkAudio() {
-    if (window.__RADIO_WIRED__) log(true, 'Radio/audio init wired');
-    else log('warn', 'Radio/audio module not initialized (ok if no audio)');
-  }
-
-  function checkMediaHub() {
-    const hub = document.querySelector('.media-hub');
-    if (!hub) return log('warn', 'Media Hub not present on this page');
-    const list = hub.querySelector('.mh-list');
-    if (list) log(true, 'Media Hub containers present');
-    else log(false, 'Media Hub list missing');
-  }
-
-  async function checkDataCounts() {
-    if (!window.PAKSTREAM_DATA) return log('warn', 'Data loader not present');
-    const data = await window.PAKSTREAM_DATA.getAllStreams();
-    if (!data) return log(false, 'all_streams.json missing or invalid');
-    const { counts } = data;
-    log(true, `Data counts: radio=${counts.radio||0}, tv=${counts.tv||0}, creators=${counts.creators||0}, freepress=${counts.freepress||0}`);
-  }
-
-  async function runChecks() {
-    console.groupCollapsed('%cPakStream Sanity Checklist', 'color:#1E88E5;font-weight:bold');
-    checkNav();
-    checkOverlay();
-    checkYouTube();
-    checkAudio();
-    checkMediaHub();
-    await checkDataCounts();
-    console.groupEnd();
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', runChecks, { once: true });
+  // PWA registration check
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations()
+      .then(regs => {
+        ok('SW registered', regs && regs.length > 0, regs.map(r => r.scope).join(', '));
+        dump();
+      })
+      .catch(() => dump());
   } else {
-    runChecks();
+    dump();
+  }
+
+  function dump() {
+    const pass = out.filter(x => x.pass).length;
+    const fail = out.length - pass;
+    const style = (p) => p ? 'color: #2e7d32' : 'color: #c62828';
+    console.groupCollapsed('%cPakStream Diagnostics%c  pass:' + pass + '  fail:' + fail, 'font-weight:700', '');
+    out.forEach(({ k, pass, extra }) => console.log('%c' + (pass ? '\u2713\uFE0E ' : '\u2717\uFE0E ') + k, style(pass), extra || ''));
+    console.groupEnd();
   }
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,12 @@
+if (window.PAKSTREAM?.Flags?.isOn('newPalette')) {
+  document.documentElement.classList.add('theme-new');
+}
+
+// Example: only render ad slots if ads are enabled
+if (window.PAKSTREAM?.Flags?.isOn('adsEnabled')) {
+  // initAds();
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   var topBar = document.querySelector('.top-bar');
   var themeToggle = document.getElementById('theme-toggle');

--- a/js/utils/flags.js
+++ b/js/utils/flags.js
@@ -1,4 +1,22 @@
-// Feature flags: baseline defaults
-window.__PAKSTREAM_FLAGS = Object.assign({
-  newPalette: false
-}, window.__PAKSTREAM_FLAGS || {});
+(function () {
+  const defaults = {
+    newPalette: false,
+    adsEnabled: false,
+    mediaHubV2: false,
+    debugDiagnostics: false
+  };
+
+  // Merge defaults with any pre-set global flags (e.g., from inline script)
+  const globalFlags = (window.__PAKSTREAM_FLAGS && typeof window.__PAKSTREAM_FLAGS === 'object')
+    ? window.__PAKSTREAM_FLAGS
+    : {};
+
+  const flags = Object.assign({}, defaults, globalFlags);
+
+  function isOn(name) { return !!flags[name]; }
+  function set(name, value) { flags[name] = !!value; }
+  function all() { return Object.assign({}, flags); }
+
+  window.PAKSTREAM = window.PAKSTREAM || {};
+  window.PAKSTREAM.Flags = { isOn, set, all };
+})();

--- a/maintenance.html
+++ b/maintenance.html
@@ -22,7 +22,6 @@ no_ads: true
 <link rel="stylesheet" href="/css/theme.css">
 <link rel="stylesheet" href="/css/z-layers.css">
 <link rel="stylesheet" href="/css/ads.css">
-<script src="/js/utils/flags.js"></script>
 <script src="/js/data.js"></script>
 <script src="/assets/js/mh-tabs.js"></script>
 <script src="/assets/js/mh-search.js"></script>
@@ -33,7 +32,6 @@ no_ads: true
 <script src="/js/main.js"></script>
 <script src="/js/ads/config.js"></script>
 <script src="/js/ads/ads.js"></script>
-<script src="/js/diagnostics.js"></script>
 <script src="/js/pwa.js"></script>
 <link rel="stylesheet" href="/css/dev/flags-panel.css">
 <script src="/js/dev/flags-panel.js"></script>


### PR DESCRIPTION
## Summary
- introduce a feature flag utility and expose flags globally
- add developer diagnostics console report when flag is enabled
- wire flags and diagnostics into base layout and guard palette/ads code

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a630e5b2c083209e61ad90c1b3a40f