### PR TITLE
Align homepage feature descriptions with index1 variant

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <iframe class="media-hub-embed" src="/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Free Press" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       <div class="feature-card-content">
         <h3>Free Press</h3>
-        <p>Discover Pakistan’s independent voices, journalists, analysts, and vloggers who share perspectives free from government or corporate influence. Here you’ll find diverse opinions and alternative viewpoints that mainstream channels often overlook.</p>
+        <p>Diverse perspectives from Pakistani creators.</p>
         <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan" class="cta-btn">Watch Now</a>
       </div>
     </div>
@@ -192,7 +192,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <iframe class="media-hub-embed" src="/media-hub-embed.html?m=radio&c=audio35&muted=1&list=0&about=0" title="PakStream Radio" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       <div class="feature-card-content">
         <h3>Live Pakistani Radio</h3>
-        <p>Listen to FM 106, City FM89, Mera FM, and more, 24/7. Perfect for background listening.</p>
+        <p>Stream Mera FM, City FM89, Mast FM & more.</p>
         <a href="/media-hub.html?m=radio&c=audio35" class="cta-btn">Listen</a>
       </div>
     </div>
@@ -200,7 +200,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <iframe class="media-hub-embed" src="/media-hub-embed.html?m=tv&c=geo&muted=1&list=0&about=0" title="PakStream Live TV" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       <div class="feature-card-content">
         <h3>Live TV Channels</h3>
-        <p>Stream Pakistan’s top news channels, morning shows, and dramas live, anytime, anywhere. Stay connected to the latest headlines and entertainment straight from home, free to watch in any browser worldwide.</p>
+        <p>Watch Pakistani news, dramas, and morning shows.</p>
         <a href="/media-hub.html?m=tv&c=24news" class="cta-btn">Watch Now</a>
       </div>
     </div>
@@ -208,7 +208,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <iframe class="media-hub-embed" src="/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0&about=0" title="PakStream Creators" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       <div class="feature-card-content">
         <h3>Trending Creators</h3>
-        <p>Discover what Pakistan’s creators are making right now, vlogs, comedy, music, tech, travel, and lifestyle, curated from the channels people are watching most.</p>
+        <p>Drama serials and entertainment shows.</p>
         <a href="/media-hub.html?m=creator&c=zeeshanusmani" class="cta-btn">Watch Now</a>
       </div>
     </div>
@@ -224,7 +224,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
       <iframe class="media-hub-embed" src="/media-hub-embed.html?m=favorites&c=wajahatsaeedkhan&muted=1&list=0&about=0" title="PakStream Favorites" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       <div class="feature-card-content">
         <h3>Your Favorites</h3>
-        <p>Save the channels you love and get instant access anytime. Your personal shortcut to the voices and shows that matter most.</p>
+        <p>Pin your go‑to channels for one‑tap playback.</p>
         <a href="/media-hub.html?m=favorites&c=wajahatsaeedkhan" class="cta-btn">View</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Sync feature card descriptions on `index.html` with `index1.html`.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a98a5d17548320bf3600d6769f8c58