### PR TITLE
feat: add CLS-safe ad scaffolding

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,6 +66,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/ads.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -73,6 +74,12 @@
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
+
+  <!-- Top banner (responsive) -->
+  <div class="ad-slot"
+       data-ad-slot
+       data-ad-type="leaderboard"
+       data-placeholder="Advertisement — 728×90 / 320×50"></div>
 
   <main>
     {{ content }}
@@ -92,6 +99,23 @@
   <script src="/js/pwa.js" defer></script>
   <script src="/js/utils/flags.js" defer></script>
   <script src="/js/diagnostics.js" defer></script>
+  <script src="/js/ads/config.js" defer></script>
+  <script src="/js/ads/ads.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <!--
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
+          crossorigin="anonymous"></script>
+  <script>
+  if (window.PAKSTREAM?.Flags?.isOn('adsEnabled')) {
+    // When integrating, replace each .ad-slot innerHTML with your <ins class="adsbygoogle">...</ins>
+    // and call: (adsbygoogle = window.adsbygoogle || []).push({});
+  }
+  </script>
+  -->
+  <noscript>
+    <div class="ad-slot" aria-hidden="true" style="min-height:120px">
+      <div class="ad-placeholder">Ads require JavaScript.</div>
+    </div>
+  </noscript>
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>
+  window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
+    adsEnabled: false
+  });
+  </script>
 {% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
@@ -54,6 +59,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/ads.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -61,6 +67,12 @@
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
+
+  <!-- Top banner (responsive) -->
+  <div class="ad-slot"
+       data-ad-slot
+       data-ad-type="leaderboard"
+       data-placeholder="Advertisement — 728×90 / 320×50"></div>
 
   <main class="post-container">
     <article class="post">
@@ -86,6 +98,14 @@
       <div class="post-content">
         {{ content }}
       </div>
+
+      <!-- Inline rectangle -->
+      <div class="ad-slot"
+           data-ad-slot
+           data-ad-type="rectangle"
+           data-ad-width="300"
+           data-ad-height="250"
+           data-placeholder="Advertisement — 300×250"></div>
 
       <!-- Social Sharing -->
       <div class="post-share">
@@ -120,5 +140,22 @@
     <p>© 2025 PakStream. All rights reserved.</p>
   </footer>
   <script defer src="/js/main.js"></script>
+  <script src="/js/ads/config.js" defer></script>
+  <script src="/js/ads/ads.js" defer></script>
+  <!--
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
+          crossorigin="anonymous"></script>
+  <script>
+  if (window.PAKSTREAM?.Flags?.isOn('adsEnabled')) {
+    // When integrating, replace each .ad-slot innerHTML with your <ins class="adsbygoogle">...</ins>
+    // and call: (adsbygoogle = window.adsbygoogle || []).push({});
+  }
+  </script>
+  -->
+  <noscript>
+    <div class="ad-slot" aria-hidden="true" style="min-height:120px">
+      <div class="ad-placeholder">Ads require JavaScript.</div>
+    </div>
+  </noscript>
 </body>
 </html>

--- a/css/ads.css
+++ b/css/ads.css
@@ -1,39 +1,41 @@
-/* Reserved heights for common display sizes (prevents CLS) */
+/* Ads: CLS-safe placeholders (additive) */
 .ad-slot {
   position: relative;
-  width: 100%;
-  margin: 16px auto;
-  background: var(--surface-variant, #EEE);
-  border: 1px dashed var(--outline, #BDBDBD);
+  box-sizing: border-box;
   display: block;
-  overflow: hidden;
+  margin: 16px auto;
+  max-width: 100%;
+  background: #f8f9fa;
+  border: 1px dashed rgba(0,0,0,.08);
+  border-radius: 10px;
 }
 
-/* Base reserved heights (can be overridden by data-ad-size) */
-.ad-slot[data-ad-size="300x250"]  { max-width: 300px;  height: 250px; }
-.ad-slot[data-ad-size="336x280"]  { max-width: 336px;  height: 280px; }
-.ad-slot[data-ad-size="320x100"]  { max-width: 320px;  height: 100px; }
-.ad-slot[data-ad-size="728x90"]   { max-width: 728px;  height: 90px;  }
-.ad-slot[data-ad-size="970x250"]  { max-width: 970px;  height: 250px; }
-
-/* Center reserved boxes */
-.ad-slot > .ad-reserved {
-  position: absolute; inset: 0;
-  display: flex; align-items: center; justify-content: center;
-  font: 600 12px/1 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-  color: var(--on-surface-variant, #424242);
-  opacity: .7;
+.ad-slot.is-ready {
+  border-style: solid;
+  border-color: rgba(0,0,0,.06);
 }
 
-/* Optional label */
-.ad-slot::before {
-  content: "Ad";
-  position: absolute; top: 4px; right: 6px;
-  font-size: 10px; opacity: .6;
+.ad-slot .ad-placeholder {
+  display: grid;
+  place-items: center;
+  font-size: .85rem;
+  color: #6b7280;
+  height: 100%;
+  width: 100%;
+  padding: 8px;
+  text-align: center;
 }
 
-/* Responsive helpers: stack medium sizes nicely on mobile */
-@media (max-width: 480px) {
-  .ad-slot[data-ad-size="728x90"]   { max-width: 320px; height: 100px; }
-  .ad-slot[data-ad-size="970x250"]  { max-width: 320px; height: 100px; }
+/* Responsive helpers (optional) */
+@media (min-width: 768px) {
+  .ad-slot[data-ad-type="leaderboard"] { min-width: 728px; min-height: 90px; }
+}
+@media (max-width: 767.98px) {
+  .ad-slot[data-ad-type="leaderboard"] { min-width: 320px; min-height: 50px; }
+}
+
+/* “Fluid” slots: fill container width; height via aspect ratio or custom CSS */
+.ad-slot[data-ad-type="fluid"] {
+  min-width: 100%;
+  min-height: 1px;
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script>
+window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
+  adsEnabled: false
+});
+</script>
 {% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
@@ -65,13 +70,20 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/ads.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 </head>
 <body>
 {% include google-tag-manager-body.html %}
-  {% include top-bar.html %}
+{% include top-bar.html %}
+
+  <!-- Top banner (responsive) -->
+  <div class="ad-slot"
+       data-ad-slot
+       data-ad-type="leaderboard"
+       data-placeholder="Advertisement — 728×90 / 320×50"></div>
 
   <!-- Hero section with image and tagline -->
   <section class="hero-banner">
@@ -94,6 +106,14 @@
       <p>Stay Connected to Pakistan — News, Radio &amp; More</p>
     </div>
   </section>
+
+  <!-- Inline rectangle -->
+  <div class="ad-slot"
+       data-ad-slot
+       data-ad-type="rectangle"
+       data-ad-width="300"
+       data-ad-height="250"
+       data-placeholder="Advertisement — 300×250"></div>
 
   <section id="continue-rail" class="rail-section lazy-rail" aria-label="Continue Watching and Listening"></section>
 
@@ -224,6 +244,14 @@
     <p>PakStream isn’t just a media website. It’s a passion project made by Pakistanis who live abroad and know how it feels to miss home. We built this to keep the voices, sounds, and stories of Pakistan within reach — anytime, anywhere.</p>
   </section>
 
+  <!-- Sidebar skyscraper -->
+  <aside>
+    <div class="ad-slot"
+         data-ad-slot
+         data-ad-type="skyscraper"
+         data-placeholder="Advertisement — 300×600"></div>
+  </aside>
+
   <!-- Placeholder for advertising or additional content -->
   <div class="ad-container">
     <!-- Google AdSense: Insert your ad code here -->
@@ -332,6 +360,23 @@
   </script>
   <script defer src="/js/discovery.js"></script>
   <script src="/js/pwa.js" defer></script>
+  <script src="/js/ads/config.js" defer></script>
+  <script src="/js/ads/ads.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <!--
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
+          crossorigin="anonymous"></script>
+  <script>
+  if (window.PAKSTREAM?.Flags?.isOn('adsEnabled')) {
+    // When integrating, replace each .ad-slot innerHTML with your <ins class="adsbygoogle">...</ins>
+    // and call: (adsbygoogle = window.adsbygoogle || []).push({});
+  }
+  </script>
+  -->
+  <noscript>
+    <div class="ad-slot" aria-hidden="true" style="min-height:120px">
+      <div class="ad-placeholder">Ads require JavaScript.</div>
+    </div>
+  </noscript>
 </body>
 </html>

--- a/js/ads/ads.js
+++ b/js/ads/ads.js
@@ -1,83 +1,45 @@
-(() => {
-  if (window.__ADS_WIRED__) return;
-  window.__ADS_WIRED__ = true;
+// Basic ad-slot scaffolding with CLS-safe placeholders
+(function () {
+  const Flags = window.PAKSTREAM?.Flags;
+  const Cfg = window.PAKSTREAM?.AdsConfig;
+  if (!Cfg) return;
 
-  const F = (window.PAKSTREAM && window.PAKSTREAM.Flags) || { isOn: () => false, all: () => ({}) };
-  const FLAGS = F.all();
-  const PRESETS = window.__PAKSTREAM_AD_PRESETS || {};
-  const log = (...a) => FLAGS.adsDebug && console.log('[ads]', ...a);
+  function applyReserveBox(slot) {
+    // Read size from data attributes or named type
+    const type = slot.dataset.adType || 'rectangle';
+    const w = Number(slot.dataset.adWidth  || Cfg.SIZES[type]?.w || 300);
+    const h = Number(slot.dataset.adHeight || Cfg.SIZES[type]?.h || 250);
 
-  const qsa = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-
-  function reserve(el) {
-    // Inject a reserved child only once
-    if (el.__reserved) return;
-    const box = document.createElement('div');
-    box.className = 'ad-reserved';
-    box.textContent = el.getAttribute('data-placeholder') || 'Advertisement';
-    el.appendChild(box);
-    el.__reserved = true;
-  }
-
-  function applyPreset(el) {
-    const preset = el.getAttribute('data-ad-preset');
-    if (!preset || !PRESETS[preset]) return;
-    const { size } = PRESETS[preset];
-    if (size && !el.getAttribute('data-ad-size')) {
-      el.setAttribute('data-ad-size', size);
+    // Reserve space to prevent CLS
+    slot.style.minWidth  = w > 1 ? w + 'px' : '';
+    slot.style.minHeight = h > 1 ? h + 'px' : '';
+    // Add a lightweight placeholder while empty
+    if (!slot.querySelector('.ad-placeholder')) {
+      const ph = document.createElement('div');
+      ph.className = 'ad-placeholder';
+      ph.textContent = slot.dataset.placeholder || 'Advertisement';
+      slot.appendChild(ph);
     }
   }
 
-  function hydrate(el) {
-    if (el.__hydrated) return;
-    el.__hydrated = true;
+  function init() {
+    const slots = document.querySelectorAll('[data-ad-slot]');
+    if (!slots.length) return;
+    slots.forEach(applyReserveBox);
 
-    // For now, place a lightweight placeholder creative (no network calls)
-    const inner = document.createElement('div');
-    inner.style.width = '100%';
-    inner.style.height = '100%';
-    inner.style.display = 'flex';
-    inner.style.alignItems = 'center';
-    inner.style.justifyContent = 'center';
-    inner.style.font = '600 12px/1 system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
-    inner.style.background = 'transparent';
-    inner.textContent = 'Ad Placeholder';
+    // Only proceed with real init if flag is on
+    if (!Flags?.isOn('adsEnabled')) return;
 
-    // Replace reserved child
-    el.innerHTML = '';
-    el.appendChild(inner);
-    log('hydrated', el);
-  }
-
-  function initAds(root=document) {
-    const slots = qsa('.ad-slot', root);
-    if (slots.length === 0) return;
-
-    // Always reserve to prevent CLS, even when ads are disabled
-    slots.forEach(el => { applyPreset(el); reserve(el); });
-
-    if (!F.isOn('adsEnabled')) {
-      log('ads disabled; reserved only');
-      return;
-    }
-
-    // Lazy hydrate using IntersectionObserver
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-          hydrate(entry.target);
-          io.unobserve(entry.target);
-        }
-      });
-    }, { rootMargin: '0px', threshold: [0.5] });
-
-    slots.forEach(el => io.observe(el));
+    // PLACEHOLDER: Where network-specific code would live (AdSense / GAM / etc.)
+    // For now, just mark slots as "ready" to validate styling and layout safety.
+    slots.forEach((slot) => {
+      slot.classList.add('is-ready');
+      // Example pseudo init: when you later integrate AdSense, replace this block.
+      // DO NOT include third-party code yet.
+    });
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => initAds(document), { once: true });
-  } else {
-    initAds(document);
-  }
-  window.addEventListener('pakstream:rerender', () => initAds(document));
+    document.addEventListener('DOMContentLoaded', init);
+  } else { init(); }
 })();

--- a/js/ads/config.js
+++ b/js/ads/config.js
@@ -1,16 +1,13 @@
-// Feature flags: merge into existing flags object if present
-window.__PAKSTREAM_FLAGS = Object.assign({
-  adsEnabled: false,     // default off (safe)
-  adsDebug: false,       // optional debug logging
-  sw: false,             // minimal service worker (off by default)
-  swDebug: false         // debug logging for service worker
-}, window.__PAKSTREAM_FLAGS || {});
-
-// Preset mapping for convenience
-window.__PAKSTREAM_AD_PRESETS = {
-  homepage_top:   { size: '728x90',  responsive: true },
-  homepage_mid:   { size: '336x280', responsive: true },
-  homepage_bottom:{ size: '300x250', responsive: true },
-  sidebar_top:    { size: '300x250', responsive: true },
-  hub_inline:     { size: '320x100', responsive: true }
-};
+// Per-slot default sizes and settings for ads
+(function () {
+  window.PAKSTREAM = window.PAKSTREAM || {};
+  // Per-slot default sizes (mobile-first; can be overridden via data attributes)
+  const SIZES = {
+    banner:      { w: 320, h: 50 },   // small mobile banner
+    leaderboard: { w: 728, h: 90 },   // desktop top banner
+    rectangle:   { w: 300, h: 250 },  // sidebar/content block
+    skyscraper:  { w: 300, h: 600 },  // tall sidebar
+    fluid:       { w: 1,   h: 1   }   // responsive (height controlled by CSS)
+  };
+  window.PAKSTREAM.AdsConfig = { SIZES };
+})();


### PR DESCRIPTION
## Summary
- introduce AdsConfig with default slot sizes
- implement lightweight ad slot initializer honoring `adsEnabled` flag
- wire placeholder ad slots, styles, and scripts across templates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6444c8f408320ab37f3926c6c1e08