### PR TITLE
Align right menu height with left in embed

### DIFF
--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -73,7 +73,7 @@
       <div id="videoList" class="video-list"></div>
     </div>
     <div class="details-container" style="height: inherit; min-height: inherit;">
-      <div class="details-list" style="display:none;"></div>
+      <div class="details-list" style="display:none;height: inherit; min-height: inherit;"></div>
     </div>
   </section>
   <script>


### PR DESCRIPTION
## Summary
- Ensure the right details menu in `media-hub-embed.html` inherits height like the left channel list for consistent layout

## Testing
- `npx htmlhint media-hub-embed.html`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8613fe26083208f4b10d4a75d4b5a