### PR TITLE
Ensure embed video section inherits parent height

### DIFF
--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <div class="video-section">
+    <div class="video-section" style="height: inherit; min-height: inherit;">
       <div class="button-row">
         <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">


### PR DESCRIPTION
## Summary
- ensure `video-section` in media-hub-embed.html inherits its parent's height and min-height

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a70dbb57fc8320b846f17a6c49cbfe