### PR TITLE
Add lightweight carousel component

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,6 +72,7 @@
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -110,6 +111,8 @@
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
   <script src="/js/maintenance.js" defer></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -61,6 +61,7 @@
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -143,6 +144,8 @@
   <script defer src="/js/main.js"></script>
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
   <script src="/js/maintenance.js" defer></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"

--- a/about.html
+++ b/about.html
@@ -61,6 +61,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -97,5 +98,7 @@
   </footer>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/assets/css/carousel.css
+++ b/assets/css/carousel.css
@@ -1,66 +1,48 @@
-#ps-carousel {
-  position: relative;
-  max-width: 100%;
-  margin: 1rem 0;
+/* Carousel (additive) */
+.ps-carousel {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 8px;
 }
 
-#ps-carousel .ps-carousel__viewport {
-  overflow: hidden;
-}
-
-#ps-carousel .ps-carousel__track {
+.ps-crs-header {
   display: flex;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  transition: transform 0.5s ease;
-  will-change: transform;
-}
-
-#ps-carousel.ps-no-motion .ps-carousel__track {
-  transition: none;
-}
-
-#ps-carousel .ps-carousel__slide {
-  flex: 0 0 100%;
-  display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: space-between;
 }
 
-#ps-carousel .ps-carousel__slide img {
-  width: 120px;
-  height: 90px;
-  object-fit: contain;
-}
+.ps-crs-title { margin: 0; font-size: 1.1rem; }
 
-#ps-carousel .ps-carousel__controls {
-  display: flex;
-  justify-content: center;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-#ps-carousel button {
-  background: none;
-  border: none;
+.ps-crs-ctrls { display: flex; gap: 6px; }
+.ps-crs-btn {
+  appearance: none;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 10px;
+  padding: 6px 10px;
   cursor: pointer;
+  font-weight: 700;
+}
+.ps-crs-btn:disabled { opacity: .45; cursor: not-allowed; }
+
+.ps-crs-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(240px, 1fr);
+  gap: 12px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 6px;
+}
+.ps-crs-track::-webkit-scrollbar { height: 8px; }
+.ps-crs-track::-webkit-scrollbar-thumb { background: #d1d5db; border-radius: 8px; }
+
+.ps-crs-item {
+  scroll-snap-align: start;
 }
 
-#ps-carousel button:focus-visible,
-#ps-carousel .ps-carousel__slide a:focus-visible {
-  outline: 2px solid #0F5132;
-  outline-offset: 2px;
-}
+.ps-crs-track.is-dragging { cursor: grabbing; }
 
-#ps-carousel .ps-carousel__status {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
-}
+/* If you place MH cards inside, they already have styles from mh-lite.css */
+

--- a/assets/js/mh-featured.js
+++ b/assets/js/mh-featured.js
@@ -1,0 +1,39 @@
+(function () {
+  const Core = window.PAKSTREAM?.MHCore;
+  if (!Core) return;
+
+  async function hydrateFeatured() {
+    const wrap = document.querySelector('[data-crs][data-crs-auto]');
+    if (!wrap) return;
+    const track = wrap.querySelector('[data-crs-track]');
+    if (!track) return;
+
+    const data = await Core.loadStreams();
+    const pick = data.slice(0, 10); // simple top-10; replace with your own selection
+    const html = pick.map(item => `
+      <div class="ps-crs-item" data-crs-item>
+        <article class="mh-card" data-mh-card data-search="${(item.title||'')+ ' ' + (item.country||'')}">
+          <div class="mh-head">
+            ${item.thumb ? `<img class="mh-thumb" src="${item.thumb}" alt="${item.title}">` : ''}
+            <div class="mh-meta">
+              <h3 class="mh-title">${item.title}</h3>
+              ${item.country ? `<div class="mh-sub">${item.country}</div>` : ''}
+            </div>
+          </div>
+          <div class="mh-media" data-stream-container ${item.yt ? 'data-youtube-container' : 'data-radio-container'}>
+            ${item.yt
+              ? `<iframe data-youtube src="https://www.youtube.com/embed/${item.yt}?enablejsapi=1" allow="autoplay; encrypted-media" loading="lazy"></iframe>`
+              : `<audio data-radio preload="none" src="${item.url}"></audio><button class="mh-play" type="button" data-mh-play>Play</button>`
+            }
+          </div>
+        </article>
+      </div>
+    `).join('');
+    track.innerHTML = html;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', hydrateFeatured);
+  } else { hydrateFeatured(); }
+})();
+

--- a/contact.html
+++ b/contact.html
@@ -61,6 +61,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -97,5 +98,7 @@
   </footer>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/creators.html
