### PR TITLE
feat: central stream state for media playback

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,6 +88,9 @@
     {% include support-us.html %}
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/pwa.js" defer></script>
   <script src="/js/utils/flags.js" defer></script>
   <script src="/js/diagnostics.js" defer></script>

--- a/creators.html
+++ b/creators.html
@@ -60,8 +60,8 @@
         <span class="label" data-default="Channels">Channels</span>
       </button>
 
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-youtube-container>
+        <iframe id="playerFrame" data-youtube src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -311,7 +311,7 @@
 
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
+      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&enablejsapi=1`;
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
   }
@@ -477,6 +477,9 @@
     });
 </script>
 
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1415,3 +1415,7 @@ footer nav a:hover {
   white-space: nowrap;
   border: 0;
 }
+
+[data-radio-container].is-playing,
+[data-youtube-container].is-playing { outline: 2px solid rgba(0,0,0,.2); }
+

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -78,8 +78,8 @@
           <span class="label" data-default="About">About</span>
         </button>
       </div>
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-youtube-container>
+        <iframe id="playerFrame" data-youtube src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -361,7 +361,7 @@
 
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
+      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&enablejsapi=1`;
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
   }
@@ -548,6 +548,9 @@
     });
 </script>
 
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>

--- a/freepress.html
+++ b/freepress.html
@@ -78,8 +78,8 @@
           <span class="label" data-default="About">About</span>
         </button>
       </div>
-      <div class="live-player">
-        <iframe id="playerFrame" src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
+      <div class="live-player" data-youtube-container>
+        <iframe id="playerFrame" data-youtube src="about:blank" loading="lazy" allow="autoplay" allowfullscreen title="Selected video player"></iframe>
       </div>
       <div id="videoList" class="video-list"><p>Loading videos…</p></div>
     </div>
