### PR TITLE
Reorder feature cards to show stream first

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -393,13 +393,14 @@ section {
 .feature-card {
   background: var(--surface);
   border-radius: 12px;
-  padding: 20px;
   box-shadow: var(--shadow-md);
-  text-align: center;
   flex: 1 1 250px;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .feature-card:hover,
@@ -408,20 +409,15 @@ section {
   box-shadow: var(--shadow-lg);
 }
 
-.feature-card .material-symbols-outlined {
-  font-size: 48px;
-  color: var(--primary);
-  margin-bottom: 10px;
+.feature-card-content {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 .feature-card p {
-  min-height: 3rem;
-}
-
-.feature-card .right-menu {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  flex: 1;
 }
 
 .media-hub-embed {
@@ -429,10 +425,11 @@ section {
   aspect-ratio: 16 / 9;
   height: auto;
   border: none;
-  border-radius: 0.75rem;
+  display: block;
 }
 
 .feature-card .cta-btn {
+  align-self: flex-start;
   display: inline-block;
   margin-top: 0.75rem;
   padding: 0.5rem 1rem;

--- a/index.html
+++ b/index.html
@@ -181,58 +181,64 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <!-- Featured cards -->
   <section class="feature-cards">
     <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">
-      <span class="material-symbols-outlined">article</span>
-      <h3>Free Press</h3>
-      <p>Discover Pakistan’s independent voices, journalists, analysts, and vloggers who share perspectives free from government or corporate influence. Here you’ll find diverse opinions and alternative viewpoints that mainstream channels often overlook.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
-      <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
+      <div class="feature-card-content">
+        <h3>Free Press</h3>
+        <p>Discover Pakistan’s independent voices, journalists, analysts, and vloggers who share perspectives free from government or corporate influence. Here you’ll find diverse opinions and alternative viewpoints that mainstream channels often overlook.</p>
+        <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
+      </div>
     </div>
     <div class="feature-card" data-m="radio" data-c="audio35">
-      <span class="material-symbols-outlined">radio</span>
-      <h3>Live Pakistani Radio</h3>
-      <p>Listen to FM 106, City FM89, Mera FM, and more, 24/7. Perfect for background listening.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1&list=0&about=0" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
-      <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
+      <div class="feature-card-content">
+        <h3>Live Pakistani Radio</h3>
+        <p>Listen to FM 106, City FM89, Mera FM, and more, 24/7. Perfect for background listening.</p>
+        <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
+      </div>
     </div>
     <div class="feature-card" data-m="tv" data-c="24news">
-      <span class="material-symbols-outlined">live_tv</span>
-      <h3>Live TV Channels</h3>
-      <p>Stream Pakistan’s top news channels, morning shows, and dramas live, anytime, anywhere. Stay connected to the latest headlines and entertainment straight from home, free to watch in any browser worldwide.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1&list=0&about=0" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
-      <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
+      <div class="feature-card-content">
+        <h3>Live TV Channels</h3>
+        <p>Stream Pakistan’s top news channels, morning shows, and dramas live, anytime, anywhere. Stay connected to the latest headlines and entertainment straight from home, free to watch in any browser worldwide.</p>
+        <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
+      </div>
     </div>
     <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
-      <span class="material-symbols-outlined">person</span>
-      <h3>Trending Creators</h3>
-      <p>Discover what Pakistan’s creators are making right now, vlogs, comedy, music, tech, travel, and lifestyle, curated from the channels people are watching most.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0&about=0" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
-      <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
+      <div class="feature-card-content">
+        <h3>Trending Creators</h3>
+        <p>Discover what Pakistan’s creators are making right now, vlogs, comedy, music, tech, travel, and lifestyle, curated from the channels people are watching most.</p>
+        <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
+      </div>
     </div>
     <div class="feature-card" data-m="all" data-c="geo">
-      <span class="material-symbols-outlined">apps</span>
-      <h3>All Streams</h3>
-      <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1&list=0&about=0" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
-      <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
+      <div class="feature-card-content">
+        <h3>All Streams</h3>
+        <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
+        <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
+      </div>
     </div>
     <div class="feature-card" data-m="favorites" data-c="wajahatsaeedkhan">
-      <span class="material-symbols-outlined">favorite</span>
-      <h3>Your Favorites</h3>
-      <p>Save the channels you love and get instant access anytime. Your personal shortcut to the voices and shows that matter most.</p>
       <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
         <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </section>
-      <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
+      <div class="feature-card-content">
+        <h3>Your Favorites</h3>
+        <p>Save the channels you love and get instant access anytime. Your personal shortcut to the voices and shows that matter most.</p>
+        <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Reordered feature-card markup so embedded streams appear before titles and descriptions
- Updated feature-card styling to flex layout with iframe-first design and new content container

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a984135ee88320be7cef8ca6cd1a48