+++ b/creators.html
@@ -43,6 +43,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -484,5 +485,7 @@
 <script type="module" src="/js/fullscreen-orientation.js"></script>
 <script src="/js/pwa.js" defer></script>
 <script defer src="/js/main.js"></script>
+<script src="/assets/js/carousel.js" defer></script>
+<script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -58,6 +58,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -555,5 +556,7 @@
 <script type="module" src="/js/fullscreen-orientation.js"></script>
 <script src="/js/pwa.js" defer></script>
 <script defer src="/js/main.js"></script>
+<script src="/assets/js/carousel.js" defer></script>
+<script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/freepress.html
+++ b/freepress.html
@@ -58,6 +58,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -566,5 +567,7 @@
 <script type="module" src="/js/fullscreen-orientation.js"></script>
 <script src="/js/pwa.js" defer></script>
 <script defer src="/js/main.js"></script>
+<script src="/assets/js/carousel.js" defer></script>
+<script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -131,6 +132,48 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <button class="scroll-btn next" aria-label="Scroll right">
         <span class="material-symbols-outlined">chevron_right</span>
       </button>
+    </div>
+  </section>
+
+  <section class="ps-carousel" data-crs aria-label="Featured channels">
+    <div class="ps-crs-header">
+      <h2 class="ps-crs-title">Featured</h2>
+      <div class="ps-crs-ctrls">
+        <button type="button" class="ps-crs-btn" data-crs-prev aria-label="Scroll left">◀</button>
+        <button type="button" class="ps-crs-btn" data-crs-next aria-label="Scroll right">▶</button>
+      </div>
+    </div>
+
+    <div class="ps-crs-track" data-crs-track>
+      <div class="ps-crs-item" data-crs-item>
+        <article class="mh-card" data-mh-card>
+          <div class="mh-head">
+            <img class="mh-thumb" src="/images/stations/100-lahore.png" alt="Sample Channel">
+            <div class="mh-meta">
+              <h3 class="mh-title">Sample Channel</h3>
+            </div>
+          </div>
+          <div class="mh-media" data-stream-container data-radio-container>
+            <audio data-radio preload="none" src="https://example.com/stream.mp3"></audio>
+            <button class="mh-play" type="button" data-mh-play>Play</button>
+          </div>
+        </article>
+      </div>
+
+      <div class="ps-crs-item" data-crs-item>
+        <article class="mh-card" data-mh-card>
+          <div class="mh-head">
+            <img class="mh-thumb" src="/images/stations/101-fm-karachi.png" alt="Another Channel">
+            <div class="mh-meta">
+              <h3 class="mh-title">Another Channel</h3>
+            </div>
+          </div>
+          <div class="mh-media" data-stream-container data-radio-container>
+            <audio data-radio preload="none" src="https://example.com/stream2.mp3"></audio>
+            <button class="mh-play" type="button" data-mh-play>Play</button>
+          </div>
+        </article>
+      </div>
     </div>
   </section>
 
@@ -363,6 +406,8 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
           crossorigin="anonymous"></script>

--- a/livetv.html
+++ b/livetv.html
@@ -58,6 +58,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -472,5 +473,7 @@
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/assets/css/carousel.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -90,5 +91,7 @@
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/media-hub.html
+++ b/media-hub.html
@@ -21,6 +21,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/assets/css/carousel.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -126,5 +127,7 @@
   <script defer src="/js/discovery.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -15,10 +15,13 @@
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
 </head>
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
   <script src="/js/pwa.js" defer></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/onboard-channel.html
+++ b/onboard-channel.html
@@ -19,6 +19,7 @@
   <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
@@ -187,5 +188,7 @@
   </script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -61,6 +61,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -123,5 +124,7 @@
   <script defer src="/js/discovery.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/radio.html
+++ b/radio.html
@@ -59,6 +59,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -607,6 +608,8 @@ document.addEventListener('DOMContentLoaded', function() {
   <script src="/js/leftmenu.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>
 

--- a/terms.html
+++ b/terms.html
@@ -61,6 +61,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -102,5 +103,7 @@
   </footer>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -65,6 +65,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link id="themeStylesheet" rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -348,5 +349,7 @@
   </script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>

--- a/youtube-playground.html
+++ b/youtube-playground.html
@@ -19,6 +19,7 @@
   <meta name="theme-color" content="#ffffff">
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/assets/css/carousel.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
@@ -159,5 +160,7 @@
   </script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>
+  <script src="/assets/js/carousel.js" defer></script>
+  <script src="/assets/js/mh-featured.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace existing carousel assets with lightweight keyboard/touch-enabled scroller
- wire carousel CSS/JS across site and add optional MH auto-population helper
- showcase featured carousel on home page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6496a87088320a3b7638b5a12a7b6