### PR TITLE
Add details sidebar to media hub embed page

### DIFF
--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -35,6 +35,9 @@
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
+        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
+          <span class="label">About</span>
+        </button>
       </div>
 
       <div class="live-player" data-stream-container data-youtube-container>
@@ -68,6 +71,9 @@
       </div>
 
       <div id="videoList" class="video-list"></div>
+    </div>
+    <div class="details-container" style="height: inherit; min-height: inherit;">
+      <div class="details-list" style="display:none;"></div>
     </div>
   </section>
   <script>


### PR DESCRIPTION
## Summary
- Add About toggle button and details container to embedded media hub so right sidebar can open/close

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a81fed0fe08320b0e7d130b1f76020