### PR TITLE
Limit media hub embed height to allow scrolling

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -256,6 +256,8 @@
   border-radius: 14px;
   padding: 12px;
   box-shadow: var(--shadow-xs);
+  height: calc(100vh - 120px);
+  overflow-y: auto;
 }
 .detail-item {
   margin-bottom: 6px;

--- a/js/main.js
+++ b/js/main.js
@@ -154,12 +154,17 @@ document.addEventListener('DOMContentLoaded', function () {
   window.resizeLivePlayers = resizeLivePlayers;
   resizeLivePlayers();
 
-  // Match iframe height to its content so feature cards don't scroll internally
+  // Limit iframe height so internal content can scroll
   function resizeMediaHubEmbeds() {
     document.querySelectorAll('.media-hub-embed').forEach(function (iframe) {
       try {
         var doc = iframe.contentWindow.document;
-        var h = Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight);
+        var scrollHeight = Math.max(
+          doc.body.scrollHeight,
+          doc.documentElement.scrollHeight,
+        );
+        var maxHeight = 210;
+        var h = Math.min(scrollHeight, maxHeight);
         iframe.style.height = h + 'px';
       } catch (e) {
         // Ignore cross-origin frames
@@ -168,7 +173,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
   window.addEventListener('resize', resizeMediaHubEmbeds);
   document.querySelectorAll('.media-hub-embed').forEach(function (iframe) {
-    iframe.setAttribute('scrolling', 'no');
+    iframe.setAttribute('scrolling', 'auto');
     iframe.addEventListener('load', resizeMediaHubEmbeds);
   });
   resizeMediaHubEmbeds();

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -21,7 +21,7 @@
 </head>
 <body style="overflow:hidden;height:100vh;height:100dvh;padding-left:0;padding-right:0">
   <section class="youtube-section media-hub-section" style="margin:0;height:100%;padding:0;">
-    <div class="channel-list open" id="left-rail" style="height: inherit; min-height: inherit;">
+    <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">
         <div class="search-wrap">
           <input id="mh-search-input" type="text" placeholder="Search…" />
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <div class="video-section" style="height: inherit; min-height: inherit;">
+    <div class="video-section">
       <div class="button-row">
         <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
@@ -72,8 +72,8 @@
 
       <div id="videoList" class="video-list"></div>
     </div>
-    <div class="details-container" style="height: inherit; min-height: inherit;">
-      <div class="details-list" style="display:none;height: inherit; min-height: inherit;"></div>
+    <div class="details-container">
+      <div class="details-list" style="display:none;"></div>
     </div>
   </section>
   <script>


### PR DESCRIPTION
## Summary
- Cap media-hub embed iframes to a modest height so content scrolls internally
- Enable iframe scrollbars and mirror left-menu styling for right-side details list
- Remove inline height styles from embed layout for consistent menu behavior

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c563399483208afdfe5ca2719faa