### PR TITLE
Add optional support flag for creators

### DIFF
--- a/all_streams.json
+++ b/all_streams.json
@@ -3404,6 +3404,7 @@
       "name": "Wajahat Saeed Khan",
       "type": "freepress",
       "platform": "youtube",
+      "support": true,
       "about": "<span>Wajahat S. Khan is an Emmy-nominated journalist and author reporting on Indo-Pacific security and focusing on the Af-Pak conflict.<br>An adjunct professor at NYU's Center of Global Affairs and non-resident Senior Fellow at the Atlantic Council, he has reported from 16 countries and served as NBC News bureau chief in Kabul and Islamabad.<br>He wrote the 2019 bestseller \"Game Changer: Being Shahid Afridi\" and lives between New York, London and Karachi.</span>",
       "profiles": [
         "https://whatsapp.com/channel/0029Vb65Ah17oQhcb3EHSK1V",

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -194,7 +194,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function renderSupportSection(item) {
-    if (!item || !item.key || !item.name) return '';
+    if (!item || !item.key || !item.name || !item.support) return '';
     const slug = item.key;
     const name = escapeHtml(item.name);
     const code = getSupportCode(slug);


### PR DESCRIPTION
## Summary
- add `support` flag in channel data to control support button display
- hide "Support this creator" section unless the flag is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a64cd5d2308320bb003cca9935364e