### PR TITLE
feat: responsive 16:9 radio player layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -901,6 +901,9 @@ button:hover,
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 16 / 9;
 }
 
 .radio-list #player-container {
@@ -923,6 +926,44 @@ button:hover,
 .station-title {
   font-weight: 700;
   margin: 0;
+}
+
+/* Compact layout when the player overflows */
+.radio-player.compact {
+  padding: 8px;
+}
+
+.radio-player.compact .station-info {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 0;
+  text-align: left;
+}
+
+.radio-player.compact .station-info img {
+  width: 40px;
+  height: 40px;
+  margin: 0 8px 0 0;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.radio-player.compact .controls {
+  margin-top: 0;
+}
+
+.radio-player.compact .station-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.radio-player.compact .live-badge,
+.radio-player.compact .not-live-badge {
+  display: none;
 }
 
 .live-badge {
@@ -966,6 +1007,7 @@ button:hover,
 }
 
 .controls {
+  --btn-size: 40px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -976,8 +1018,9 @@ button:hover,
 .controls button {
   border: none;
   border-radius: 50%;
-  width: 40px;
-  height: 40px;
+  width: var(--btn-size);
+  height: var(--btn-size);
+  font-size: calc(var(--btn-size) * 0.6);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -985,6 +1028,7 @@ button:hover,
   background: var(--primary);
   color: var(--on-primary);
   cursor: pointer;
+  box-sizing: border-box;
 }
 
 .controls button:hover {

--- a/js/main.js
+++ b/js/main.js
@@ -143,11 +143,33 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  // Maintain 16:9 aspect ratio for any live-player iframes
+  // Maintain 16:9 aspect ratio for live-player iframes and radio players
   function resizeLivePlayers() {
-    document.querySelectorAll('.live-player iframe').forEach(function (iframe) {
-      var w = iframe.clientWidth;
-      if (w > 0) iframe.style.height = (w * 9 / 16) + 'px';
+    document.querySelectorAll('.live-player iframe').forEach(function (el) {
+      var w = el.clientWidth;
+      if (w > 0) el.style.height = (w * 9 / 16) + 'px';
+    });
+
+    document.querySelectorAll('.radio-player').forEach(function (el) {
+      var w = el.clientWidth;
+      if (w > 0) {
+        el.style.height = (w * 9 / 16) + 'px';
+        var overflow = el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+        el.classList.toggle('compact', overflow);
+        var stationInfo = el.querySelector('.station-info');
+        var controls = el.querySelector('.controls');
+        if (controls) controls.style.setProperty('--btn-size', '40px');
+        if (overflow && stationInfo && controls) {
+          var availableHeight = el.clientHeight - stationInfo.offsetHeight;
+          var availableWidth = el.clientWidth;
+          var scaleH = availableHeight / controls.scrollHeight;
+          var scaleW = availableWidth / controls.scrollWidth;
+          var scale = Math.min(scaleH, scaleW, 1);
+          if (scale < 1) {
+            controls.style.setProperty('--btn-size', (40 * scale) + 'px');
+          }
+        }
+      }
     });
   }
   window.addEventListener('resize', resizeLivePlayers);


### PR DESCRIPTION
## Summary
- ensure radio player containers keep a 16:9 aspect ratio
- extend resize helper to size radio players, toggle compact mode, and scale controls when space is tight
- prevent radio player width overflow and shrink station info with truncation in tiny viewports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8e77ace6c832096dce173cbf5435e