### PR TITLE
Add demo for flex-based YouTube section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1491,3 +1491,22 @@ footer nav a:hover {
   outline: 2px solid rgba(30,136,229,.35);
   outline-offset: 2px;
 }
+
+/* Utility: stack controls and videos vertically inside a section */
+.youtube-section.vertical {
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.youtube-section.vertical iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+}
+
+.youtube-section.vertical .channels-btn {
+  align-self: flex-start;
+  margin-bottom: 8px;
+}

--- a/youtube-section-demo.html
+++ b/youtube-section-demo.html
@@ -1,0 +1,22 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include google-tag-manager-head.html %}
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>YouTube Section Demo</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  {% include top-bar.html %}
+  <main class="container">
+    <h2>YouTube Section Demo</h2>
+    <section class="youtube-section vertical">
+      <button class="channels-btn">Channels</button>
+      <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" allowfullscreen></iframe>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `.youtube-section.vertical` utility to stack controls and video without overflow
- create `youtube-section-demo.html` to showcase button and video layout

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a6614117b48320b9ec7442b346c3bc