### PR TITLE
Fix media hub embed height to remove stray scroll

### DIFF
--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -19,8 +19,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
-<body>
-  <section class="youtube-section media-hub-section" style="margin: 0px;min-height: 100vh;">
+<body style="overflow:hidden;height:100vh;height:100dvh;">
+  <section class="youtube-section media-hub-section" style="margin:0;height:100%;">
     <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">
         <div class="search-wrap">
@@ -73,7 +73,7 @@
   </section>
   <script>
     function postHeight() {
-      var h = document.documentElement.scrollHeight;
+      var h = window.innerHeight;
       parent.postMessage({ type: 'media-hub-height', height: h }, '*');
     }
     window.addEventListener('load', function () {
@@ -81,6 +81,7 @@
       if (window.ResizeObserver) {
         new ResizeObserver(postHeight).observe(document.body);
       }
+      window.addEventListener('resize', postHeight);
     });
   </script>
   <script src="/js/error-overlay.js" defer></script>


### PR DESCRIPTION
## Summary
- Prevent `media-hub-embed.html` from scrolling by locking body to viewport height and hiding overflow
- Report embed height using `window.innerHeight` and update on resize

## Testing
- `npx -y htmlhint media-hub-embed.html`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a70d283da8832093571033227c43f9