### PR TITLE
docs: reference YouTube terms and Google privacy

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -75,7 +75,7 @@
 <section>
   <h2>Privacy &amp; History</h2>
   <p>At PakStream, your privacy is important. This website uses cookies to deliver and improve the service. We use Google Analytics to understand how visitors interact with the site, and we plan to integrate Google Ads which may also use cookies for ad personalisation.</p>
-  <p>PakStream uses YouTube API Services to retrieve and display channel and video information. By using PakStream, you agree to be bound by the <a href="https://www.youtube.com/t/terms">YouTube Terms of Service</a>. PakStream does not store or collect personal information from these services. For details on how Google collects and processes data, please see the <a href="https://www.google.com/policies/privacy">Google Privacy Policy</a>.</p>
+  <p>PakStream uses YouTube API Services to retrieve and display channel and video information. By using PakStream, you agree to the <a href="https://www.youtube.com/t/terms">YouTube Terms of Service</a>. Google may collect and process data as described in the <a href="https://www.google.com/policies/privacy">Google Privacy Policy</a>. PakStream does not store or collect personal information from these services.</p>
   <p>We do not collect personal data directly. Any information gathered through cookies is processed by Google in accordance with their policies. You can manage your cookie preferences through your browser settings or via the cookie consent banner.</p>
   <p>If you have any privacy concerns or questions, feel free to contact me at:
     <a href="mailto:atif.sheikh87@gmail.com">atif.sheikh87@gmail.com</a>

--- a/terms.html
+++ b/terms.html
@@ -74,7 +74,7 @@
   <!-- Terms and conditions content -->
 <section>
   <h2>Terms & Conditions</h2>
-  <p>By using PakStream, you agree to the <a href="https://www.youtube.com/t/terms">YouTube Terms of Service</a> and the following:</p>
+  <p>PakStream uses YouTube API Services. By using PakStream, you agree to these Terms &amp; Conditions and to be bound by the <a href="https://www.youtube.com/t/terms">YouTube Terms of Service</a>.</p>
   <ul>
     <li>This website is provided “as is”, it’s free to use, with no guarantees or warranties of any kind.</li>
     <li>We link to external live TV and radio streams, as well as YouTube channels. We do not control their content or availability.</li>


### PR DESCRIPTION
## Summary
- Clarify that PakStream uses YouTube API Services and that use of the site binds users to YouTube's Terms of Service.
- Update privacy policy to note YouTube API Services usage and reference Google's Privacy Policy.

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a64f6200f48320b2df5eb3bd8a019c