### PR TITLE
Use h3 heading for YouTube API privacy notice

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -76,7 +76,7 @@
   <h2>Privacy Policy</h2>
   <!-- BEGIN: YOUTUBE-API-PRIVACY-NOTICE -->
   <section id="youtube-api-privacy-notice">
-    <h2>YouTube API Services & Your Privacy</h2>
+    <h3>YouTube API Services & Your Privacy</h3>
     <p>PakStream uses <strong>YouTube API Services</strong> to retrieve and display public channel, video, and livestream information. By using PakStream, you also agree to the     <a href="https://www.youtube.com/t/terms" target="_blank" rel="noopener noreferrer">YouTube Terms of Service</a>.   </p>
     <p>Data handling related to Google and YouTube is further governed by the     <a href="http://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Privacy Policy</a>.     You can review and manage your Google account permissions anytime at     <a href="https://security.google.com/settings/security/permissions" target="_blank" rel="noopener noreferrer">Google Security Settings</a>.   </p>
     <p>PakStream does not store YouTube OAuth tokens, and it does not access private YouTube user data. Any data shown is fetched directly from YouTube’s public endpoints via YouTube API Services and displayed to you.</p>


### PR DESCRIPTION
## Summary
- Downgrade YouTube API Services privacy notice heading from `<h2>` to `<h3>` while keeping marker comments intact.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a7a76c93fc83208672ac5e8345dbe2