### PR TITLE
Fix radio player layout overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1665,4 +1665,18 @@ footer nav a:hover {
 
 .media-hub-section .radio-player { padding-bottom: calc(var(--card-pad) + 4px); }
 
+/* Ensure the radio card grows to fit its children */
+#player-container.radio-player {
+  height: auto !important;
+  min-height: max-content;     /* force wrap to content height */
+  overflow: visible !important;/* undo group overflow:hidden */
+}
+
+/* Grid rows should size to their content (not stretch/compress) */
+#player-container.radio-player .controls {
+  grid-auto-rows: min-content !important;
+  overflow: visible !important;
+  padding-bottom: var(--controls-gap);
+}
+
 /* --- END PATCH --- */


### PR DESCRIPTION
## Summary
- allow radio player card to grow to fit its children
- adjust radio controls grid to size rows to content and show overflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9027eeef483208ec90713b1462c73