### PR TITLE
Fix channel/about toggle labels

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -59,7 +59,7 @@
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
         <span class="material-symbols-outlined icon">chevron_left</span>
-        <span class="label" data-default="Channels">Channels</span>
+        <span class="label">Channels</span>
       </button>
 
       <div class="live-player" data-stream-container data-youtube-container>
@@ -320,12 +320,7 @@
 
   function toggleChannelList() {
     const list = document.querySelector('.channel-list');
-    const btn = document.getElementById('toggle-channels');
-    const label = btn?.querySelector('.label');
     list.classList.toggle('open');
-    if (label) {
-      label.textContent = list.classList.contains('open') ? 'Hide' : (label.dataset.default || 'Channels');
-    }
   }
 
   async function handleChannelClick(card) {
@@ -345,8 +340,6 @@
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
       list.classList.remove('open');
-      const label = document.querySelector('#toggle-channels .label');
-      if (label) label.textContent = label.dataset.default || 'Channels';
     }
 
     if (!channelId) {

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -73,11 +73,11 @@
       <div class="button-row">
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="material-symbols-outlined icon">chevron_left</span>
-          <span class="label" data-default="Channels">Channels</span>
+          <span class="label">Channels</span>
         </button>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
           <span class="material-symbols-outlined icon">chevron_right</span>
-          <span class="label" data-default="About">About</span>
+          <span class="label">About</span>
         </button>
       </div>
       <div class="live-player" data-stream-container data-youtube-container>
@@ -370,23 +370,13 @@
 
   function toggleChannelList() {
     const list = document.querySelector('.channel-list');
-    const btn = document.getElementById('toggle-channels');
-    const label = btn?.querySelector('.label');
     list.classList.toggle('open');
-    if (label) {
-      label.textContent = list.classList.contains('open') ? 'Hide' : (label.dataset.default || 'Channels');
-    }
   }
 
   function toggleDetailsList() {
     const details = document.querySelector('.details-list');
-    const btn = document.getElementById('toggle-details');
-    const label = btn?.querySelector('.label');
     details.classList.toggle('open');
     details.style.display = details.classList.contains('open') ? '' : 'none';
-    if (label) {
-      label.textContent = details.classList.contains('open') ? 'Hide' : (label.dataset.default || 'About');
-    }
   }
 
   async function handleChannelClick(card) {
@@ -426,8 +416,6 @@
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
       list.classList.remove('open');
-      const label = document.querySelector('#toggle-channels .label');
-      if (label) label.textContent = label.dataset.default || 'Channels';
     }
 
     if (!channelId) {

--- a/freepress.html
+++ b/freepress.html
@@ -73,11 +73,11 @@
       <div class="button-row">
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="material-symbols-outlined icon">chevron_left</span>
-          <span class="label" data-default="Channels">Channels</span>
+          <span class="label">Channels</span>
         </button>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
           <span class="material-symbols-outlined icon">chevron_right</span>
-          <span class="label" data-default="About">About</span>
+          <span class="label">About</span>
         </button>
       </div>
       <div class="live-player" data-stream-container data-youtube-container>
@@ -370,23 +370,13 @@
 
   function toggleChannelList() {
     const list = document.querySelector('.channel-list');
-    const btn = document.getElementById('toggle-channels');
-    const label = btn?.querySelector('.label');
     list.classList.toggle('open');
-    if (label) {
-      label.textContent = list.classList.contains('open') ? 'Hide' : (label.dataset.default || 'Channels');
-    }
   }
 
   function toggleDetailsList() {
     const details = document.querySelector('.details-list');
-    const btn = document.getElementById('toggle-details');
-    const label = btn?.querySelector('.label');
     details.classList.toggle('open');
     details.style.display = details.classList.contains('open') ? '' : 'none';
-    if (label) {
-      label.textContent = details.classList.contains('open') ? 'Hide' : (label.dataset.default || 'About');
-    }
   }
 
   async function handleChannelClick(card) {
@@ -426,8 +416,6 @@
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
       list.classList.remove('open');
-      const label = document.querySelector('#toggle-channels .label');
-      if (label) label.textContent = label.dataset.default || 'Channels';
     }
 
     if (!channelId) {

--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -8,13 +8,6 @@
     ".youtube-section, .media-hub-section",
   );
 
-  const channelLabelEl = channelToggleBtn?.querySelector(".label");
-  const channelToggleDefaultText =
-    channelLabelEl?.textContent || channelToggleBtn?.textContent || "";
-  if (channelLabelEl) channelLabelEl.dataset.default = channelToggleDefaultText;
-  const detailsLabelEl = detailsToggleBtn?.querySelector(".label");
-  const detailsToggleDefaultText = detailsLabelEl?.textContent || "About";
-  if (detailsLabelEl) detailsLabelEl.dataset.default = detailsToggleDefaultText;
 
   const FOCUSABLE_SELECTOR =
     'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -50,15 +43,9 @@
   function toggleChannelList() {
     if (!channelList || !channelToggleBtn) return;
     const icon = channelToggleBtn.querySelector(".icon");
-    const label = channelToggleBtn.querySelector(".label");
     if (window.innerWidth <= 768) {
       const opening = !channelList.classList.contains("open");
       channelList.classList.toggle("open");
-      if (label) {
-        label.textContent = opening
-          ? `Close ${channelToggleDefaultText}`
-          : channelToggleDefaultText;
-      }
       if (typeof updateScrollLock === "function") updateScrollLock();
       if (opening) {
         removeChannelFocusTrap = trapFocus(channelList);
@@ -86,8 +73,6 @@
       !channelToggleBtn.contains(e.target)
     ) {
       channelList.classList.remove("open");
-      const label = channelToggleBtn.querySelector(".label");
-      if (label) label.textContent = channelToggleDefaultText;
       if (typeof updateScrollLock === "function") updateScrollLock();
       if (removeChannelFocusTrap) removeChannelFocusTrap();
       channelToggleBtn.focus();
@@ -99,8 +84,6 @@
       if (window.innerWidth > 768) return;
       if (e.target.closest(".channel-card")) {
         channelList.classList.remove("open");
-        const label = channelToggleBtn?.querySelector(".label");
-        if (label) label.textContent = channelToggleDefaultText;
         if (typeof updateScrollLock === "function") updateScrollLock();
         if (removeChannelFocusTrap) removeChannelFocusTrap();
         channelToggleBtn.focus();
@@ -120,8 +103,6 @@
       const touchEndX = e.changedTouches[0].clientX;
       if (!touchFromModeTabs && touchStartX - touchEndX > 50) {
         channelList.classList.remove("open");
-        const label = channelToggleBtn?.querySelector(".label");
-        if (label) label.textContent = channelToggleDefaultText;
         if (typeof updateScrollLock === "function") updateScrollLock();
         if (removeChannelFocusTrap) removeChannelFocusTrap();
         channelToggleBtn.focus();
@@ -152,8 +133,6 @@
       const touchEndX = e.changedTouches[0].clientX;
       if (touchEndX - openStartX > 50 && openStartX < 50) {
         channelList.classList.add("open");
-        const label = channelToggleBtn?.querySelector(".label");
-        if (label) label.textContent = `Close ${channelToggleDefaultText}`;
         if (typeof updateScrollLock === "function") updateScrollLock();
         removeChannelFocusTrap = trapFocus(channelList);
       }
@@ -164,16 +143,10 @@
   function toggleDetailsList() {
     if (!detailsList || !detailsToggleBtn) return;
     const icon = detailsToggleBtn.querySelector(".icon");
-    const label = detailsToggleBtn.querySelector(".label");
       if (window.innerWidth <= 1080) {
         if (detailsToggleBtn.style.display === "none") return;
         const opening = !detailsList.classList.contains("open");
         detailsList.classList.toggle("open");
-        if (label) {
-          label.textContent = opening
-            ? `Close ${detailsToggleDefaultText}`
-            : detailsToggleDefaultText;
-        }
         if (typeof updateScrollLock === "function") updateScrollLock();
         if (opening) {
           removeDetailsFocusTrap = trapFocus(detailsList);
@@ -202,8 +175,6 @@
       !detailsToggleBtn.contains(e.target)
     ) {
       detailsList.classList.remove("open");
-      const label = detailsToggleBtn.querySelector(".label");
-      if (label) label.textContent = detailsToggleDefaultText;
       if (typeof updateScrollLock === "function") updateScrollLock();
       if (removeDetailsFocusTrap) removeDetailsFocusTrap();
       detailsToggleBtn.focus();
@@ -221,8 +192,6 @@
       const touchEndX = e.changedTouches[0].clientX;
       if (touchEndX - detailsTouchStartX > 50) {
           detailsList.classList.remove("open");
-          const label = detailsToggleBtn.querySelector(".label");
-          if (label) label.textContent = detailsToggleDefaultText;
           if (typeof updateScrollLock === "function") updateScrollLock();
           if (removeDetailsFocusTrap) removeDetailsFocusTrap();
           detailsToggleBtn.focus();
@@ -261,8 +230,6 @@
         detailsOpenStartX - touchEndX > 50
       ) {
           detailsList.classList.add("open");
-          const label = detailsToggleBtn.querySelector(".label");
-          if (label) label.textContent = `Close ${detailsToggleDefaultText}`;
           if (typeof updateScrollLock === "function") updateScrollLock();
           removeDetailsFocusTrap = trapFocus(detailsList);
         }

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -258,7 +258,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   function updateDetails(item) {
     if (!details || !toggleDetailsBtn) return;
-    const label = toggleDetailsBtn.querySelector('.label');
     let html = '';
     if (item) {
       if (item.details_html) {
@@ -277,13 +276,11 @@ document.addEventListener("DOMContentLoaded", async () => {
       attachSupportHandlers(details);
       details.style.display = '';
       toggleDetailsBtn.style.display = '';
-      if (label) label.textContent = label.dataset.default || 'About';
     } else {
       details.classList.remove('open');
       details.innerHTML = '';
       details.style.display = 'none';
       toggleDetailsBtn.style.display = 'none';
-      if (label) label.textContent = label.dataset.default || 'About';
     }
   }
 
@@ -866,8 +863,6 @@ async function renderLatestVideosRSS(channelId) {
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
       if (list) list.classList.remove('open');
-      const label = document.querySelector('#toggle-channels .label');
-      if (label) label.textContent = label.dataset.default || label.textContent;
       if (typeof window.updateScrollLock === 'function') window.updateScrollLock();
     }
 
@@ -973,8 +968,6 @@ async function renderLatestVideosRSS(channelId) {
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');
       if (list) list.classList.remove('open');
-      const label = document.querySelector('#toggle-channels .label');
-      if (label) label.textContent = label.dataset.default || label.textContent;
       if (typeof window.updateScrollLock === 'function') window.updateScrollLock();
     }
     updateFavoritesUI();

--- a/livetv.html
+++ b/livetv.html
@@ -354,8 +354,6 @@
       if (window.innerWidth <= 768) {
         const list = document.querySelector('.channel-list');
         list.classList.remove('open');
-        const label = document.querySelector('#toggle-channels .label');
-        if (label) label.textContent = label.dataset.default || label.textContent;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
     }

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -34,7 +34,7 @@
         <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="material-symbols-outlined icon">chevron_left</span>
-          <span class="label" data-default="Channels">Channels</span>
+          <span class="label">Channels</span>
         </button>
       </div>
 

--- a/media-hub.html
+++ b/media-hub.html
@@ -58,11 +58,11 @@
         <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="material-symbols-outlined icon">chevron_left</span>
-          <span class="label" data-default="Channels">Channels</span>
+          <span class="label">Channels</span>
         </button>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
           <span class="material-symbols-outlined icon">chevron_right</span>
-          <span class="label" data-default="About">About</span>
+          <span class="label">About</span>
         </button>
       </div>
 

--- a/radio.html
+++ b/radio.html
@@ -444,8 +444,6 @@ document.addEventListener('DOMContentLoaded', function() {
       if (window.innerWidth <= 768) {
         const list = document.querySelector('.channel-list');
         list.classList.remove('open');
-        const label = document.querySelector('#toggle-channels .label');
-        if (label) label.textContent = label.dataset.default || label.textContent;
         if (typeof updateScrollLock === 'function') updateScrollLock();
       }
 


### PR DESCRIPTION
## Summary
- Remove `data-default` attributes and simplify channel/about button markup
- Stop scripts from rewriting button labels
- Keep channel and detail buttons showing static text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7207af7d4832089c0553cd550858d