### PR TITLE
Improve media hub embed header styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -915,17 +915,49 @@ button:hover,
 .station-info {
   text-align: center;
 }
-
-.station-info img {
+.station-info > img {
   width: 80px;
   height: 80px;
   object-fit: contain;
   margin-bottom: 8px;
 }
 
+/* Header row: avatar + title side by side */
+.station-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0.5rem 0;
+  min-width: 0;
+}
+
+/* Round avatar like YouTube */
+.station-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: #eee;
+}
+
+/* Title: bold, one line only, truncate with ellipsis */
 .station-title {
-  font-weight: 700;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--text-color, #263238);
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+/* Compact on very small screens */
+@media (max-width: 360px) {
+  .station-avatar { width: 40px; height: 40px; }
+  .station-title  { font-size: 0.95rem; }
 }
 
 /* Compact layout when the player overflows */
@@ -942,11 +974,10 @@ button:hover,
   text-align: left;
 }
 
-.radio-player.compact .station-info img {
+.radio-player.compact .station-avatar {
   width: 40px;
   height: 40px;
   margin: 0 8px 0 0;
-  border-radius: 8px;
   flex-shrink: 0;
 }
 

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -48,8 +48,10 @@
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none; margin-bottom:0">
             <div class="station-info">
-              <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
-              <h3 id="current-station" class="station-title">Select a station</h3>
+              <div class="station-header">
+                <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">
+                <h3 id="current-station" class="station-title">Select a station</h3>
+              </div>
               <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
               <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
             </div>


### PR DESCRIPTION
## Summary
- Wrap station image and title in a `.station-header` container
- Add circular avatar and ellipsis-truncated title styling

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8f6a92ff88320bdbd615f30f4075a