### PR TITLE
Remove chevron icons from channel toggles

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -58,7 +58,6 @@
 
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
-        <span class="material-symbols-outlined icon">chevron_left</span>
         <span class="label">Channels</span>
       </button>
 

--- a/css/style.css
+++ b/css/style.css
@@ -859,10 +859,6 @@ button:hover,
   background: var(--primary-container);
 }
 
-.channel-toggle .icon,
-.details-toggle .icon {
-  display: none;
-}
 
 @media (min-width: 769px) {
   .channel-toggle,
@@ -873,16 +869,6 @@ button:hover,
     padding: 4px;
     border-radius: 0;
     font-size: 20px;
-  }
-
-  .channel-toggle .label,
-  .details-toggle .label {
-    display: none;
-  }
-
-  .channel-toggle .icon,
-  .details-toggle .icon {
-    display: inline-block;
   }
 
   .channel-toggle:hover,

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -72,11 +72,9 @@
     <div class="video-section">
       <div class="button-row">
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
-          <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label">Channels</span>
         </button>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
           <span class="label">About</span>
         </button>
       </div>

--- a/freepress.html
+++ b/freepress.html
@@ -72,11 +72,9 @@
     <div class="video-section">
       <div class="button-row">
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
-          <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label">Channels</span>
         </button>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
           <span class="label">About</span>
         </button>
       </div>

--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -42,7 +42,6 @@
 
   function toggleChannelList() {
     if (!channelList || !channelToggleBtn) return;
-    const icon = channelToggleBtn.querySelector(".icon");
     if (window.innerWidth <= 768) {
       const opening = !channelList.classList.contains("open");
       channelList.classList.toggle("open");
@@ -58,7 +57,6 @@
       const collapsed = channelList.classList.contains("collapsed");
       if (channelSection)
         channelSection.classList.toggle("channels-collapsed", collapsed);
-      if (icon) icon.textContent = collapsed ? "chevron_right" : "chevron_left";
       localStorage.setItem("channelListCollapsed", collapsed);
     }
   }
@@ -142,7 +140,6 @@
 
   function toggleDetailsList() {
     if (!detailsList || !detailsToggleBtn) return;
-    const icon = detailsToggleBtn.querySelector(".icon");
       if (window.innerWidth <= 1080) {
         if (detailsToggleBtn.style.display === "none") return;
         const opening = !detailsList.classList.contains("open");
@@ -160,7 +157,6 @@
         const collapsed = detailsContainer.classList.contains("collapsed");
         if (channelSection)
           channelSection.classList.toggle("details-collapsed", collapsed);
-      if (icon) icon.textContent = collapsed ? "chevron_left" : "chevron_right";
       localStorage.setItem("detailsListCollapsed", collapsed);
     }
   }
@@ -239,20 +235,16 @@
 
   (function () {
     if (channelList) {
-      const icon = channelToggleBtn?.querySelector(".icon");
       if (localStorage.getItem("channelListCollapsed") === "true") {
         channelList.classList.add("collapsed");
         if (channelSection) channelSection.classList.add("channels-collapsed");
-        if (icon) icon.textContent = "chevron_right";
       }
     }
     if (detailsContainer && detailsToggleBtn) {
-      const icon = detailsToggleBtn.querySelector(".icon");
       const collapsedPref = localStorage.getItem("detailsListCollapsed");
       if (collapsedPref === null || collapsedPref === "true") {
         detailsContainer.classList.add("collapsed");
         if (channelSection) channelSection.classList.add("details-collapsed");
-        if (icon) icon.textContent = "chevron_left";
       }
     }
   })();

--- a/livetv.html
+++ b/livetv.html
@@ -73,7 +73,6 @@
     <div class="channel-list"></div>
     <div class="video-section">
       <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()" aria-label="Toggle channel list">
-        <span class="material-symbols-outlined icon">chevron_left</span>
         <span class="label">Channels</span>
       </button>
     </div>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -33,7 +33,6 @@
       <div class="button-row">
         <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
-          <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label">Channels</span>
         </button>
       </div>

--- a/media-hub.html
+++ b/media-hub.html
@@ -57,11 +57,9 @@
       <div class="button-row">
         <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
-          <span class="material-symbols-outlined icon">chevron_left</span>
           <span class="label">Channels</span>
         </button>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
-          <span class="material-symbols-outlined icon">chevron_right</span>
           <span class="label">About</span>
         </button>
       </div>

--- a/radio.html
+++ b/radio.html
@@ -73,7 +73,6 @@
     <div class="channel-list"></div>
     <div class="video-section">
       <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle station list">
-        <span class="material-symbols-outlined icon">chevron_left</span>
         <span class="label">Stations</span>
       </button>
       <div class="live-player">


### PR DESCRIPTION
## Summary
- simplify channel and details toggle buttons to text-only
- remove chevron icon CSS/JS

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a776adb6688320ade35c8d34e5e3a2