### PR TITLE
Remove Buy Me a Coffee link from top bar

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -18,7 +18,6 @@
     <a href="/privacy.html">Privacy</a>
     <a href="/terms.html">Terms</a>
   </nav>
-  <a href="https://buymeacoffee.com/pakstream" class="bmc-button" target="_blank" rel="noopener">Buy me a coffee ☕</a>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌓</button>
 </header>
 <script src="/js/pwa.js" defer></script>


### PR DESCRIPTION
## Summary
- Remove redundant Buy Me a Coffee button from the top bar include.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a84cdf620083209fec185b3e8906ba