### PR TITLE
Remove margin from home-page YouTube embeds

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -661,6 +661,21 @@ section {
   color: var(--on-surface-variant);
 }
 
+/* Home page YouTube sections */
+.index-youtube-section {
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  aspect-ratio: 16 / 9;
+  height: auto;
+}
+
+/* Offset feature card padding so embeds touch the edges */
+.feature-card .index-youtube-section {
+  margin: -20px -20px 0;
+}
+
 /* Responsive behaviour for channel list */
 @media (max-width: 768px) {
   .youtube-section {

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <span class="material-symbols-outlined">article</span>
       <h3>Free Press</h3>
       <p>Stay updated with the latest new from Independent Voices.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+      <section class="index-youtube-section">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
@@ -193,7 +193,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <span class="material-symbols-outlined">radio</span>
       <h3>Popular Radio Stations</h3>
       <p>Listen to trending Pakistani radio.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+      <section class="index-youtube-section">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
@@ -202,7 +202,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <span class="material-symbols-outlined">live_tv</span>
       <h3>Live TV Channels</h3>
       <p>Watch the most viewed live TV streams.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+      <section class="index-youtube-section">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
@@ -211,7 +211,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <span class="material-symbols-outlined">person</span>
       <h3>Trending Creators</h3>
       <p>Watch the latest from Pakistani creators.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+      <section class="index-youtube-section">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
@@ -220,7 +220,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <span class="material-symbols-outlined">apps</span>
       <h3>All Streams</h3>
       <p>Browse every channel in one place.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+      <section class="index-youtube-section">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
@@ -229,7 +229,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <span class="material-symbols-outlined">favorite</span>
       <h3>Your Favorites</h3>
       <p>Quick access to your saved channels.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
+      <section class="index-youtube-section">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>


### PR DESCRIPTION
## Summary
- tighten `.index-youtube-section` styles and offset feature card padding so embeds sit flush without extra margins

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6605010f083208d44a8785baf5e7e