### PR TITLE
Ensure channel list inherits parent height in embed

### DIFF
--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -21,7 +21,7 @@
 </head>
 <body style="overflow:hidden;height:100vh;height:100dvh;">
   <section class="youtube-section media-hub-section" style="margin:0;height:100%;">
-    <div class="channel-list open" id="left-rail">
+    <div class="channel-list open" id="left-rail" style="height: inherit; min-height: inherit;">
       <div class="left-rail-header">
         <div class="search-wrap">
           <input id="mh-search-input" type="text" placeholder="Search…" />


### PR DESCRIPTION
## Summary
- Ensure media hub channel list inherits parent height in embed layout for proper sizing

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a70f6e0eb48320bc061312404e078c