### PR TITLE
Wrap radio player controls inside container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -912,7 +912,11 @@ button:hover,
   padding: 16px;
   border-radius: 12px;
   box-shadow: var(--shadow-lg);
-  margin-bottom: 16px;
+  margin-bottom: 0; /* controls are inside now */
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: flex-start;
   align-items: center;
 }
 
@@ -1582,6 +1586,11 @@ footer nav a:hover {
   box-sizing: border-box;
   overflow: hidden;
   min-height: 0; /* allow shrink inside fixed-aspect card */
+}
+
+.radio-player .controls {
+  overflow: visible;
+  padding-bottom: var(--controls-gap);
 }
 
 /* Uniform circular buttons that can shrink */

--- a/js/radio.js
+++ b/js/radio.js
@@ -37,6 +37,13 @@
   }
 
   function init() {
+    doc.querySelectorAll('[data-radio-container]').forEach(wrap => {
+      const player = wrap.querySelector('#player-container, .radio-player');
+      const controls = wrap.querySelector(':scope > .controls');
+      if (player && controls && !player.contains(controls)) {
+        player.appendChild(controls);
+      }
+    });
     doc.querySelectorAll('audio[data-radio], [data-radio] audio').forEach(wireRadio);
   }
   if (document.readyState === 'loading') {

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -46,7 +46,7 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           title="Selected video player"></iframe>
-        <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none; margin-bottom:0">
+        <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none;">
             <div class="station-info">
               <div class="station-header">
                 <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">


### PR DESCRIPTION
## Summary
- Ensure radio player `.controls` are appended inside `#player-container` and move them at runtime if needed
- Convert `.radio-player` to a flex column so card background wraps buttons
- Keep media hub embed overrides and expose controls with `overflow: visible`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a8ffdffbd08320878c0ea6ab892df7