### PR TITLE
refactor: remove redundant audio wrapper

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -153,12 +153,6 @@
   border-color: var(--primary);
   color: var(--on-primary-container);
 }
-.live-player .audio-wrap {
-  background: var(--surface);
-  border-radius: 14px;
-  box-shadow: var(--shadow-xs);
-  padding: 12px;
-}
 
 /* layout that mirrors your existing pages */
 .page-wrap {
@@ -239,14 +233,14 @@
   display: none;
 }
 
-.player-container iframe,
-.player-container .audio-wrap {
+.live-player iframe,
+.live-player .radio-player {
   width: 100%;
   border: 0;
   border-radius: 14px;
   box-shadow: var(--shadow-xs);
 }
-.player-container .audio-wrap {
+.live-player .radio-player {
   padding: 14px;
   background: var(--surface);
 }

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -23,7 +23,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
   const listEl = showChannels ? leftRail : null; // left menu is the list container
   const playerIF  = document.getElementById("playerFrame");
-  const audioWrap = document.getElementById("audioWrap");
   const videoListEl = document.getElementById("videoList");
   if (!showVideoList && videoListEl) videoListEl.style.display = "none";
   const videoList = showVideoList ? videoListEl : null;
@@ -334,10 +333,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     const videoPlaying = playerIF && playerIF.src && playerIF.src !== "about:blank";
     if (currentAudio || (!videoPlaying && mode === "radio")) {
       if (playerIF) playerIF.style.display = "none";
-      if (audioWrap) audioWrap.style.display = "";
+      if (radioContainer) radioContainer.style.display = "";
     } else {
       if (playerIF) playerIF.style.display = "";
-      if (audioWrap) audioWrap.style.display = "none";
+      if (radioContainer) radioContainer.style.display = "none";
       if (window.resizeLivePlayers) window.resizeLivePlayers();
     }
 
@@ -816,7 +815,7 @@ async function renderLatestVideosRSS(channelId) {
           playerIF.src = `https://www.youtube-nocookie.com/embed/${vid}?autoplay=1&rel=0&enablejsapi=1${muteParam}`;
           if (window.resizeLivePlayers) window.resizeLivePlayers();
         }
-        if (audioWrap) audioWrap.style.display = "none";
+        if (radioContainer) radioContainer.style.display = "none";
         if (details && toggleDetailsBtn && details.innerHTML.trim().length) {
           toggleDetailsBtn.style.display = "";
         }
@@ -862,7 +861,7 @@ async function renderLatestVideosRSS(channelId) {
     if (videoList) videoList.innerHTML = "";
     currentVideoChannelId = null;
     if (playerIF) playerIF.style.display = "";
-    if (audioWrap) audioWrap.style.display = "none";
+    if (radioContainer) radioContainer.style.display = "none";
 
     // stop any radio that might be playing
     if (mainPlayer) {
@@ -957,7 +956,7 @@ async function renderLatestVideosRSS(channelId) {
       playerIF.src = "about:blank";
       playerIF.style.display = "none";
     }
-    if (audioWrap) audioWrap.style.display = "";
+    if (radioContainer) radioContainer.style.display = "";
 
     if (stationLogo) stationLogo.src = logoUrl || defaultLogo;
     if (liveBadge) liveBadge.hidden = true;

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -46,8 +46,7 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
-        <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player" data-stream-container data-radio-container style="margin-bottom:0">
+        <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none; margin-bottom:0">
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -66,7 +65,6 @@
               <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
               <audio id="radio-player" data-radio autoplay></audio>
             </div>
-          </div>
         </div>
       </div>
 

--- a/media-hub.html
+++ b/media-hub.html
@@ -70,8 +70,7 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
-        <div id="audioWrap" class="audio-wrap" style="display:none;">
-          <div id="player-container" class="radio-player" data-stream-container data-radio-container>
+        <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none;">
             <div class="station-info">
               <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
               <h3 id="current-station" class="station-title">Select a station</h3>
@@ -90,7 +89,6 @@
               <button id="share-btn" class="fav-btn material-symbols-outlined" type="button" aria-label="Share">share</button>
               <audio id="radio-player" data-radio autoplay></audio>
             </div>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- simplify media hub player by merging `audioWrap` into `player-container`
- update media-hub script to toggle the radio container directly
- adjust CSS selectors for new structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8f079bbf48320824f4a5cdeba881f