### PR TITLE
Ensure media hub layout matches video section height

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -1,3 +1,9 @@
+/* Ensure the page and layout section are tall enough to display the full video area */
+body,
+.youtube-section.media-hub-section {
+  min-height: calc(100vh - 120px);
+}
+
 /* Layout: mode tabs on top, channel list and video section below */
 .media-hub-section {
   display: grid;


### PR DESCRIPTION
## Summary
- Ensure `<body>` and media hub section expand to fit the video section by setting a minimum height

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a714cd6a3883208cfa5f4be8fb28fa