### PR TITLE
Add lightweight media hub channel list and search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,6 +72,7 @@
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/assets/css/mh-lite.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -111,6 +112,9 @@
   <script src="/js/ads/ads.js" defer></script>
   <script defer src="/js/main.js"></script>
   <script src="/js/maintenance.js" defer></script>
+  <script src="/assets/js/mh-core.js" defer></script>
+  <script src="/assets/js/mh-search.js" defer></script>
+  <script src="/assets/js/mh-channels.js" defer></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
           crossorigin="anonymous"></script>

--- a/assets/css/mh-lite.css
+++ b/assets/css/mh-lite.css
@@ -1,0 +1,33 @@
+/* Minimal Media Hub styles (additive) */
+.mh-wrap { display: grid; gap: 16px; }
+.mh-row { display: grid; gap: 12px; }
+.mh-search { display: flex; align-items: center; gap: 8px; }
+.mh-search input[type="search"] {
+  width: 100%; padding: 10px 12px; border-radius: 10px;
+  border: 1px solid #e0e0e0; font: inherit;
+}
+
+.mh-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.mh-card {
+  background: #fff; border-radius: 12px; box-shadow: var(--ps-shadow-1,0 6px 18px rgba(0,0,0,.12));
+  padding: 12px; display: grid; gap: 10px;
+}
+.mh-head { display: grid; grid-template-columns: 56px 1fr; gap: 10px; align-items: center; }
+.mh-thumb { width: 56px; height: 56px; object-fit: cover; border-radius: 8px; background: #f3f4f6; }
+.mh-title { margin: 0; font-size: 1rem; line-height: 1.2; }
+.mh-sub { font-size: .85rem; opacity: .7; }
+.mh-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+.mh-tag { font-size: .75rem; background: #f1f5f9; padding: 2px 6px; border-radius: 6px; }
+
+.mh-media iframe,
+.mh-media audio { width: 100%; border: 0; }
+.mh-play {
+  appearance: none; border: 0; border-radius: 10px; padding: 8px 12px; font-weight: 700;
+  background: var(--ps-color-primary,#1e88e5); color: #fff; cursor: pointer;
+}
+.mh-empty { padding: 24px; text-align: center; opacity: .75; }

--- a/assets/js/mh-channels.js
+++ b/assets/js/mh-channels.js
@@ -1,89 +1,71 @@
-const __mh = (() => {
-  if (window.__PAKSTREAM_MH_UTILS__) return window.__PAKSTREAM_MH_UTILS__;
-  const qs=(s,r=document)=>r.querySelector(s);
-  const qsa=(s,r=document)=>Array.from(r.querySelectorAll(s));
-  const on=(el,ev,fn,opts)=>el&&el.addEventListener(ev,fn,opts);
-  function required(el,label){ if(!el){ console.warn(`[MediaHub] Missing required element: ${label}`); return null;} return el; }
-  function emptyState(container,message){ if(!container) return; if(container.__emptyRendered) return; container.innerHTML=`<div class="mh-empty" role="status" aria-live="polite"><p>${message}</p></div>`; container.__emptyRendered=true; }
-  function clearContainer(container){ if(!container) return; container.__emptyRendered=false; container.innerHTML=''; }
-  function emit(name, detail){ document.dispatchEvent(new CustomEvent(name,{detail})); }
-  return (window.__PAKSTREAM_MH_UTILS__={qs,qsa,on,required,emptyState,clearContainer,emit});
-})();
+// assets/js/mh-channels.js
+(function () {
+  const Core = window.PAKSTREAM?.MHCore;
+  if (!Core) return;
 
-window.PAKSTREAM_MH_CHANNELS = (function () {
-  const { qs, qsa, on, required, emptyState, clearContainer } = __mh;
+  function cardHTML(item) {
+    const isYT = !!item.yt;
+    const media = isYT
+      ? `<div class="mh-media" data-stream-container data-youtube-container>
+           <iframe data-youtube src="https://www.youtube.com/embed/${item.yt}?enablejsapi=1"
+                   allow="autoplay; encrypted-media" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+         </div>`
+      : `<div class="mh-media" data-stream-container data-radio-container>
+           <audio data-radio preload="none" src="${item.url}"></audio>
+           <button class="mh-play" type="button" data-mh-play>Play</button>
+         </div>`;
 
-  async function fetchData(){
-    return await (window.PAKSTREAM_DATA?.getAllStreams?.() || null);
-  }
+    const tags = (item.tags || []).slice(0, 3).map(t => `<span class="mh-tag">${t}</span>`).join('');
 
-  function filterItems(data, opts){
-    if(!data || !Array.isArray(data.items)) return [];
-    const q=(opts?.q||'').toLowerCase();
-    const tab = opts?.tab || null;
+    const searchBlob = [item.title, item.country, ...(item.tags || [])].join(' ');
+    const thumb = item.thumb ? `<img class="mh-thumb" src="${item.thumb}" alt="${item.title}">` : '';
 
-    const kindByTab={ radio:'radio', tv:'tv', creators:'creator', freepress:'freepress' };
-    let items = data.items;
-    const kind = kindByTab[tab] || null;
-
-    if(kind) items = items.filter(x=>x.kind===kind);
-    if(q){
-      items = items.filter(x =>
-        (x.name||'').toLowerCase().includes(q) ||
-        (x.desc||'').toLowerCase().includes(q) ||
-        (Array.isArray(x.tags)? x.tags.join(' ').toLowerCase() : '').includes(q)
-      );
-    }
-    return items;
-  }
-
-  function renderList(listEl, items){
-    if(!listEl) return;
-    clearContainer(listEl);
-    if(!items || !items.length){
-      emptyState(listEl,'No channels to show yet.');
-      return;
-    }
-    const frag = document.createDocumentFragment();
-    items.forEach(item=>{
-      const el = document.createElement('div');
-      el.className = 'mh-item';
-      el.innerHTML = `
-        <button class="mh-play" data-audio-play aria-label="Play ${item.name}"></button>
+    return `<article class="mh-card" data-mh-card data-search="${searchBlob}">
+      <div class="mh-head">
+        ${thumb}
         <div class="mh-meta">
-          <div class="mh-name">${item.name}</div>
-          <div class="mh-desc">${item.desc || ''}</div>
-        </div>`;
-      if (item.stream) el.dataset.stream = item.stream;
-      frag.appendChild(el);
+          <h3 class="mh-title">${item.title}</h3>
+          ${item.country ? `<div class="mh-sub">${item.country}</div>` : ''}
+          ${tags ? `<div class="mh-tags">${tags}</div>` : ''}
+        </div>
+      </div>
+      ${media}
+    </article>`;
+  }
+
+  function wireInteractions(container) {
+    container.querySelectorAll('[data-mh-play]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const audio = btn.closest('[data-radio-container]')?.querySelector('audio[data-radio]');
+        if (audio) { try { audio.play(); } catch {} }
+      });
     });
-    listEl.appendChild(frag);
   }
 
-  function init({ root, list }){
-    if(!root) return;
-    if(!list){ console.warn('[MediaHub] missing list container (.mh-list)'); return; }
-    if(list.__wired) return;
-    list.__wired = true;
+  async function render(root) {
+    const list = root.querySelector('[data-mh-list]');
+    if (!list) return;
+    list.innerHTML = '<div class="mh-empty">Loading…</div>';
 
-    let lastOpts = {};
-    async function rerender(opts = {}){
-      lastOpts = { ...lastOpts, ...opts };
-      const data = await fetchData();
-      if(!data){
-        emptyState(list, 'Could not load channels. Please try again later.');
-        return;
-      }
-      const tabName = lastOpts.name || lastOpts.tab || null;
-      const q = lastOpts.q || '';
-      const items = filterItems(data, { tab: tabName, q });
-      renderList(list, items);
-    }
+    const data = await Core.loadStreams();
+    if (!data.length) { list.innerHTML = '<div class="mh-empty">No channels available.</div>'; return; }
 
-    rerender();
-    document.addEventListener('pakstream:hub:tabchange', (e)=> rerender({ tab: e.detail?.name }));
-    document.addEventListener('pakstream:hub:rerender', (e)=> rerender({ ...e.detail }));
+    const html = data.map(cardHTML).join('');
+    list.innerHTML = html;
+    wireInteractions(list);
   }
 
-  return { init };
+  function init(root) {
+    if (!root || root.__mhChannels) return;
+    root.__mhChannels = true;
+    render(root);
+  }
+
+  function auto() {
+    document.querySelectorAll('[data-mh]').forEach(init);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', auto);
+  } else { auto(); }
 })();

--- a/assets/js/mh-core.js
+++ b/assets/js/mh-core.js
@@ -1,0 +1,47 @@
+// assets/js/mh-core.js
+(function () {
+  if (window.PAKSTREAM?.MHCore) return;
+
+  async function loadStreams() {
+    // Preferred: global data module
+    if (window.PAKSTREAM?.DATA?.getAllStreams) {
+      try { 
+        const arr = await window.PAKSTREAM.DATA.getAllStreams();
+        return normalize(arr);
+      } catch (e) {}
+    }
+    // Fallback: static JSON
+    try {
+      const res = await fetch('/all_streams.json', { cache: 'no-store' });
+      if (!res.ok) throw new Error('failed');
+      const json = await res.json();
+      return normalize(json.items || json.streams || json || []);
+    } catch (e) {
+      console.warn('[MH] load fallback failed', e);
+      return [];
+    }
+  }
+
+  function normalize(items) {
+    return (items || []).map((x, i) => ({
+      id: x.id || x.key || `s-${i}`,
+      title: x.title || x.name || 'Untitled',
+      type: (x.type || x.kind || 'radio').toLowerCase(),
+      country: x.country || x.lang || '',
+      tags: x.tags || x.categories || [],
+      thumb: x.thumb || x.logo || x.image || '',
+      url: x.url || x.stream_url || x.src || '',
+      yt: x.youtube_id || x.yt || null
+    })).filter(x => x.url || x.yt);
+  }
+
+  function fuzzyIncludes(hay, needle) {
+    if (!needle) return true;
+    hay = (hay || '').toString().toLowerCase();
+    needle = needle.toLowerCase().trim();
+    return hay.includes(needle);
+  }
+
+  window.PAKSTREAM = window.PAKSTREAM || {};
+  window.PAKSTREAM.MHCore = { loadStreams, fuzzyIncludes };
+})();

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/assets/css/mh-lite.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -253,12 +254,20 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   </aside>
 
   <!-- Placeholder for advertising or additional content -->
-  <div class="ad-container">
-    <!-- Google AdSense: Insert your ad code here -->
-  </div>
+    <div class="ad-container">
+      <!-- Google AdSense: Insert your ad code here -->
+    </div>
+    <section class="mh-wrap" data-mh>
+      <div class="mh-row mh-search">
+        <label for="mh-q" class="visually-hidden">Search channels</label>
+        <input id="mh-q" data-mh-search-input type="search" placeholder="Search channels…">
+      </div>
 
-  <!-- Footer with copyright notice -->
-  <footer>
+      <div class="mh-grid" data-mh-list></div>
+    </section>
+
+    <!-- Footer with copyright notice -->
+    <footer>
     <nav class="footer-nav">
       <a href="/about.html">About Us</a>
       <a href="/contact.html">Contact</a>
@@ -362,6 +371,9 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <script src="/js/pwa.js" defer></script>
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
+  <script src="/assets/js/mh-core.js" defer></script>
+  <script src="/assets/js/mh-search.js" defer></script>
+  <script src="/assets/js/mh-channels.js" defer></script>
   <script defer src="/js/main.js"></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"


### PR DESCRIPTION
## Summary
- Add MHCore helper to load stream data with graceful fallback
- Render responsive media hub cards and instant search filtering
- Globally include Media Hub assets and hook up a minimal channel section on the homepage

## Testing
- ⚠️ `npm test` (missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68a6490e8f148320bf90767400474334