### PR TITLE
Fix blog page front matter for Jekyll processing

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,12 +1,13 @@
-<link rel="manifest" href="/manifest.webmanifest" type="application/manifest+json">
-<meta name="theme-color" content="#ffffff">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<link rel="apple-touch-icon" href="/images/icons/icon-192-maskable.png">
 ---
 layout: default
 title: PakStream Blog - News for Overseas Pakistanis
 description: Insightful blogs covering Pakistani media, culture, and diaspora life abroad.
 ---
+
+<link rel="manifest" href="/manifest.webmanifest" type="application/manifest+json">
+<meta name="theme-color" content="#ffffff">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<link rel="apple-touch-icon" href="/images/icons/icon-192-maskable.png">
 <section class="blog-list">
   <h1>Latest Blog Posts</h1>
 


### PR DESCRIPTION
## Summary
- Place Jekyll front matter at top of `blog.html` so Jekyll recognizes the template.
- Keep manifest and meta tags after the front matter.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a91096f1ac8320b333314ed6ca00f6