### PR TITLE
Hide empty button row in media hub embed

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -15,6 +15,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const leftRail = document.getElementById("left-rail");
   const channelsBtn = document.getElementById("toggle-channels");
   const mediaHubSection = document.querySelector(".media-hub-section");
+  const buttonRow = document.querySelector(".button-row");
   if (!showChannels) {
     if (leftRail) leftRail.style.display = "none";
     if (channelsBtn) channelsBtn.style.display = "none";
@@ -35,6 +36,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (detailsContainer) detailsContainer.style.display = "none";
     if (toggleDetailsBtn) toggleDetailsBtn.style.display = "none";
     if (mediaHubSection) mediaHubSection.classList.add("no-details");
+  }
+
+  if (!showChannels && !showDetails && buttonRow) {
+    buttonRow.style.display = "none";
   }
 
   // Radio player elements


### PR DESCRIPTION
## Summary
- hide the button-row in media-hub embed when both channel and details toggles are off so it no longer wastes vertical space

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8e56a412c8320ab328b3976aa2685