### PR TITLE
Style station header row

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -928,6 +928,35 @@ button:hover,
   margin: 0;
 }
 
+/* Station row: image + title side by side */
+.station-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;       /* space between image and title */
+  padding: 0.5rem;
+}
+
+/* Make station image round, like YouTube avatars */
+.station-header img {
+  width: 48px;       /* adjust size as needed */
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover; /* ensures image doesn’t stretch */
+  flex-shrink: 0;
+  margin: 0;
+}
+
+/* Title text aligns nicely with image */
+.station-header .station-title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #263238; /* your charcoal text color */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Compact layout when the player overflows */
 .radio-player.compact {
   padding: 8px;

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -48,8 +48,10 @@
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none; margin-bottom:0">
             <div class="station-info">
-              <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
-              <h3 id="current-station" class="station-title">Select a station</h3>
+              <div class="station-header">
+                <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
+                <h3 id="current-station" class="station-title">Select a station</h3>
+              </div>
               <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
               <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
             </div>


### PR DESCRIPTION
## Summary
- Display station image and title in a horizontal flex row for media hub embed
- Render station logo as a circular avatar and truncate long titles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f66ed71083209aeec297f48501db