### PR TITLE
Add stream error overlay with retry

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,6 +88,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/error-overlay.js" defer></script>
   <script src="/js/pwa.js" defer></script>
   <script src="/js/utils/flags.js" defer></script>
   <script src="/js/diagnostics.js" defer></script>

--- a/creators.html
+++ b/creators.html
@@ -60,8 +60,8 @@
         <span class="label" data-default="Channels">Channels</span>
       </button>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen data-youtube title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -476,7 +476,7 @@
       }
     });
 </script>
-
+  <script src="/js/error-overlay.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1415,3 +1415,45 @@ footer nav a:hover {
   white-space: nowrap;
   border: 0;
 }
+/* Error overlay (additive) */
+.ps-error-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0,0,0,.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease;
+  z-index: 950;
+}
+.ps-error-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.ps-error-card {
+  max-width: 420px;
+  width: calc(100% - 2rem);
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.2);
+  padding: 16px 18px;
+  text-align: center;
+}
+.ps-error-title { font-weight: 700; margin-bottom: 6px; }
+.ps-error-msg { font-size: 0.95rem; opacity: .85; margin-bottom: 12px; }
+.ps-error-actions { display: flex; justify-content: center; gap: 8px; }
+.ps-error-retry {
+  appearance: none;
+  border: 0;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #1e88e5;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ps-error-retry:focus { outline: 2px solid #000; outline-offset: 2px; }
+
+/* Ensure stream containers establish a positioning context (non-breaking) */
+[data-stream-container] { position: relative; }

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -78,8 +78,8 @@
           <span class="label" data-default="About">About</span>
         </button>
       </div>
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen data-youtube title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -547,7 +547,7 @@
       if (defaultCard) handleChannelClick(defaultCard);
     });
 </script>
-
+  <script src="/js/error-overlay.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>

--- a/freepress.html
+++ b/freepress.html
@@ -78,8 +78,8 @@
           <span class="label" data-default="About">About</span>
         </button>
       </div>
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen data-youtube title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -558,7 +558,7 @@
         if (defaultCard) handleChannelClick(defaultCard);
       });
 </script>
-
+  <script src="/js/error-overlay.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>

--- a/js/error-overlay.js
+++ b/js/error-overlay.js
@@ -1,58 +1,65 @@
-(function(){
-  window.showStreamError = function(container, opts){
-    if(!container) return;
-    var overlay = document.createElement('div');
-    overlay.className = 'error-overlay';
-    var msg = document.createElement('p');
-    msg.textContent = "This stream isn't responding";
-    overlay.appendChild(msg);
-    var actions = document.createElement('div');
-    var retry = document.createElement('button');
-    retry.className = 'btn';
-    retry.textContent = 'Retry';
-    retry.addEventListener('click', function(){
-      if(opts && opts.onRetry) opts.onRetry();
-      overlay.remove();
+(function () {
+  if (window.PAKSTREAM?.ErrorOverlay) return;
+
+  function h(tag, attrs = {}, children = []) {
+    const el = document.createElement(tag);
+    Object.entries(attrs).forEach(([k, v]) => {
+      if (k === 'class') el.className = v;
+      else if (k === 'text') el.textContent = v;
+      else el.setAttribute(k, v);
     });
-    actions.appendChild(retry);
-    if(opts && opts.onAlt){
-      var alt = document.createElement('button');
-      alt.className = 'btn';
-      alt.textContent = 'Try another source';
-      alt.addEventListener('click', opts.onAlt);
-      actions.appendChild(alt);
-    }
-    if(opts && opts.youtube){
-      var yt = document.createElement('a');
-      yt.className = 'btn';
-      yt.textContent = 'Open on YouTube';
-      yt.href = opts.youtube;
-      yt.target = '_blank';
-      yt.rel = 'noopener';
-      actions.appendChild(yt);
-    }
-    var rep = document.createElement('a');
-    rep.className = 'btn';
-    rep.textContent = 'Report';
-    rep.href = '/contact.html';
-    actions.appendChild(rep);
-    overlay.appendChild(actions);
-    if(opts && Array.isArray(opts.suggestions) && opts.suggestions.length){
-      var sugg = document.createElement('div');
-      sugg.className = 'suggestion-cards';
-      opts.suggestions.forEach(function(it){
-        var a = document.createElement('a');
-        a.href = it.url;
-        a.className = 'btn';
-        a.textContent = it.title;
-        sugg.appendChild(a);
-      });
-      overlay.appendChild(sugg);
-    }
-    container.style.position = 'relative';
+    children.forEach(c => el.appendChild(c));
+    return el;
+  }
+
+  function ensureOverlay(container) {
+    let overlay = container.querySelector('[data-error-overlay]');
+    if (overlay) return overlay;
+    overlay = h('div', { class: 'ps-error-overlay', 'data-error-overlay': '' }, [
+      h('div', { class: 'ps-error-card' }, [
+        h('div', { class: 'ps-error-title', text: 'Stream unavailable' }),
+        h('div', { class: 'ps-error-msg', text: 'We couldn\u2019t load this stream. You can try again.' }),
+        h('div', { class: 'ps-error-actions' }, [
+          h('button', { type: 'button', class: 'ps-error-retry', 'data-error-retry': '', text: 'Retry' })
+        ])
+      ])
+    ]);
     container.appendChild(overlay);
-    var first = overlay.querySelector('button, a');
-    if(first) first.focus();
     return overlay;
-  };
+  }
+
+  function show(container, { onRetry } = {}) {
+    const overlay = ensureOverlay(container);
+    overlay.hidden = false;
+    overlay.classList.add('is-visible');
+    const btn = overlay.querySelector('[data-error-retry]');
+    if (onRetry) {
+      btn.onclick = () => {
+        hide(container);
+        try { onRetry(); } catch {}
+      };
+    } else {
+      btn.onclick = () => hide(container);
+    }
+  }
+
+  function hide(container) {
+    const overlay = container.querySelector('[data-error-overlay]');
+    if (!overlay) return;
+    overlay.classList.remove('is-visible');
+    // keep overlay in DOM for reuse; just hide
+    overlay.hidden = true;
+  }
+
+  // Simple watchdog for iframes that don\u2019t fire onerror
+  function armIframeTimeout(iframe, ms, onTimeout) {
+    const container = iframe.closest('[data-stream-container]') || iframe.parentElement;
+    let done = false;
+    function mark() { done = true; }
+    iframe.addEventListener('load', mark, { once: true });
+    setTimeout(() => { if (!done) onTimeout?.(container); }, ms);
+  }
+
+  window.PAKSTREAM = window.PAKSTREAM || {};
+  window.PAKSTREAM.ErrorOverlay = { show, hide, armIframeTimeout };
 })();

--- a/js/radio.js
+++ b/js/radio.js
@@ -88,6 +88,13 @@
       on(audio, 'pause', () => { setPlayingUI(container, false); if (current === audio) current = null; });
       on(audio, 'ended', () => { setPlayingUI(container, false); if (current === audio) current = null; });
 
+      on(audio, 'error', () => {
+        const container = audio.closest('[data-stream-container]') || audio.parentElement;
+        window.PAKSTREAM?.ErrorOverlay?.show(container, {
+          onRetry: () => { try { audio.load(); audio.play(); } catch {} }
+        });
+      });
+
       // Click-to-toggle on container if you prefer (optional)
       // on(container, 'click', (e) => { if (e.target.closest('button, a, input, textarea')) return;
       //   if (audio.paused) playBtn?.click(); else pauseBtn?.click();

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -123,6 +123,20 @@
       });
 
       players.add(player);
+
+      try {
+        const iframeEl = player.getIframe();
+        window.PAKSTREAM?.ErrorOverlay?.armIframeTimeout(iframeEl, 6000, (cont) => {
+          window.PAKSTREAM?.ErrorOverlay?.show(cont, {
+            onRetry: () => {
+              try {
+                const src = iframeEl.getAttribute('src');
+                iframeEl.setAttribute('src', src);
+              } catch {}
+            }
+          });
+        });
+      } catch {}
     });
 
     // B) Upgrade existing iframes to API players (if not already)
