### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,8 @@
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}">
   <link rel="canonical" href="{{ page.url | absolute_url }}" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -76,6 +78,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -18,6 +18,8 @@
   <meta charset="UTF-8">
   <link rel="canonical" href="https://pakstream.com/about.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
@@ -93,6 +95,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -18,6 +18,8 @@
   <meta charset="UTF-8">
   <link rel="canonical" href="https://pakstream.com/contact.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
@@ -93,6 +95,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/creators.html
+++ b/creators.html
@@ -19,6 +19,8 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/creators.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -477,6 +479,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -19,6 +19,8 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/freepress.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -548,6 +550,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/freepress.html
+++ b/freepress.html
@@ -19,6 +19,8 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/freepress.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -559,6 +561,7 @@
 
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <link rel="preload" as="image"
     href="/images/pakistan-abstract-380.webp"
@@ -330,6 +332,7 @@
     });
   </script>
   <script defer src="/js/discovery.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,36 +1,7 @@
-(() => {
-  if (!('serviceWorker' in navigator)) return;
-
-  const FLAGS = window.__PAKSTREAM_FLAGS || {};
-  const SW_PATH = '/sw.js';
-
-  // Console helper to unregister and clear caches
-  window.PAKSTREAM_SW_RESET = async function () {
-    const regs = await navigator.serviceWorker.getRegistrations();
-    await Promise.all(regs.map(r => r.unregister()));
-    const keys = await caches.keys();
-    await Promise.all(keys.map(k => caches.delete(k)));
-    console.log('[pwa] service workers unregistered and caches cleared');
-  };
-
-  if (!FLAGS.sw) {
-    // If a SW exists but flag is off, unregister it (dev convenience)
-    navigator.serviceWorker.getRegistrations().then(regs => {
-      if (regs.length && FLAGS.swDebug) console.log('[pwa] flag off → unregister existing SW');
-      regs.forEach(r => r.unregister());
-    });
-    return;
-  }
-
-  // Register the minimal SW
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register(SW_PATH)
-      .then(reg => {
-        if (FLAGS.swDebug) console.log('[pwa] registered', reg);
-      })
-      .catch(err => {
-        console.warn('[pwa] registration failed', err);
-      });
+(function () {
+  if (!("serviceWorker" in navigator)) return;
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch(() => {});
   });
 })();
 

--- a/livetv.html
+++ b/livetv.html
@@ -18,7 +18,9 @@
   <meta name="author" content="PakStream by Chatdroid AB" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://pakstream.com/livetv.html" />
-  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
@@ -468,6 +470,7 @@
   </script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,15 +1,15 @@
 {
   "name": "PakStream",
   "short_name": "PakStream",
-  "description": "Your gateway to Pakistani TV, Radio & Free Press",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
-  "theme_color": "#0F5132",
-  "background_color": "#FAFAFA",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
   "icons": [
-    {"src": "/images/icons/icon-192-maskable.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable"},
-    {"src": "/images/icons/icon-256-maskable.png", "sizes": "256x256", "type": "image/png", "purpose": "any maskable"},
-    {"src": "/images/icons/icon-384-maskable.png", "sizes": "384x384", "type": "image/png", "purpose": "any maskable"},
-    {"src": "/images/icons/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable"}
+    { "src": "/images/icons/icon-192-maskable.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable any" },
+    { "src": "/images/icons/icon-256-maskable.png", "sizes": "256x256", "type": "image/png", "purpose": "maskable any" },
+    { "src": "/images/icons/icon-384-maskable.png", "sizes": "384x384", "type": "image/png", "purpose": "maskable any" },
+    { "src": "/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable any" }
   ]
 }

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -5,6 +5,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
   <title>PakStream Media Hub Embed</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -81,6 +84,7 @@
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/media-hub.html
+++ b/media-hub.html
@@ -16,6 +16,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
@@ -119,6 +121,7 @@
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script defer src="/js/discovery.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -9,6 +9,9 @@
   <!-- End cookieyes banner -->
   {% include google-analytics.html %}
   <meta charset="UTF-8">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/theme.css">
@@ -16,5 +19,6 @@
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
+  <script src="/js/pwa.js" defer></script>
 </body>
 </html>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -15,6 +15,8 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="canonical" href="https://pakstream.com/onboard-channel.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
@@ -183,6 +185,7 @@
       navigator.clipboard.writeText(text);
     });
   </script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -18,6 +18,8 @@
   <meta charset="UTF-8">
   <link rel="canonical" href="https://pakstream.com/privacy.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
@@ -120,6 +122,7 @@
     });
   </script>
   <script defer src="/js/discovery.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -19,6 +19,8 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/radio.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -599,6 +601,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   </script>
   <script src="/js/leftmenu.js"></script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,28 +1,31 @@
-const CACHE_NAME = 'pakstream-image-cache-v1';
+// sw.js
+const CACHE_NAME = "pakstream-shell-v1";
+const SHELL = ["/", "/index.html", "/manifest.webmanifest"];
 
-self.addEventListener('install', event => {
-  self.skipWaiting();
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((c) => c.addAll(SHELL)));
 });
 
-self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
 });
 
-self.addEventListener('fetch', event => {
-  const req = event.request;
-  if (req.destination === 'image') {
-    event.respondWith(
-      caches.open(CACHE_NAME).then(cache =>
-        cache.match(req).then(resp => {
-          if (resp) return resp;
-          return fetch(req).then(networkResp => {
-            if (networkResp && networkResp.status === 200) {
-              cache.put(req, networkResp.clone());
-            }
-            return networkResp;
-          });
-        })
-      )
-    );
-  }
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+  event.respondWith(
+    caches.match(request).then((cached) =>
+      cached ||
+      fetch(request).then((resp) => {
+        const copy = resp.clone();
+        caches.open(CACHE_NAME).then((c) => c.put(request, copy)).catch(() => {});
+        return resp;
+      }).catch(() => cached)
+    )
+  );
 });
+

--- a/terms.html
+++ b/terms.html
@@ -18,6 +18,8 @@
   <meta charset="UTF-8">
   <link rel="canonical" href="https://pakstream.com/terms.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph Meta Tags (Facebook, WhatsApp, LinkedIn) -->
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
@@ -98,6 +100,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -19,6 +19,8 @@
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pakstream.com/" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
 
   <link rel="preload" as="image"
     href="/images/pakistan-abstract-380.webp"
@@ -344,6 +346,7 @@
       document.getElementById('themeStylesheet').href = this.value;
     });
   </script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -15,6 +15,8 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="canonical" href="https://pakstream.com/youtube-playground.html" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
@@ -155,6 +157,7 @@
       }
     });
   </script>
+  <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- register a service worker and add a minimal PWA loader script
- link to the manifest and theme color across pages for better installability
- update manifest and service worker cache settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a6308add6c83208d383523db0d4500