### PR TITLE
Streamline homepage feature cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
     <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">
       <span class="material-symbols-outlined">article</span>
       <h3>Free Press</h3>
-      <p>Stay updated with the latest new from Independent Voices.</p>
+      <p>Independent YouTube voices from Pakistan—journalists, analysts, and vloggers in one place.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -191,8 +191,8 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
     </div>
     <div class="feature-card" data-m="radio" data-c="audio35">
       <span class="material-symbols-outlined">radio</span>
-      <h3>Popular Radio Stations</h3>
-      <p>Listen to trending Pakistani radio.</p>
+      <h3>Live Pakistani Radio</h3>
+      <p>Stream Mera FM, City FM89, Mast FM, and more—24/7 with no buffering. Works on mobile or desktop and is perfect for background listening at work or on the road abroad.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -201,7 +201,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
     <div class="feature-card" data-m="tv" data-c="24news">
       <span class="material-symbols-outlined">live_tv</span>
       <h3>Live TV Channels</h3>
-      <p>Watch the most viewed live TV streams.</p>
+      <p>Watch Pakistani news, dramas, and morning shows live—free and in any browser worldwide.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -241,35 +241,6 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
     <h2>PakStream – Stay Connected to Pakistan, Wherever You Are</h2>
     <p>Missing home? Whether you're sipping chai in Sweden, commuting in London, or relaxing in Toronto — PakStream is here to bring Pakistan closer to you.</p>
     <p>Our platform makes it simple to watch Pakistani news online, listen to Urdu radio stations, and stay up-to-date with political talk shows and entertainment – all from one place. No VPNs. No hassle.</p>
-  </section>
-
-  <section class="radio-section">
-    <h3>Live Pakistani Radio – Music, Talk, and More</h3>
-    <p>Stream your favorite Urdu and regional radio stations 24/7. From Mera FM, City FM89, and Mast FM to regional gems from Karachi, Lahore, and beyond – we’ve got them all lined up for you.</p>
-    <ul>
-      <li>No buffering</li>
-      <li>Compatible with mobile &amp; desktop</li>
-      <li>Great for background listening at work or while driving abroad</li>
-    </ul>
-    <p><a href="/radio.html">Listen to Pakistani radio stations</a></p>
-  </section>
-
-  <section class="tv-section">
-    <h3>Watch Pakistani TV Channels – Live &amp; Free</h3>
-    <p>Catch up on Pakistani TV channels online, no matter the time zone. Whether you’re into news, drama, or morning shows, PakStream makes it easy to stream Urdu TV abroad without jumping through hoops.</p>
-    <ul>
-      <li>Live news from major broadcasters</li>
-      <li>Drama serials and morning shows</li>
-      <li>Works on any browser – no app required</li>
-    </ul>
-    <p><a href="/livetv.html">Watch live Pakistani channels</a></p>
-  </section>
-
-  <section class="youtube-home">
-    <h3>Independent YouTube Voices from Pakistan</h3>
-    <p>We bring you hand-picked YouTube channels from across Pakistan — from journalists and commentators to vloggers and analysts.</p>
-    <p>Whether you want political insight, comedy, or cultural commentary — our YouTubers keep you informed and entertained.</p>
-    <p><a href="/freepress.html">Explore Pakistani YouTubers</a></p>
   </section>
 
   <section class="blog-section">

--- a/theme-tester.html
+++ b/theme-tester.html
@@ -131,7 +131,7 @@
     <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">
       <span class="material-symbols-outlined">article</span>
       <h3>Free Press</h3>
-      <p>Stay updated with the latest new from Independent Voices.</p>
+      <p>Independent YouTube voices from Pakistan—journalists, analysts, and vloggers in one place.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -139,8 +139,8 @@
     </div>
     <div class="feature-card" data-m="radio" data-c="audio35">
       <span class="material-symbols-outlined">radio</span>
-      <h3>Popular Radio Stations</h3>
-      <p>Listen to trending Pakistani radio.</p>
+      <h3>Live Pakistani Radio</h3>
+      <p>Stream Mera FM, City FM89, Mast FM, and more—24/7 with no buffering. Works on mobile or desktop and is perfect for background listening at work or on the road abroad.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -149,7 +149,7 @@
     <div class="feature-card" data-m="tv" data-c="24news">
       <span class="material-symbols-outlined">live_tv</span>
       <h3>Live TV Channels</h3>
-      <p>Watch the most viewed live TV streams.</p>
+      <p>Watch Pakistani news, dramas, and morning shows live—free and in any browser worldwide.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
@@ -189,35 +189,6 @@
     <h2>PakStream – Stay Connected to Pakistan, Wherever You Are</h2>
     <p>Missing home? Whether you're sipping chai in Sweden, commuting in London, or relaxing in Toronto — PakStream is here to bring Pakistan closer to you.</p>
     <p>Our platform makes it simple to watch Pakistani news online, listen to Urdu radio stations, and stay up-to-date with political talk shows and entertainment – all from one place. No VPNs. No hassle.</p>
-  </section>
-
-  <section class="radio-section">
-    <h3>Live Pakistani Radio – Music, Talk, and More</h3>
-    <p>Stream your favorite Urdu and regional radio stations 24/7. From Mera FM, City FM89, and Mast FM to regional gems from Karachi, Lahore, and beyond – we’ve got them all lined up for you.</p>
-    <ul>
-      <li>No buffering</li>
-      <li>Compatible with mobile &amp; desktop</li>
-      <li>Great for background listening at work or while driving abroad</li>
-    </ul>
-    <p><a href="/radio.html">Listen to Pakistani radio stations</a></p>
-  </section>
-
-  <section class="tv-section">
-    <h3>Watch Pakistani TV Channels – Live &amp; Free</h3>
-    <p>Catch up on Pakistani TV channels online, no matter the time zone. Whether you’re into news, drama, or morning shows, PakStream makes it easy to stream Urdu TV abroad without jumping through hoops.</p>
-    <ul>
-      <li>Live news from major broadcasters</li>
-      <li>Drama serials and morning shows</li>
-      <li>Works on any browser – no app required</li>
-    </ul>
-    <p><a href="/livetv.html">Watch live Pakistani channels</a></p>
-  </section>
-
-  <section class="youtube-home">
-    <h3>Independent YouTube Voices from Pakistan</h3>
-    <p>We bring you hand-picked YouTube channels from across Pakistan — from journalists and commentators to vloggers and analysts.</p>
-    <p>Whether you want political insight, comedy, or cultural commentary — our YouTubers keep you informed and entertained.</p>
-    <p><a href="/freepress.html">Explore Pakistani YouTubers</a></p>
   </section>
 
   <section class="blog-section">


### PR DESCRIPTION
## Summary
- Condensed Free Press, Radio, and Live TV feature cards with new descriptive copy.
- Removed redundant Radio, TV, and YouTube sections from homepage and theme tester.

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a7793e9e108320beb193cd55d67cdf