### PR TITLE
feat: align station title with circular avatar in embed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -916,16 +916,51 @@ button:hover,
   text-align: center;
 }
 
-.station-info img {
+/* Station header: flex aligns title with avatar center */
+.station-header {
+  display: flex;
+  align-items: center;   /* vertical alignment */
+  gap: 12px;
+  padding: 0.5rem 0;
+  min-width: 0;          /* enables text truncation */
+}
+
+/* Round avatar, no distortion */
+.station-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: #eee;      /* fallback if no image */
+}
+
+/* Station title: one line, truncate with ellipsis */
+.station-title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;       /* keeps vertical balance */
+  color: var(--text-color, #263238);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;    /* force one line */
+  flex: 1;                /* take available space */
+  display: block;         /* stable box model for ellipsis */
+}
+
+/* Station info image fallback when not using avatar */
+.station-info img:not(.station-avatar) {
   width: 80px;
   height: 80px;
   object-fit: contain;
   margin-bottom: 8px;
 }
 
-.station-title {
-  font-weight: 700;
-  margin: 0;
+/* Compact version for narrow screens */
+@media (max-width: 360px) {
+  .station-avatar { width: 40px; height: 40px; }
+  .station-title  { font-size: 0.95rem; }
 }
 
 /* Compact layout when the player overflows */
@@ -933,32 +968,8 @@ button:hover,
   padding: 8px;
 }
 
-.radio-player.compact .station-info {
-  align-self: flex-start;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  margin-bottom: 0;
-  text-align: left;
-}
-
-.radio-player.compact .station-info img {
-  width: 40px;
-  height: 40px;
-  margin: 0 8px 0 0;
-  border-radius: 8px;
-  flex-shrink: 0;
-}
-
 .radio-player.compact .controls {
   margin-top: 0;
-}
-
-.radio-player.compact .station-title {
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .radio-player.compact .live-badge,

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -48,8 +48,10 @@
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none; margin-bottom:0">
             <div class="station-info">
-              <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
-              <h3 id="current-station" class="station-title">Select a station</h3>
+              <div class="station-header">
+                <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">
+                <span id="current-station" class="station-title">Select a station</span>
+              </div>
               <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
               <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
             </div>


### PR DESCRIPTION
## Summary
- restructure station header with avatar and single-line title
- style station header flexbox with round avatar and ellipsis truncation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8f6b3bfc483208b0e5aa39e4c55d9