### PR TITLE
Fix feature card layout when right menu present

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -399,6 +399,7 @@ section {
   flex: 1 1 250px;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
 }
 
 .feature-card:hover,
@@ -415,6 +416,12 @@ section {
 
 .feature-card p {
   min-height: 3rem;
+}
+
+.feature-card .right-menu {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
 }
 
 .media-hub-embed {


### PR DESCRIPTION
## Summary
- Ensure feature cards keep consistent height when a right-side menu is added by positioning the menu absolutely

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a86dc526108320b86afae342ca9ce3