### PR TITLE
Add stream error overlay with retry

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,6 +76,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -119,6 +119,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/creators.html
+++ b/creators.html
@@ -58,8 +58,8 @@
         <span class="label" data-default="Channels">Channels</span>
       </button>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen data-youtube title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -477,6 +477,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -1378,3 +1378,46 @@ footer nav a:hover {
   background: var(--primary);
   border-radius: 2px;
 }
+
+/* Error overlay (additive) */
+.ps-error-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0,0,0,.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease;
+  z-index: 950;
+}
+.ps-error-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.ps-error-card {
+  max-width: 420px;
+  width: calc(100% - 2rem);
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.2);
+  padding: 16px 18px;
+  text-align: center;
+}
+.ps-error-title { font-weight: 700; margin-bottom: 6px; }
+.ps-error-msg { font-size: 0.95rem; opacity: .85; margin-bottom: 12px; }
+.ps-error-actions { display: flex; justify-content: center; gap: 8px; }
+.ps-error-retry {
+  appearance: none;
+  border: 0;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #1e88e5;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ps-error-retry:focus { outline: 2px solid #000; outline-offset: 2px; }
+
+/* Ensure stream containers establish a positioning context (non-breaking) */
+[data-stream-container] { position: relative; }

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -76,8 +76,8 @@
           <span class="label" data-default="About">About</span>
         </button>
       </div>
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen data-youtube title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -548,6 +548,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/freepress.html
+++ b/freepress.html
@@ -76,8 +76,8 @@
           <span class="label" data-default="About">About</span>
         </button>
       </div>
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen data-youtube title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -559,6 +559,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/radio.js
+++ b/js/radio.js
@@ -88,6 +88,13 @@
       on(audio, 'pause', () => { setPlayingUI(container, false); if (current === audio) current = null; });
       on(audio, 'ended', () => { setPlayingUI(container, false); if (current === audio) current = null; });
 
+      on(audio, 'error', () => {
+        const container = audio.closest('[data-stream-container]') || audio.parentElement;
+        window.PAKSTREAM?.ErrorOverlay?.show(container, {
+          onRetry: () => { try { audio.load(); audio.play(); } catch {} }
+        });
+      });
+
       // Click-to-toggle on container if you prefer (optional)
       // on(container, 'click', (e) => { if (e.target.closest('button, a, input, textarea')) return;
       //   if (audio.paused) playBtn?.click(); else pauseBtn?.click();

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -120,13 +120,27 @@
             }
           }
         }
+        });
+
+        players.add(player);
+
+        try {
+          const iframeEl = player.getIframe();
+          window.PAKSTREAM?.ErrorOverlay?.armIframeTimeout(iframeEl, 6000, (container) => {
+            window.PAKSTREAM?.ErrorOverlay?.show(container, {
+              onRetry: () => {
+                try {
+                  const src = iframeEl.getAttribute('src');
+                  iframeEl.setAttribute('src', src);
+                } catch {}
+              }
+            });
+          });
+        } catch {}
       });
 
-      players.add(player);
-    });
-
-    // B) Upgrade existing iframes to API players (if not already)
-    iframes.forEach(iframe => {
+      // B) Upgrade existing iframes to API players (if not already)
+      iframes.forEach(iframe => {
       if (iframe.__ytMounted) return;
       iframe.__ytMounted = true;
 
@@ -160,10 +174,24 @@
             }
           }
         }
-      });
+        });
 
-      players.add(player);
-    });
+        players.add(player);
+
+        try {
+          const iframeEl = iframe?.tagName ? iframe : player.getIframe();
+          window.PAKSTREAM?.ErrorOverlay?.armIframeTimeout(iframeEl, 6000, (container) => {
+            window.PAKSTREAM?.ErrorOverlay?.show(container, {
+              onRetry: () => {
+                try {
+                  const src = iframeEl.getAttribute('src');
+                  iframeEl.setAttribute('src', src);
+                } catch {}
+              }
+            });
+          });
+        } catch {}
+      });
 
     // Global safety: pause all when the tab is hidden
     document.addEventListener('visibilitychange', () => {

--- a/livetv.html
+++ b/livetv.html
@@ -241,6 +241,7 @@
             const div = document.createElement('div');
             div.id = ch.id;
             div.className = 'live-player';
+            div.setAttribute('data-stream-container', '');
             div.style.display = 'none';
 
             const iframe = document.createElement('iframe');
@@ -250,6 +251,7 @@
             iframe.loading = 'lazy';
             iframe.allow = 'autoplay';
             iframe.allowFullscreen = true;
+            iframe.setAttribute('data-youtube', '');
             div.appendChild(iframe);
             videoSection.appendChild(div);
           });
@@ -468,6 +470,7 @@
   </script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -33,14 +33,14 @@
         </button>
       </div>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank"
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" data-youtube
           loading="lazy"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player">
+          <div id="player-container" class="radio-player" data-stream-container>
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -81,6 +81,7 @@
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub.html
+++ b/media-hub.html
@@ -63,14 +63,14 @@
         </button>
       </div>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank"
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" data-youtube
           loading="lazy"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player">
+          <div id="player-container" class="radio-player" data-stream-container>
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -118,6 +118,7 @@
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/discovery.js"></script>
   <script defer src="/js/main.js"></script>
 </body>

--- a/radio.html
+++ b/radio.html
@@ -73,7 +73,7 @@
         <span class="label">Stations</span>
       </button>
       <div class="live-player">
-        <div id="player-container" class="radio-player">
+        <div id="player-container" class="radio-player" data-stream-container>
           <div class="station-info">
             <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
             <h3 id="current-station" class="station-title">Select a station</h3>
@@ -593,12 +593,17 @@ document.addEventListener('DOMContentLoaded', function() {
     stationLogo.src = defaultLogo;
     stationLogo.hidden = false;
     updateFavoritesUI();
+    const container = mainPlayer.closest('[data-stream-container]') || mainPlayer.parentElement;
+    window.PAKSTREAM?.ErrorOverlay?.show(container, {
+      onRetry: () => { try { mainPlayer.load(); mainPlayer.play(); } catch {} }
+    });
   });
 
 });
 
   </script>
   <script src="/js/leftmenu.js"></script>
+  <script src="/js/error-overlay.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add reusable error overlay component with retry support for failed streams
- Wire radio and YouTube players to display overlay on errors or timeouts
- Style overlay and include script across layouts and standalone pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a6303d351c832089018bd955b500c7