@@ -163,6 +177,20 @@
       });
 
       players.add(player);
+
+      try {
+        const iframeEl = iframe;
+        window.PAKSTREAM?.ErrorOverlay?.armIframeTimeout(iframeEl, 6000, (cont) => {
+          window.PAKSTREAM?.ErrorOverlay?.show(cont, {
+            onRetry: () => {
+              try {
+                const src = iframeEl.getAttribute('src');
+                iframeEl.setAttribute('src', src);
+              } catch {}
+            }
+          });
+        });
+      } catch {}
     });
 
     // Global safety: pause all when the tab is hidden

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -36,14 +36,14 @@
         </button>
       </div>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank"
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" data-youtube
           loading="lazy"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player">
+          <div id="player-container" class="radio-player" data-stream-container>
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -60,7 +60,7 @@
               <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
               <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
               <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
-              <audio id="radio-player" autoplay></audio>
+              <audio id="radio-player" data-radio autoplay></audio>
             </div>
           </div>
         </div>
@@ -81,6 +81,7 @@
       }
     });
   </script>
+  <script src="/js/error-overlay.js" defer></script>
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>

--- a/media-hub.html
+++ b/media-hub.html
@@ -64,14 +64,14 @@
         </button>
       </div>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank"
+      <div class="live-player" data-stream-container>
+        <iframe id="playerFrame" src="about:blank" data-youtube
           loading="lazy"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player">
+          <div id="player-container" class="radio-player" data-stream-container>
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -88,7 +88,7 @@
               <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
               <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
               <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
-              <audio id="radio-player" autoplay></audio>
+              <audio id="radio-player" data-radio autoplay></audio>
             </div>
           </div>
         </div>
@@ -114,6 +114,7 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/error-overlay.js" defer></script>
 
   <!-- Keep order to preserve swipe/lock behavior from your site -->
   <script src="/js/media-hub.js"></script>

--- a/radio.html
+++ b/radio.html
@@ -75,7 +75,7 @@
         <span class="label">Stations</span>
       </button>
       <div class="live-player">
-        <div id="player-container" class="radio-player">
+        <div id="player-container" class="radio-player" data-stream-container>
           <div class="station-info">
             <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
             <h3 id="current-station" class="station-title">Select a station</h3>
@@ -92,7 +92,7 @@
             <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
             <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
             <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
-            <audio id="radio-player" autoplay></audio>
+            <audio id="radio-player" data-radio autoplay></audio>
           </div>
         </div>
       </div>
@@ -600,6 +600,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
   </script>
+  <script src="/js/error-overlay.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>


### PR DESCRIPTION
## Summary
- introduce reusable error overlay with retry logic and iframe watchdog
- hook radio and YouTube players to show overlay on stream failure
- include overlay script and styles globally and mark player containers for positioning

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6424319d883208db04b8e9b105b01