### PR TITLE
Ensure media hub layout matches video section height

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -1,3 +1,9 @@
+/* Ensure the page and layout section are tall enough to display the full video area */
+body.media-hub-embed,
+body.media-hub-embed .youtube-section.media-hub-section {
+  min-height: calc(100vh - 120px);
+}
+
 /* Layout: mode tabs on top, channel list and video section below */
 .media-hub-section {
   display: grid;

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -19,7 +19,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
-<body class="media-hub-embed" style="overflow:hidden;height:100vh;height:100dvh;padding-left:0;padding-right:0">
+<body class="media-hub-embed" style="overflow:auto;min-height:100vh;min-height:100dvh;padding-left:0;padding-right:0">
   <section class="youtube-section media-hub-section" style="margin:0;height:100%;padding:0;">
     <div class="channel-list open" id="left-rail" style="height: inherit; min-height: inherit;">
       <div class="left-rail-header">

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -19,7 +19,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
-<body style="overflow:hidden;height:100vh;height:100dvh;padding-left:0;padding-right:0">
+<body class="media-hub-embed" style="overflow:hidden;height:100vh;height:100dvh;padding-left:0;padding-right:0">
   <section class="youtube-section media-hub-section" style="margin:0;height:100%;padding:0;">
     <div class="channel-list open" id="left-rail" style="height: inherit; min-height: inherit;">
       <div class="left-rail-header">


### PR DESCRIPTION
## Summary
- Ensure `<body>` and media hub section expand to fit the video section by setting a minimum height
- Limit the min-height rule to the embedded media hub so the standard page layout is unaffected

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a714cd6a3883208cfa5f4be8fb28fa