### PR TITLE
Add about param to hide details panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <h3>Free Press</h3>
       <p>Discover Pakistan’s independent voices, journalists, analysts, and vloggers who share perspectives free from government or corporate influence. Here you’ll find diverse opinions and alternative viewpoints that mainstream channels often overlook.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
     </div>
@@ -194,7 +194,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <h3>Live Pakistani Radio</h3>
       <p>Listen to FM 106, City FM89, Mera FM, and more, 24/7. Perfect for background listening.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1&list=0" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1&list=0&about=0" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
     </div>
@@ -203,7 +203,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <h3>Live TV Channels</h3>
       <p>Stream Pakistan’s top news channels, morning shows, and dramas live, anytime, anywhere. Stay connected to the latest headlines and entertainment straight from home, free to watch in any browser worldwide.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1&list=0" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1&list=0&about=0" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
     </div>
@@ -212,7 +212,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <h3>Trending Creators</h3>
       <p>Discover what Pakistan’s creators are making right now, vlogs, comedy, music, tech, travel, and lifestyle, curated from the channels people are watching most.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0&about=0" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
     </div>
@@ -221,7 +221,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <h3>All Streams</h3>
       <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1&list=0" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1&list=0&about=0" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
     </div>
@@ -230,7 +230,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <h3>Your Favorites</h3>
       <p>Save the channels you love and get instant access anytime. Your personal shortcut to the voices and shows that matter most.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1&list=0" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
       <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
     </div>

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let muteParam = isMuted ? "&mute=1" : "";
   const showVideoList = params.get("list") !== "0";
   const showChannels = params.get("channels") !== "0";
+  const showDetails = params.get("about") !== "0";
 
   // DOM
   const leftRail = document.getElementById("left-rail");
@@ -25,10 +26,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   const videoListEl = document.getElementById("videoList");
   if (!showVideoList && videoListEl) videoListEl.style.display = "none";
   const videoList = showVideoList ? videoListEl : null;
-  const details   = document.querySelector(".details-list");
+  const detailsContainer = document.querySelector(".details-container");
+  const details   = showDetails ? document.querySelector(".details-list") : null;
   const tabs      = document.querySelectorAll(".tab-btn");
   const searchEl  = document.getElementById("mh-search-input");
   const toggleDetailsBtn = document.getElementById("toggle-details");
+  if (!showDetails) {
+    if (detailsContainer) detailsContainer.style.display = "none";
+    if (toggleDetailsBtn) toggleDetailsBtn.style.display = "none";
+    if (mediaHubSection) mediaHubSection.classList.add("no-details");
+  }
 
   // Radio player elements
   const radioContainer = document.getElementById("player-container");


### PR DESCRIPTION
## Summary
- allow hiding the details/about panel in Media Hub embeds with `about=0`
- hide details panel in homepage embeds by passing `about=0`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8e3226cec8320b1657d584a390f33