### PR TITLE
fix: resize feature-card iframes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -154,6 +154,25 @@ document.addEventListener('DOMContentLoaded', function () {
   window.resizeLivePlayers = resizeLivePlayers;
   resizeLivePlayers();
 
+  // Match iframe height to its content so feature cards don't scroll internally
+  function resizeMediaHubEmbeds() {
+    document.querySelectorAll('.media-hub-embed').forEach(function (iframe) {
+      try {
+        var doc = iframe.contentWindow.document;
+        var h = Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight);
+        iframe.style.height = h + 'px';
+      } catch (e) {
+        // Ignore cross-origin frames
+      }
+    });
+  }
+  window.addEventListener('resize', resizeMediaHubEmbeds);
+  document.querySelectorAll('.media-hub-embed').forEach(function (iframe) {
+    iframe.setAttribute('scrolling', 'no');
+    iframe.addEventListener('load', resizeMediaHubEmbeds);
+  });
+  resizeMediaHubEmbeds();
+
   var scroller = document.querySelector('.station-scroller .scroller-track');
   if (scroller) {
     fetch('/all_streams.json')


### PR DESCRIPTION
## Summary
- resize embedded media-hub iframes so feature cards don't scroll internally

## Testing
- `npm test` *(fails: missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a71ddd2ccc83209cefd379d34a88b1