### PR TITLE
feat: add toast helper and now playing indicator

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,6 +72,7 @@
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/ads.css">
+  <link rel="stylesheet" href="/css/toast.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -104,6 +105,8 @@
   <script src="/js/stream-state.js" defer></script>
   <script src="/js/radio.js" defer></script>
   <script src="/js/youtube.js" defer></script>
+  <script src="/js/ui/toast.js" defer></script>
+  <script src="/js/now-playing.js" defer></script>
   <script src="/js/pwa.js" defer></script>
   <script src="/js/utils/flags.js" defer></script>
   <script src="/js/diagnostics.js" defer></script>

--- a/creators.html
+++ b/creators.html
@@ -43,6 +43,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/toast.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -480,6 +481,8 @@
 <script src="/js/stream-state.js" defer></script>
 <script src="/js/radio.js" defer></script>
 <script src="/js/youtube.js" defer></script>
+<script src="/js/ui/toast.js" defer></script>
+<script src="/js/now-playing.js" defer></script>
 <script src="/js/leftmenu.js"></script>
 <script type="module" src="/js/fullscreen-orientation.js"></script>
 <script src="/js/pwa.js" defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1460,3 +1460,34 @@ footer nav a:hover {
 
 [data-radio-container].is-playing,
 [data-youtube-container].is-playing { outline: 2px solid rgba(0,0,0,.2); }
+
+/* Now Playing badge (additive) */
+[data-stream-container] { position: relative; }
+.ps-now-playing {
+  position: absolute;
+  top: 8px; right: 8px;
+  background: rgba(30,136,229,.95);
+  color: #fff;
+  font-size: .75rem;
+  padding: 6px 8px;
+  border-radius: 999px;
+  display: inline-flex; align-items: center; gap: 6px;
+  box-shadow: var(--ps-shadow-1, 0 6px 18px rgba(0,0,0,.12));
+}
+.ps-now-playing .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 2px rgba(34,197,94,.35);
+  animation: ps-pulse 1.2s infinite;
+}
+@keyframes ps-pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+.has-now-playing .mh-card,
+.has-now-playing .video-tile,
+.has-now-playing .radio-tile {
+  outline: 2px solid rgba(30,136,229,.35);
+  outline-offset: 2px;
+}

--- a/css/toast.css
+++ b/css/toast.css
@@ -1,0 +1,24 @@
+/* Toasts (additive) */
+.ps-toast-host {
+  position: fixed;
+  inset: auto 0 16px 0;
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  pointer-events: none;
+  z-index: var(--z-toast, 1000);
+}
+.ps-toast {
+  pointer-events: auto;
+  background: #111827;
+  color: #fff;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: .95rem;
+  box-shadow: var(--ps-shadow-1, 0 6px 18px rgba(0,0,0,.12));
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity .2s ease, transform .2s ease;
+}
+.ps-toast.is-in { opacity: 1; transform: translateY(0); }
+.ps-toast.is-out { opacity: 0; transform: translateY(8px); }

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -58,6 +58,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/toast.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -551,6 +552,8 @@
 <script src="/js/stream-state.js" defer></script>
 <script src="/js/radio.js" defer></script>
 <script src="/js/youtube.js" defer></script>
+<script src="/js/ui/toast.js" defer></script>
+<script src="/js/now-playing.js" defer></script>
 <script src="/js/leftmenu.js"></script>
 <script type="module" src="/js/fullscreen-orientation.js"></script>
 <script src="/js/pwa.js" defer></script>

--- a/freepress.html
+++ b/freepress.html
@@ -58,6 +58,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/toast.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -562,6 +563,8 @@
 <script src="/js/stream-state.js" defer></script>
 <script src="/js/radio.js" defer></script>
 <script src="/js/youtube.js" defer></script>
+<script src="/js/ui/toast.js" defer></script>
+<script src="/js/now-playing.js" defer></script>
 <script src="/js/leftmenu.js"></script>
 <script type="module" src="/js/fullscreen-orientation.js"></script>
 <script src="/js/pwa.js" defer></script>

