### PR TITLE
feat: enforce 16:9 aspect for radio player

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -901,6 +901,9 @@ button:hover,
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 16 / 9;
 }
 
 .radio-list #player-container {

--- a/js/main.js
+++ b/js/main.js
@@ -143,11 +143,11 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  // Maintain 16:9 aspect ratio for any live-player iframes
+  // Maintain 16:9 aspect ratio for live-player iframes and radio players
   function resizeLivePlayers() {
-    document.querySelectorAll('.live-player iframe').forEach(function (iframe) {
-      var w = iframe.clientWidth;
-      if (w > 0) iframe.style.height = (w * 9 / 16) + 'px';
+    document.querySelectorAll('.live-player iframe, .radio-player').forEach(function (el) {
+      var w = el.clientWidth;
+      if (w > 0) el.style.height = (w * 9 / 16) + 'px';
     });
   }
   window.addEventListener('resize', resizeLivePlayers);


### PR DESCRIPTION
## Summary
- ensure radio player containers keep a 16:9 aspect ratio
- extend resize helper to size radio players along with live iframes
- prevent radio player width overflow by applying border-box sizing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8e77ace6c832096dce173cbf5435e