### PR TITLE
Right-align About button on media hub pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -527,6 +527,10 @@ section {
   margin-bottom: 8px;
 }
 
+.button-row .spacer {
+  flex: 1;
+}
+
 .youtube-section .channel-card,
 .media-hub-section .channel-card,
 .youtube-section .detail-item,

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -31,10 +31,10 @@
 
     <div class="video-section">
       <div class="button-row">
-        <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
+        <div class="spacer"></div>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
           <span class="label">About</span>
         </button>

--- a/media-hub.html
+++ b/media-hub.html
@@ -55,10 +55,10 @@
     <!-- CENTER -->
     <div class="video-section">
       <div class="button-row">
-        <div class="spacer"></div>
         <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
+        <div class="spacer"></div>
         <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
           <span class="label">About</span>
         </button>


### PR DESCRIPTION
## Summary
- Move spacer between channel and About buttons so About floats to the right
- Add flex spacer rule to button row

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8df76c8fc8320b811a447c334a044