### PR TITLE
feat: add maintenance mode kill-switch

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,11 @@
     debugDiagnostics: true
   };
   </script>
+  <script>
+  window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
+    maintenance: false   // flip to true to enable maintenance redirect
+  });
+  </script>
 {% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
@@ -105,6 +110,7 @@
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/js/maintenance.js" defer></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
           crossorigin="anonymous"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
+<script>
   window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
-    adsEnabled: false
+    adsEnabled: false,
+    maintenance: false   // flip to true to enable maintenance redirect
   });
-  </script>
+</script>
 {% include google-tag-manager-head.html %}
   <!-- Start cookieyes banner -->
   <script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/4d58f851fda21f329d07e980/script.js"></script>
@@ -142,6 +143,7 @@
   <script defer src="/js/main.js"></script>
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
+  <script src="/js/maintenance.js" defer></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
           crossorigin="anonymous"></script>

--- a/js/maintenance-page.js
+++ b/js/maintenance-page.js
@@ -1,19 +1,19 @@
-document.addEventListener('DOMContentLoaded', function(){
-  var title = document.getElementById('mt-title');
-  if(title) title.focus();
-  if(window.analytics) analytics('maintenance_page_view');
-  var retry = document.getElementById('mt-retry');
-  if(retry){
-    retry.addEventListener('click', function(){
-      if(window.analytics) analytics('maintenance_action',{action:'retry'});
-      location.reload();
+// js/maintenance-page.js
+(function () {
+  const $ = (s) => document.querySelector(s);
+  const p = new URLSearchParams(location.search);
+  const from = p.get('from');
+  if (from) {
+    const el = $('#origin');
+    if (el) el.textContent = 'Original page: ' + decodeURIComponent(from);
+  }
+  const retry = $('#retry');
+  if (retry) {
+    retry.addEventListener('click', () => {
+      // Retry original page if known, else home; add ?live=1 to bypass gate
+      const target = from ? decodeURIComponent(from) : '/';
+      const url = target.includes('?') ? target + '&live=1' : target + '?live=1';
+      location.href = url;
     });
   }
-  document.addEventListener('click', function(ev){
-    var link = ev.target.closest('[data-analytics="follow_status"]');
-    if(link && window.analytics) analytics('maintenance_action',{action:'follow_status'});
-    var home = ev.target.closest('[data-analytics="home"]');
-    var hub = ev.target.closest('[data-analytics="media_hub"]');
-    if((home || hub) && window.analytics) analytics('maintenance_action',{action:(home?'home':'media_hub')});
-  });
-});
+})();

--- a/js/maintenance.js
+++ b/js/maintenance.js
@@ -1,23 +1,17 @@
-document.addEventListener('DOMContentLoaded', function(){
-  fetch('/config.json?ts=' + Date.now(), {cache:'no-store'}).then(function(r){return r.json();}).then(function(cfg){
-    if(!cfg || !cfg.maintenance) return;
-    if(sessionStorage.getItem('ps-maint-dismiss') === '1') return;
-    var banner = document.getElementById('maintenance-banner');
-    if(!banner) return;
-    banner.innerHTML = '<span class="msg">PakStream is upgrading.</span> <a href="/maintenance.html" data-analytics="follow_status">Learn more</a> <button type="button" id="mt-dismiss">Dismiss</button>';
-    banner.hidden = false;
-    document.body.classList.add('maintenance-on');
-    if(window.analytics) analytics('maintenance_banner_view');
-    var dismiss = document.getElementById('mt-dismiss');
-    dismiss.addEventListener('click', function(){
-      banner.hidden = true;
-      sessionStorage.setItem('ps-maint-dismiss', '1');
-      document.body.classList.remove('maintenance-on');
-      if(window.analytics) analytics('maintenance_action',{action:'dismiss'});
-    });
-    banner.addEventListener('click', function(ev){
-      var link = ev.target.closest('[data-analytics="follow_status"]');
-      if(link && window.analytics) analytics('maintenance_action',{action:'follow_status'});
-    });
-  }).catch(function(){});
-});
+// js/maintenance.js
+(function () {
+  // Allow bypass: ?live=1 on URL
+  const params = new URLSearchParams(location.search);
+  if (params.get('live') === '1') return;
+
+  const flags = (window.__PAKSTREAM_FLAGS || {});
+  const on = !!flags.maintenance;
+
+  // Don't redirect from the maintenance page itself
+  const isMaintenancePage = /\/maintenance\.html$/i.test(location.pathname);
+
+  if (on && !isMaintenancePage) {
+    const from = encodeURIComponent(location.pathname + location.search + location.hash);
+    location.replace('/maintenance.html?from=' + from);
+  }
+})();

--- a/maintenance.html
+++ b/maintenance.html
@@ -1,37 +1,37 @@
----
-layout: default
-title: "Maintenance"
-permalink: /maintenance.html
-robots: noindex
-canonical: /
-no_ads: true
----
-<section class="mt-hero">
-  <img src="/images/icons/icon-192-maskable.png" alt="" class="mt-illust" width="96" height="96">
-  <h1 id="mt-title" tabindex="-1">We're upgrading PakStream</h1>
-  <p>Some features may be unavailable. Please check back soon.</p>
-  <div class="mt-actions">
-     <button id="mt-retry" class="btn" data-analytics="retry">Retry</button>
-     <a class="btn" href="/" data-analytics="home">Home</a>
-     <a class="btn" href="/media-hub.html" data-analytics="media_hub">Media Hub</a>
-  </div>
-  <p><a href="https://twitter.com/PakStream" target="_blank" rel="noopener" data-analytics="follow_status">Status updates</a> · <a href="/contact.html" data-analytics="follow_status">Contact</a></p>
-</section>
-<script defer src="/js/maintenance-page.js"></script>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>PakStream — Maintenance</title>
+  <meta name="robots" content="noindex,nofollow"/>
+  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/assets/css/tokens.css">
+  <link rel="stylesheet" href="/assets/css/a11y-focus.css">
+  <style>
+    html,body{height:100%}
+    body{margin:0;display:grid;place-items:center;background:var(--ps-neutral-50,#fafafa);color:var(--ps-on-surface,#212121);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial}
+    .card{max-width:560px;width:calc(100% - 2rem);background:#fff;border-radius:16px;box-shadow:var(--ps-shadow-1,0 6px 18px rgba(0,0,0,.12));padding:24px}
+    .title{font-size:1.4rem;font-weight:800;margin:0 0 .25rem}
+    .sub{opacity:.8;margin:0 0 1rem}
+    .row{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;justify-content:center;margin-top:1rem}
+    .btn{appearance:none;border:0;border-radius:12px;padding:10px 16px;font-weight:700;cursor:pointer}
+    .primary{background:var(--ps-color-primary,#1e88e5);color:#fff}
+    .ghost{background:#eef2f7}
+    .meta{font-size:.85rem;opacity:.7;margin-top:.75rem;text-align:center}
+  </style>
+</head>
+<body>
+  <main class="card" role="main">
+    <h1 class="title">We’ll be right back</h1>
+    <p class="sub">PakStream is undergoing a quick update. Thanks for your patience.</p>
+    <div class="row">
+      <button class="btn primary" id="retry">Try the site</button>
+      <a class="btn ghost" href="mailto:support@pakstream.com">Contact support</a>
+    </div>
+    <p class="meta" id="origin"></p>
+  </main>
 
-<link rel="stylesheet" href="/css/theme.css">
-<link rel="stylesheet" href="/css/z-layers.css">
-<link rel="stylesheet" href="/css/ads.css">
-<script src="/js/data.js"></script>
-<script src="/assets/js/mh-tabs.js"></script>
-<script src="/assets/js/mh-search.js"></script>
-<script src="/assets/js/mh-channels.js"></script>
-<script src="/js/media-hub.js"></script>
-<script src="/js/youtube.js"></script>
-<script src="/js/radio.js"></script>
-<script src="/js/main.js"></script>
-<script src="/js/ads/config.js"></script>
-<script src="/js/ads/ads.js"></script>
-<script src="/js/pwa.js"></script>
-<link rel="stylesheet" href="/css/dev/flags-panel.css">
-<script src="/js/dev/flags-panel.js"></script>
+  <script src="/js/maintenance-page.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone maintenance page with retry and support links
- introduce gating script redirecting all pages when maintenance flag is on
- expose maintenance flag and script loading in default and post layouts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a647cd31888320989ab33ed66ebe97