### PR TITLE
Reorder feature cards to show stream first

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -380,73 +380,97 @@ section {
   }
 }
 
-/* Featured card layout */
+/* Feature card layout */
 .feature-cards {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 20px;
+  max-width: 1200px;
   margin: 40px auto;
-  max-width: 960px;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
 }
 
 .feature-card {
-  background: var(--surface);
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: var(--shadow-md);
-  text-align: center;
-  flex: 1 1 250px;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  position: relative;
-}
-
-.feature-card:hover,
-.feature-card:focus-within {
-  transform: translateY(-4px) scale(1.02);
+  background: linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02));
+  border: 1px solid var(--outline);
+  border-radius: 20px;
   box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
-.feature-card .material-symbols-outlined {
-  font-size: 48px;
-  color: var(--primary);
-  margin-bottom: 10px;
+.feature-card iframe {
+  width: 100%;
+  aspect-ratio: 16/9;
+  border: 0;
+  border-bottom: 1px solid var(--outline);
+}
+
+.feature-card-content {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.feature-card h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  color: var(--on-surface);
 }
 
 .feature-card p {
-  min-height: 3rem;
-}
-
-.feature-card .right-menu {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-}
-
-.media-hub-embed {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  height: auto;
-  border: none;
-  border-radius: 0.75rem;
+  margin: 0 0 12px;
+  color: var(--on-surface-variant);
+  font-size: 14px;
+  flex: 1;
 }
 
 .feature-card .cta-btn {
-  display: inline-block;
-  margin-top: 0.75rem;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  background: var(--primary);
-  color: var(--on-primary);
-  border-radius: 0.5rem;
+  align-self: flex-start;
+  background: var(--secondary);
+  color: var(--on-secondary);
+  padding: 8px 14px;
+  border-radius: 10px;
+  font-weight: 600;
   text-decoration: none;
+  font-size: 0.875rem;
   transition: background 0.2s ease;
 }
 
 .feature-card .cta-btn:hover {
-  background: color-mix(in srgb, var(--primary) 85%, black);
+  background: color-mix(in srgb, var(--secondary) 85%, black);
+}
+
+@media (max-width: 768px) {
+  .feature-cards {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 0 16px;
+    margin: 28px auto;
+  }
+
+  .feature-card {
+    border-radius: 16px;
+  }
+
+  .feature-card-content {
+    padding: 12px;
+  }
+
+  .feature-card h3 {
+    font-size: 16px;
+  }
+
+  .feature-card p {
+    font-size: 13px;
+  }
+
+  .feature-card .cta-btn {
+    width: 100%;
+    text-align: center;
+  }
 }
 
 /* Blog list styling */

--- a/index.html
+++ b/index.html
@@ -181,58 +181,52 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <!-- Featured cards -->
   <section class="feature-cards">
     <div class="feature-card" data-m="freepress" data-c="wajahatsaeedkhan">
-      <span class="material-symbols-outlined">article</span>
-      <h3>Free Press</h3>
-      <p>Discover Pakistan’s independent voices, journalists, analysts, and vloggers who share perspectives free from government or corporate influence. Here you’ll find diverse opinions and alternative viewpoints that mainstream channels often overlook.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
+      <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div class="feature-card-content">
+        <h3>Free Press</h3>
+        <p>Discover Pakistan’s independent voices, journalists, analysts, and vloggers who share perspectives free from government or corporate influence. Here you’ll find diverse opinions and alternative viewpoints that mainstream channels often overlook.</p>
+        <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
+      </div>
     </div>
     <div class="feature-card" data-m="radio" data-c="audio35">
-      <span class="material-symbols-outlined">radio</span>
-      <h3>Live Pakistani Radio</h3>
-      <p>Listen to FM 106, City FM89, Mera FM, and more, 24/7. Perfect for background listening.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1&list=0&about=0" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
+      <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1&list=0&about=0" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div class="feature-card-content">
+        <h3>Live Pakistani Radio</h3>
+        <p>Listen to FM 106, City FM89, Mera FM, and more, 24/7. Perfect for background listening.</p>
+        <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
+      </div>
     </div>
     <div class="feature-card" data-m="tv" data-c="24news">
-      <span class="material-symbols-outlined">live_tv</span>
-      <h3>Live TV Channels</h3>
-      <p>Stream Pakistan’s top news channels, morning shows, and dramas live, anytime, anywhere. Stay connected to the latest headlines and entertainment straight from home, free to watch in any browser worldwide.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1&list=0&about=0" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
+      <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1&list=0&about=0" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div class="feature-card-content">
+        <h3>Live TV Channels</h3>
+        <p>Stream Pakistan’s top news channels, morning shows, and dramas live, anytime, anywhere. Stay connected to the latest headlines and entertainment straight from home, free to watch in any browser worldwide.</p>
+        <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
+      </div>
     </div>
     <div class="feature-card" data-m="creator" data-c="zeeshanusmani">
-      <span class="material-symbols-outlined">person</span>
-      <h3>Trending Creators</h3>
-      <p>Discover what Pakistan’s creators are making right now, vlogs, comedy, music, tech, travel, and lifestyle, curated from the channels people are watching most.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0&about=0" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
+      <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0&about=0" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div class="feature-card-content">
+        <h3>Trending Creators</h3>
+        <p>Discover what Pakistan’s creators are making right now, vlogs, comedy, music, tech, travel, and lifestyle, curated from the channels people are watching most.</p>
+        <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
+      </div>
     </div>
     <div class="feature-card" data-m="all" data-c="geo">
-      <span class="material-symbols-outlined">apps</span>
-      <h3>All Streams</h3>
-      <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1&list=0&about=0" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
+      <iframe class="media-hub-embed" src="/media-hub-embed.html?m=all&c=geo&muted=1&list=0&about=0" title="PakStream Media Hub" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div class="feature-card-content">
+        <h3>All Streams</h3>
+        <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
+        <a href="/media-hub.html?m=all&c=geo" class="cta-btn">Browse</a>
+      </div>
     </div>
     <div class="feature-card" data-m="favorites" data-c="wajahatsaeedkhan">
-      <span class="material-symbols-outlined">favorite</span>
-      <h3>Your Favorites</h3>
-      <p>Save the channels you love and get instant access anytime. Your personal shortcut to the voices and shows that matter most.</p>
-      <section class="youtube-section media-hub-section" style="padding: 0; margin: 0;">
-        <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </section>
-      <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
+      <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      <div class="feature-card-content">
+        <h3>Your Favorites</h3>
+        <p>Save the channels you love and get instant access anytime. Your personal shortcut to the voices and shows that matter most.</p>
+        <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Embed streams directly in feature cards and drop extra section wrapper
- Restyle feature cards with grid layout, consistent padding, borders, and responsive tweaks to match index1 design

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a984135ee88320be7cef8ca6cd1a48