--- a/js/now-playing.js
+++ b/js/now-playing.js
@@ -1,0 +1,32 @@
+// js/now-playing.js
+(function () {
+  const SS = window.PAKSTREAM?.StreamState;
+  if (!SS) return;
+
+  function applyBadge(container, on) {
+    if (!container) return;
+    let badge = container.querySelector('.ps-now-playing');
+    if (!badge) {
+      badge = document.createElement('div');
+      badge.className = 'ps-now-playing';
+      badge.innerHTML = '<span class="dot" aria-hidden="true"></span><span class="txt">Now Playing</span>';
+      container.appendChild(badge);
+    }
+    container.classList.toggle('has-now-playing', !!on);
+    badge.hidden = !on;
+  }
+
+  // On change, toggle badge on the active container; remove from others
+  SS.onChange(({ currentId }) => {
+    document.querySelectorAll('[data-stream-container]').forEach(cont => {
+      const el = cont.querySelector('[data-radio], [data-youtube]');
+      const id = el?.dataset.playerId;
+      applyBadge(cont, id && id === currentId);
+    });
+  });
+
+  // When first loaded, clear all badges
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-stream-container]').forEach(cont => applyBadge(cont, false));
+  });
+})();

--- a/js/ui/toast.js
+++ b/js/ui/toast.js
@@ -1,0 +1,40 @@
+// js/ui/toast.js
+(function () {
+  if (window.PAKSTREAM?.Toast) return;
+
+  function ensureHost() {
+    let host = document.querySelector('.ps-toast-host');
+    if (host) return host;
+    host = document.createElement('div');
+    host.className = 'ps-toast-host';
+    document.body.appendChild(host);
+    return host;
+  }
+
+  function show(message, { timeout = 2500 } = {}) {
+    const host = ensureHost();
+    const el = document.createElement('div');
+    el.className = 'ps-toast';
+    el.setAttribute('role', 'status');
+    el.setAttribute('aria-live', 'polite');
+    el.textContent = message;
+    host.appendChild(el);
+
+    requestAnimationFrame(() => el.classList.add('is-in'));
+    const t = setTimeout(() => hide(el), timeout);
+
+    el.addEventListener('click', () => {
+      clearTimeout(t);
+      hide(el);
+    });
+  }
+
+  function hide(el) {
+    el.classList.remove('is-in');
+    el.classList.add('is-out');
+    setTimeout(() => el.remove(), 220);
+  }
+
+  window.PAKSTREAM = window.PAKSTREAM || {};
+  window.PAKSTREAM.Toast = { show };
+})();

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/css/toast.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -83,10 +84,12 @@
   </script>
   <script src="/js/error-overlay.js" defer></script>
   <script src="/js/stream-state.js" defer></script>
-  <script src="/js/radio.js" defer></script>
-  <script src="/js/youtube.js" defer></script>
-  <script src="/js/media-hub.js"></script>
-  <script src="/js/leftmenu.js"></script>
+<script src="/js/radio.js" defer></script>
+<script src="/js/youtube.js" defer></script>
+<script src="/js/ui/toast.js" defer></script>
+<script src="/js/now-playing.js" defer></script>
+<script src="/js/media-hub.js"></script>
+<script src="/js/leftmenu.js"></script>
   <script type="module" src="/js/fullscreen-orientation.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>

--- a/media-hub.html
+++ b/media-hub.html
@@ -21,6 +21,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
+  <link rel="stylesheet" href="/css/toast.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
@@ -118,6 +119,8 @@
   <script src="/js/stream-state.js" defer></script>
   <script src="/js/radio.js" defer></script>
   <script src="/js/youtube.js" defer></script>
+  <script src="/js/ui/toast.js" defer></script>
+  <script src="/js/now-playing.js" defer></script>
 
   <!-- Keep order to preserve swipe/lock behavior from your site -->
   <script src="/js/media-hub.js"></script>

--- a/radio.html
+++ b/radio.html
@@ -59,6 +59,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/toast.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
@@ -527,8 +528,10 @@ document.addEventListener('DOMContentLoaded', function() {
     } else if (navigator.clipboard) {
       navigator.clipboard.writeText(shareData.url).then(() => {
         alert('Page URL copied to clipboard');
+        window.PAKSTREAM?.Toast?.show('Link copied');
       }, () => {
         window.prompt('Copy this URL', shareData.url);
+        window.PAKSTREAM?.Toast?.show('Could not copy link');
       });
     } else {
       window.prompt('Copy this URL', shareData.url);
@@ -604,6 +607,8 @@ document.addEventListener('DOMContentLoaded', function() {
   <script src="/js/stream-state.js" defer></script>
   <script src="/js/radio.js" defer></script>
   <script src="/js/youtube.js" defer></script>
+  <script src="/js/ui/toast.js" defer></script>
+  <script src="/js/now-playing.js" defer></script>
   <script src="/js/leftmenu.js"></script>
   <script src="/js/pwa.js" defer></script>
   <script defer src="/js/main.js"></script>


### PR DESCRIPTION
## Summary
- add lightweight toast helper and styles
- show now playing badge via StreamState
- wire toast copy-link feedback on radio page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a649d0771483208212ec011258ec98