### PR TITLE
Hide error overlay when switching streams

### DIFF
--- a/js/radio.js
+++ b/js/radio.js
@@ -17,7 +17,10 @@
     };
     const unregister = SS.register(id, api);
 
-    el.addEventListener('play', () => SS.play(id));
+    el.addEventListener('play', () => {
+      try { window.PAKSTREAM?.ErrorOverlay?.hide(container); } catch {}
+      SS.play(id);
+    });
     el.addEventListener('pause', () => {
       if (SS.getCurrentId() === id) { /* keep current unless another starts */ }
       container?.classList.remove('is-playing');

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -114,6 +114,8 @@
         events: {
           onStateChange: (e) => {
             if (destroyed) return;
+            // Hide any previous error overlay once the player state changes
+            try { window.PAKSTREAM?.ErrorOverlay?.hide(container); } catch {}
             // 1 = playing, 2 = paused, 0 = ended
             if (e.data === 1) { SS.play(id); container?.classList.add('is-playing'); }
             if (e.data === 2) { container?.classList.remove('is-playing'); }


### PR DESCRIPTION
## Summary
- Hide error overlay whenever a YouTube player state changes
- Hide error overlay when radio streams start playing

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a6522f47b483209a4e65614dc0b729