### PR TITLE
feat: responsive 16:9 radio player layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -901,6 +901,9 @@ button:hover,
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 16 / 9;
 }
 
 .radio-list #player-container {
@@ -923,6 +926,40 @@ button:hover,
 .station-title {
   font-weight: 700;
   margin: 0;
+}
+
+/* Compact layout when the player overflows */
+.radio-player.compact {
+  padding: 8px;
+}
+
+.radio-player.compact .station-info {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 8px;
+  text-align: left;
+}
+
+.radio-player.compact .station-info img {
+  width: 40px;
+  height: 40px;
+  margin: 0 8px 0 0;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.radio-player.compact .station-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.radio-player.compact .live-badge,
+.radio-player.compact .not-live-badge {
+  display: none;
 }
 
 .live-badge {

--- a/js/main.js
+++ b/js/main.js
@@ -143,11 +143,20 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  // Maintain 16:9 aspect ratio for any live-player iframes
+  // Maintain 16:9 aspect ratio for live-player iframes and radio players
   function resizeLivePlayers() {
-    document.querySelectorAll('.live-player iframe').forEach(function (iframe) {
-      var w = iframe.clientWidth;
-      if (w > 0) iframe.style.height = (w * 9 / 16) + 'px';
+    document.querySelectorAll('.live-player iframe').forEach(function (el) {
+      var w = el.clientWidth;
+      if (w > 0) el.style.height = (w * 9 / 16) + 'px';
+    });
+
+    document.querySelectorAll('.radio-player').forEach(function (el) {
+      var w = el.clientWidth;
+      if (w > 0) {
+        el.style.height = (w * 9 / 16) + 'px';
+        var overflow = el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+        el.classList.toggle('compact', overflow);
+      }
     });
   }
   window.addEventListener('resize', resizeLivePlayers);


### PR DESCRIPTION
## Summary
- ensure radio player containers keep a 16:9 aspect ratio
- extend resize helper to size radio players and toggle compact mode when content overflows
- prevent radio player width overflow and shrink station info with truncation in tiny viewports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8e77ace6c832096dce173cbf5435e