@@ -361,7 +361,7 @@
 
   function loadVideo(videoId) {
     if (videoId) {
-      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
+      playerFrame.src = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&enablejsapi=1`;
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
   }
@@ -559,6 +559,9 @@
       });
 </script>
 
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>

--- a/js/radio.js
+++ b/js/radio.js
@@ -1,117 +1,42 @@
-(() => {
-  if (window.__RADIO_WIRED__) return;
-  window.__RADIO_WIRED__ = true;
+// js/radio.js
+(function () {
+  const SS = window.PAKSTREAM && window.PAKSTREAM.StreamState;
+  if (!SS) return;
+  const doc = document;
 
-  const qs  = (sel, root=document) => root.querySelector(sel);
-  const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-  const on  = (el, ev, fn, opts) => el && el.addEventListener(ev, fn, opts);
+  function wireRadio(el) {
+    const id = el.dataset.playerId || ('radio-' + Math.random().toString(36).slice(2));
+    el.dataset.playerId = id;
+    const container = el.closest('[data-radio-container]') || el.parentElement;
 
-  // Registry of managed <audio> elements
-  const audioSet = new Set();
-  let current = null;
+    const api = {
+      type: 'radio',
+      el,
+      play() { try { el.play(); } catch {} container?.classList.add('is-playing'); },
+      pause() { try { el.pause(); } catch {} container?.classList.remove('is-playing'); }
+    };
+    const unregister = SS.register(id, api);
 
-  // Optional UI helpers (no-op if not present)
-  function setPlayingUI(root, isPlaying) {
-    try {
-      const playBtn  = qs('[data-audio-play]', root);
-      const pauseBtn = qs('[data-audio-pause]', root);
-      const stateEl  = qs('[data-audio-state]', root);
-      if (playBtn)  playBtn.hidden  = isPlaying;
-      if (pauseBtn) pauseBtn.hidden = !isPlaying;
-      if (stateEl)  stateEl.textContent = isPlaying ? 'Playing' : 'Paused';
-      root?.classList?.toggle('is-playing', !!isPlaying);
-    } catch {}
-  }
-
-  function pauseAll(except = null) {
-    for (const a of audioSet) {
-      if (a !== except) {
-        try { a.pause(); } catch {}
-        setPlayingUI(a.closest('[data-audio-item]') || a.parentElement, false);
-      }
-    }
-    if (except == null) current = null;
-  }
-
-  // Expose a global, safe-to-call pause hook for other modules (e.g., YouTube)
-  window.PAKSTREAM_PAUSE_ALL_AUDIO = () => pauseAll(null);
-
-  function initAudio(root = document) {
-    const items = qsa('audio[data-radio], [data-audio-item] audio', root);
-    if (items.length === 0) return;
-
-    items.forEach(audio => {
-      // Guard against double-binding
-      if (audio.__wired) return;
-      audio.__wired = true;
-
-      // Keep reference
-      audioSet.add(audio);
-
-      // Ensure attributes for reliable mobile playback
-      audio.setAttribute('preload', audio.getAttribute('preload') || 'none');
-      audio.setAttribute('playsinline', 'true');
-      // If cross-origin, allow CORS-friendly loads (depends on source headers)
-      if (!audio.hasAttribute('crossorigin')) {
-        audio.setAttribute('crossorigin', 'anonymous');
-      }
-
-      // Optional play/pause UI buttons near each item
-      const container = audio.closest('[data-audio-item]') || audio.parentElement;
-      const playBtn  = qs('[data-audio-play]', container);
-      const pauseBtn = qs('[data-audio-pause]', container);
-
-      on(playBtn, 'click', (e) => {
-        e.preventDefault();
-        // Pause any other audio and any video players
-        pauseAll(audio);
-        try { window.__YT_WIRED__ && window.PAKSTREAM_PAUSE_ALL_YT && window.PAKSTREAM_PAUSE_ALL_YT(); } catch {}
-
-        audio.play().then(() => {
-          current = audio;
-          setPlayingUI(container, true);
-        }).catch(() => {
-          // Autoplay blocked; show paused state
-          setPlayingUI(container, false);
-        });
-      });
-
-      on(pauseBtn, 'click', (e) => {
-        e.preventDefault();
-        audio.pause();
-        setPlayingUI(container, false);
-        if (current === audio) current = null;
-      });
-
-      // Keep UI in sync with native events
-      on(audio, 'play',  () => { pauseAll(audio); setPlayingUI(container, true); current = audio; });
-      on(audio, 'pause', () => { setPlayingUI(container, false); if (current === audio) current = null; });
-      on(audio, 'ended', () => { setPlayingUI(container, false); if (current === audio) current = null; });
-
-      // Click-to-toggle on container if you prefer (optional)
-      // on(container, 'click', (e) => { if (e.target.closest('button, a, input, textarea')) return;
-      //   if (audio.paused) playBtn?.click(); else pauseBtn?.click();
-      // });
+    el.addEventListener('play', () => SS.play(id));
+    el.addEventListener('pause', () => {
+      if (SS.getCurrentId() === id) { /* keep current unless another starts */ }
+      container?.classList.remove('is-playing');
     });
+    el.addEventListener('ended', () => {
+      if (SS.getCurrentId() === id) SS.stopAll(null);
+    });
+
+    // Cleanup on removal
+    const obs = new MutationObserver(() => {
+      if (!doc.contains(el)) { unregister(); obs.disconnect(); }
+    });
+    obs.observe(doc, { childList: true, subtree: true });
   }
 
-  // Pause on tab hide
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') pauseAll(null);
-  });
-
-  // Pause on custom Media Hub navigation events (emit these in your hub JS)
-  window.addEventListener('pakstream:tabchange', () => pauseAll(null));
-  window.addEventListener('pakstream:routestart', () => pauseAll(null));
-
-  // Initialize on DOM ready
+  function init() {
+    doc.querySelectorAll('audio[data-radio], [data-radio] audio').forEach(wireRadio);
+  }
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => initAudio(document), { once: true });
-  } else {
-    initAudio(document);
-  }
-
-  // Safe to re-run after dynamic renders
-  window.addEventListener('pakstream:rerender', () => initAudio(document));
-
+    document.addEventListener('DOMContentLoaded', init);
+  } else { init(); }
 })();

--- a/js/stream-state.js
+++ b/js/stream-state.js
@@ -147,3 +147,39 @@
   window.initStreamAutoRetry = initStreamAutoRetry;
   window.watchMediaStalls = watchMediaStalls;
 })();
+
+// Global singleton registry to coordinate media playback
+(function () {
+  if (window.PAKSTREAM && window.PAKSTREAM.StreamState) return;
+  const listeners = new Set();
+  const players = new Map(); // id -> { type, play, pause, el }
+  let currentId = null;
+
+  function notify() {
+    listeners.forEach(fn => { try { fn({ currentId }); } catch {} });
+  }
+  function register(id, api) {
+    players.set(id, api);
+    return () => players.delete(id);
+  }
+  function stopAll(exceptId) {
+    players.forEach((api, id) => {
+      if (id !== exceptId) { try { api.pause(); } catch {} }
+    });
+    if (exceptId == null) currentId = null;
+    notify();
+  }
+  function play(id) {
+    if (!players.has(id)) return;
+    stopAll(id);
+    currentId = id;
+    try { players.get(id).play(); } catch {}
+    notify();
+  }
+  function onChange(fn) { listeners.add(fn); return () => listeners.delete(fn); }
+
+  window.PAKSTREAM = window.PAKSTREAM || {};
+  window.PAKSTREAM.StreamState = { register, stopAll, play, onChange, getCurrentId: () => currentId };
+  // Optional global stop for debugging
+  window.PAKSTREAM.stopAll = () => stopAll(null);
+})();

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -1,188 +1,60 @@
-(() => {
-  if (window.__YT_WIRED__) return;
-  window.__YT_WIRED__ = true;
+// js/youtube.js
+(function () {
+  const SS = window.PAKSTREAM && window.PAKSTREAM.StreamState;
+  if (!SS) return;
+  const YT_IFRAME_SRC = 'https://www.youtube.com/iframe_api';
+  let apiReady = false, pending = [];
 
-  const YT_API_SRC = "https://www.youtube.com/iframe_api";
-  const qs  = (sel, root=document) => root.querySelector(sel);
-  const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-
-  // Global registry of players
-  const players = new Set();
-  let currentPlaying = null;
-
-  // ---- 1) Load IFrame API once (idempotent) ----
-  function loadYTAPI() {
-    if (window.YT && window.YT.Player) return Promise.resolve(window.YT);
-    if (document.querySelector('script[data-yt-api]')) {
-      // If the script exists but YT not ready yet, wait for onYouTubeIframeAPIReady
-      return waitForYTReady();
-    }
-    const s = document.createElement('script');
-    s.src = YT_API_SRC;
-    s.async = true;
-    s.defer = true;
-    s.setAttribute('data-yt-api', '1');
+  function loadYT() {
+    if (window.YT && window.YT.Player) { apiReady = true; flush(); return; }
+    if (document.querySelector('script[src*="youtube.com/iframe_api"]')) return;
+    const s = document.createElement('script'); s.src = YT_IFRAME_SRC; s.async = true;
     document.head.appendChild(s);
-    return waitForYTReady();
+    window.onYouTubeIframeAPIReady = function () { apiReady = true; flush(); };
   }
+  function flush() { pending.splice(0).forEach(fn => fn()); }
 
-  function waitForYTReady() {
-    return new Promise((resolve) => {
-      if (window.YT && window.YT.Player) return resolve(window.YT);
-      const prev = window.onYouTubeIframeAPIReady;
-      window.onYouTubeIframeAPIReady = function () {
-        if (typeof prev === 'function') prev();
-        resolve(window.YT);
+  function wireYT(iframe) {
+    const id = iframe.dataset.playerId || ('yt-' + Math.random().toString(36).slice(2));
+    iframe.dataset.playerId = id;
+    const container = iframe.closest('[data-youtube-container]') || iframe.parentElement;
+
+    function makePlayer() {
+      const player = new YT.Player(iframe, {
+        events: {
+          onStateChange: (e) => {
+            // 1 = playing, 2 = paused, 0 = ended
+            if (e.data === 1) { SS.play(id); container?.classList.add('is-playing'); }
+            if (e.data === 2) { container?.classList.remove('is-playing'); }
+            if (e.data === 0) { container?.classList.remove('is-playing'); if (SS.getCurrentId() === id) SS.stopAll(null); }
+          }
+        }
+      });
+      const api = {
+        type: 'youtube',
+        el: iframe,
+        play() { try { player.playVideo(); } catch {} container?.classList.add('is-playing'); },
+        pause() { try { player.pauseVideo(); } catch {} container?.classList.remove('is-playing'); }
       };
-    });
-  }
-
-  // ---- 2) Utilities ----
-  function ensureEnableJsApi(url) {
-    try {
-      const u = new URL(url, location.href);
-      if (!u.searchParams.has('enablejsapi')) u.searchParams.set('enablejsapi', '1');
-      if (!u.searchParams.has('playsinline')) u.searchParams.set('playsinline', '1');
-      // modestbranding to reduce chrome; not required but nice
-      if (!u.searchParams.has('modestbranding')) u.searchParams.set('modestbranding', '1');
-      return u.toString();
-    } catch {
-      return url;
-    }
-  }
-
-  function pauseAllExcept(player) {
-    for (const p of players) {
-      if (p !== player) {
-        try { p.pauseVideo && p.pauseVideo(); } catch {}
-      }
-    }
-  }
-
-  function markPlaying(player) {
-    currentPlaying = player;
-    pauseAllExcept(player);
-  }
-
-  function markStopped(player) {
-    if (currentPlaying === player) currentPlaying = null;
-  }
-
-  // ---- 3) Upgrade or create players ----
-  async function initYT() {
-    const containers = qsa('.yt-player[data-video-id]');
-    const iframes = qsa('iframe.yt-iframe');
-
-    if (containers.length === 0 && iframes.length === 0) {
-      // Nothing to do
-      return;
-    }
-
-    const YT = await loadYTAPI();
-
-    // A) Convert containers into API players
-    containers.forEach(container => {
-      const videoId = container.getAttribute('data-video-id');
-      if (!videoId) return;
-
-      // Guard against double mount
-      if (container.__ytMounted) return;
-      container.__ytMounted = true;
-
-      const player = new YT.Player(container, {
-        videoId,
-        playerVars: {
-          autoplay: 0,
-          rel: 0,
-          playsinline: 1,
-          modestbranding: 1
-        },
-        events: {
-          onReady: (e) => {
-            // Click-through should already work; make sure iframe allows interaction
-            const iframe = container.querySelector('iframe');
-            if (iframe) {
-              iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share');
-              iframe.setAttribute('title', iframe.getAttribute('title') || 'YouTube video');
-              iframe.setAttribute('allowfullscreen', '');
-              iframe.setAttribute('playsinline', '1');
-              // Defensive: remove any accidental pointer-events:none
-              iframe.style.pointerEvents = 'auto';
-            }
-          },
-          onStateChange: (e) => {
-            const YTState = window.YT.PlayerState;
-            if (!YTState) return;
-            if (e.data === YTState.PLAYING) {
-              markPlaying(e.target);
-            } else if (e.data === YTState.PAUSED || e.data === YTState.ENDED) {
-              markStopped(e.target);
-            }
-          }
-        }
+      const unregister = SS.register(id, api);
+      // Cleanup when removed
+      const obs = new MutationObserver(() => {
+        if (!document.contains(iframe)) { unregister(); obs.disconnect(); try { player.destroy(); } catch {} }
       });
+      obs.observe(document, { childList: true, subtree: true });
+    }
 
-      players.add(player);
-    });
-
-    // B) Upgrade existing iframes to API players (if not already)
-    iframes.forEach(iframe => {
-      if (iframe.__ytMounted) return;
-      iframe.__ytMounted = true;
-
-      // Ensure enablejsapi & playsinline
-      iframe.src = ensureEnableJsApi(iframe.src);
-
-      // Create API player bound to the iframe
-      const parent = iframe.parentElement || document.body;
-      const placeholder = document.createElement('div');
-      parent.insertBefore(placeholder, iframe);
-      // Move iframe into placeholder so the API can control it
-      placeholder.appendChild(iframe);
-
-      const player = new YT.Player(placeholder, {
-        events: {
-          onReady: (e) => {
-            // defensive attributes
-            iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share');
-            iframe.setAttribute('title', iframe.getAttribute('title') || 'YouTube video');
-            iframe.setAttribute('allowfullscreen', '');
-            iframe.setAttribute('playsinline', '1');
-            iframe.style.pointerEvents = 'auto';
-          },
-          onStateChange: (e) => {
-            const YTState = window.YT.PlayerState;
-            if (!YTState) return;
-            if (e.data === YTState.PLAYING) {
-              markPlaying(e.target);
-            } else if (e.data === YTState.PAUSED || e.data === YTState.ENDED) {
-              markStopped(e.target);
-            }
-          }
-        }
-      });
-
-      players.add(player);
-    });
-
-    // Global safety: pause all when the tab is hidden
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'hidden') {
-        for (const p of players) {
-          try { p.pauseVideo && p.pauseVideo(); } catch {}
-        }
-      }
-    });
+    if (apiReady) makePlayer(); else pending.push(makePlayer);
   }
 
-  // ---- 4) Initialize on DOM ready (idempotent) ----
+  function init() {
+    const iframes = document.querySelectorAll('iframe[data-youtube], [data-youtube] iframe');
+    if (!iframes.length) return;
+    loadYT();
+    iframes.forEach(wireYT);
+  }
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initYT, { once: true });
-  } else {
-    initYT();
-  }
-
-  // Optional: re-run on page-specific events if your router swaps content
-  window.addEventListener('pakstream:rerender', () => initYT());
-
+    document.addEventListener('DOMContentLoaded', init);
+  } else { init(); }
 })();

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -43,7 +43,7 @@
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player">
+          <div id="player-container" class="radio-player" data-radio-container>
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -60,7 +60,7 @@
               <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
               <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
               <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
-              <audio id="radio-player" autoplay></audio>
+              <audio id="radio-player" data-radio autoplay></audio>
             </div>
           </div>
         </div>
@@ -81,6 +81,9 @@
       }
     });
   </script>
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>

--- a/media-hub.html
+++ b/media-hub.html
@@ -71,7 +71,7 @@
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player">
+          <div id="player-container" class="radio-player" data-radio-container>
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -88,7 +88,7 @@
               <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
               <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
               <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
-              <audio id="radio-player" autoplay></audio>
+              <audio id="radio-player" data-radio autoplay></audio>
             </div>
           </div>
         </div>
@@ -116,6 +116,9 @@
   </footer>
 
   <!-- Keep order to preserve swipe/lock behavior from your site -->
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/media-hub.js"></script>
   <script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>

--- a/radio.html
+++ b/radio.html
@@ -75,7 +75,7 @@
         <span class="label">Stations</span>
       </button>
       <div class="live-player">
-        <div id="player-container" class="radio-player">
+        <div id="player-container" class="radio-player" data-radio-container>
           <div class="station-info">
             <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
             <h3 id="current-station" class="station-title">Select a station</h3>
@@ -92,7 +92,7 @@
             <button id="next-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Next station" disabled>skip_next</button>
             <button id="mute-btn" class="mute-btn material-symbols-outlined" type="button" aria-label="Mute" disabled>volume_up</button>
             <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
-            <audio id="radio-player" autoplay></audio>
+            <audio id="radio-player" data-radio autoplay></audio>
           </div>
         </div>
       </div>
@@ -600,6 +600,9 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
   </script>
+  <script src="/js/stream-state.js" defer></script>
+  <script src="/js/radio.js" defer></script>
+  <script src="/js/youtube.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>


### PR DESCRIPTION
## Summary
- add StreamState registry to coordinate all media players
- wrap radio audio and YouTube iframes with managed play/pause hooks
- update pages to use data attributes and include new scripts with minimal now-playing CSS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a642897f448320824f28ce54e1cf34