### PR TITLE
fix: make ad slots responsive on mobile

### DIFF
--- a/css/ads.css
+++ b/css/ads.css
@@ -4,6 +4,7 @@
   box-sizing: border-box;
   display: block;
   margin: 16px auto;
+  width: 100%;
   max-width: 100%;
   background: #f8f9fa;
   border: 1px dashed rgba(0,0,0,.08);
@@ -28,14 +29,14 @@
 
 /* Responsive helpers (optional) */
 @media (min-width: 768px) {
-  .ad-slot[data-ad-type="leaderboard"] { min-width: 728px; min-height: 90px; }
+  .ad-slot[data-ad-type="leaderboard"] { max-width: 728px; min-height: 90px; }
 }
 @media (max-width: 767.98px) {
-  .ad-slot[data-ad-type="leaderboard"] { min-width: 320px; min-height: 50px; }
+  .ad-slot[data-ad-type="leaderboard"] { max-width: 320px; min-height: 50px; }
 }
 
 /* “Fluid” slots: fill container width; height via aspect ratio or custom CSS */
 .ad-slot[data-ad-type="fluid"] {
-  min-width: 100%;
+  width: 100%;
   min-height: 1px;
 }

--- a/js/ads/ads.js
+++ b/js/ads/ads.js
@@ -7,12 +7,20 @@
   function applyReserveBox(slot) {
     // Read size from data attributes or named type
     const type = slot.dataset.adType || 'rectangle';
-    const w = Number(slot.dataset.adWidth  || Cfg.SIZES[type]?.w || 300);
-    const h = Number(slot.dataset.adHeight || Cfg.SIZES[type]?.h || 250);
+    let w = Number(slot.dataset.adWidth  || Cfg.SIZES[type]?.w || 300);
+    let h = Number(slot.dataset.adHeight || Cfg.SIZES[type]?.h || 250);
 
-    // Reserve space to prevent CLS
-    slot.style.minWidth  = w > 1 ? w + 'px' : '';
+    // Switch to mobile banner size if viewport is narrow
+    if (type === 'leaderboard' && window.matchMedia('(max-width: 767.98px)').matches) {
+      w = Cfg.SIZES.banner.w;
+      h = Cfg.SIZES.banner.h;
+    }
+
+    // Reserve space to prevent CLS while staying responsive
+    slot.style.width = '100%';
+    slot.style.maxWidth = w > 1 ? w + 'px' : '';
     slot.style.minHeight = h > 1 ? h + 'px' : '';
+
     // Add a lightweight placeholder while empty
     if (!slot.querySelector('.ad-placeholder')) {
       const ph = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure ad slots scale to container width with max-width breakpoints
- switch leaderboard ads to mobile dimensions when viewport is narrow

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a6579967fc8320bf23ef8473380b18