### PR TITLE
Fix channel and about button styles on media hub pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -867,26 +867,6 @@ button:hover,
 }
 
 
-@media (min-width: 769px) {
-  .channel-toggle,
-  .details-toggle {
-    background: none;
-    color: var(--primary);
-    border: none;
-    padding: 4px;
-    border-radius: 0;
-    font-size: 20px;
-  }
-
-  .channel-toggle:hover,
-  .channel-toggle:focus,
-  .details-toggle:hover,
-  .details-toggle:focus {
-    background: none;
-    color: var(--hover-primary);
-  }
-}
-
 button:hover,
 .channel-toggle:hover {
   transform: scale(1.03);


### PR DESCRIPTION
## Summary
- remove desktop-specific styles for `.channel-toggle` and `.details-toggle`
- buttons now consistently use mobile styling on all screen sizes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df4be378832081e3c988c7449cfa