### PR TITLE
Enable radio controls without channel list

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -897,7 +897,7 @@ async function renderLatestVideosRSS(channelId) {
       const playPromise = mainPlayer.play();
       if (playPromise !== undefined) {
         pendingBtn = btn;
-        btn.classList.add('loading');
+        if (btn) btn.classList.add('loading');
         if (playPauseBtn) playPauseBtn.classList.add('loading');
         playPromise.catch(() => {
           // require user interaction
@@ -1064,4 +1064,21 @@ async function renderLatestVideosRSS(channelId) {
     }
   updateActiveUI();
   renderList(searchEl ? (searchEl.value || "") : "");
+
+  // If no channels are rendered but a specific radio channel is requested,
+  // load it directly so primary controls remain enabled.
+  const initialKey = params.get('c');
+  if (!currentAudio && initialKey) {
+    const item = items.find(i => i.key === initialKey || i.ids?.internal_id === initialKey);
+    if (item && modeOfItem(item) === 'radio') {
+      const ep = radioEndpoint(item);
+      if (ep) {
+        const audio = document.createElement('audio');
+        audio.id = item.ids?.internal_id || item.key;
+        audio.src = ep.url;
+        audio.dataset.logo = thumbOf(item);
+        playRadio(null, audio, displayName(item), audio.dataset.logo, item);
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- Allow radio playback without a channel card by skipping button loading state when absent
- Automatically load requested radio station if no channels are rendered so controls remain active

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a721f669cc8320b7eaf482e85159ef