### PR TITLE
feat: revamp home search design

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1743,3 +1743,146 @@ footer.site-footer .copy {
     padding: 16px;
   }
 }
+
+/* Landing hero with search */
+.landing-hero {
+  padding: 56px 20px 36px;
+  text-align: center;
+  border-bottom: 1px solid var(--outline);
+  background: radial-gradient(circle at top, var(--surface), var(--background) 80%);
+}
+.landing-hero h1 {
+  font-size: 48px;
+  line-height: 1.15;
+  margin: 0;
+}
+.landing-hero p {
+  margin: 8px auto 16px;
+  color: var(--on-surface-variant);
+  max-width: 760px;
+}
+.search-xl {
+  margin: 16px auto 0;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  border: 1px solid var(--outline);
+  border-radius: 18px;
+  padding: 10px 12px;
+  box-shadow: var(--shadow-lg);
+  max-width: 720px;
+  position: relative;
+  transition: box-shadow .2s ease, border-color .2s ease;
+}
+.search-xl:focus-within {
+  border-color: var(--secondary);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--secondary) 35%, transparent), var(--shadow-lg);
+}
+.search-xl input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--on-surface);
+  font-size: 17px;
+  padding: 12px;
+}
+.search-xl input::placeholder {
+  color: var(--on-surface-variant);
+}
+.search-xl:focus-within input::placeholder {
+  color: color-mix(in srgb, var(--on-surface) 85%, white);
+}
+.search-xl .search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--surface);
+  border: 1px solid var(--outline);
+  border-radius: 12px;
+  margin-top: 4px;
+  box-shadow: var(--shadow-lg);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+.search-xl .search-results a {
+  display: block;
+  padding: 8px 12px;
+  color: var(--on-surface);
+  text-decoration: none;
+}
+.search-xl .search-results a:hover {
+  background: color-mix(in srgb, var(--on-surface) 12%, transparent);
+}
+.btn {
+  appearance: none;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.btn-primary {
+  background: var(--secondary);
+  color: var(--on-secondary);
+}
+.btn-ghost {
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  color: var(--on-surface);
+  border: 1px solid var(--outline);
+}
+.suggest {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 12px;
+}
+.chip {
+  border: 1px solid var(--outline);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .landing-hero {
+    padding: 36px 16px 24px;
+  }
+  .landing-hero h1 {
+    font-size: 32px;
+    line-height: 1.2;
+  }
+  .landing-hero p {
+    font-size: 14px;
+    max-width: 100%;
+  }
+  .search-xl {
+    max-width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    border-radius: 14px;
+    padding: 10px;
+  }
+  .search-xl input {
+    padding: 12px 10px;
+    font-size: 16px;
+  }
+  .search-xl .btn {
+    width: 100%;
+  }
+  .suggest {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding: 0 2px;
+    gap: 8px;
+  }
+  .suggest .chip {
+    white-space: nowrap;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -87,27 +87,23 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
        data-ad-type="leaderboard"
        data-placeholder="Advertisement — 728×90 / 320×50"></div>
 
-  <!-- Hero section with image and tagline -->
-  <section class="hero-banner">
-    <picture>
-      <source
-        type="image/webp"
-        srcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
-        sizes="(max-width: 420px) 80vw, 380px" />
-      <img
-        src="/images/pakistan-abstract-380.webp"
-        width="380"
-        height="380"
-        alt="Abstract Pakistan crescent and star"
-        decoding="async"
-        fetchpriority="high"
-        style="aspect-ratio: 1 / 1; object-fit: cover;" />
-    </picture>
-    <div class="hero-text">
-      <h2>Your Gateway to Pakistani Media</h2>
-      <p>Stay Connected to Pakistan News, Radio &amp; More</p>
-    </div>
-  </section>
+   <!-- Hero section with prominent search -->
+   <section class="landing-hero">
+     <h1>Stream Pakistani TV, Radio &amp; Independent Voices</h1>
+     <p>Search by channel, show, or creator — fast, free, and worldwide. No sign‑up required.</p>
+     <form id="search-form" class="search-xl" role="search" autocomplete="off">
+       <input id="search-input" type="search" placeholder="Try: Geo News, ARY News, Mera FM, Coke Studio" aria-label="Search" autocomplete="off">
+       <a class="btn btn-ghost" href="/media-hub.html">Browse All</a>
+       <button class="btn btn-primary" type="submit">Search</button>
+       <div id="search-results" class="search-results"></div>
+     </form>
+     <div class="suggest">
+       <span class="chip">🔥 Geo News – Live</span>
+       <span class="chip">📻 Mera FM 107.4</span>
+       <span class="chip">🎵 Coke Studio</span>
+       <span class="chip">📰 Wajahat Saeed Khan</span>
+     </div>
+   </section>
 
   <!-- Inline rectangle -->
   <div class="ad-slot"
@@ -265,14 +261,6 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
     <div class="ad-container">
       <!-- Google AdSense: Insert your ad code here -->
     </div>
-    <section class="mh-wrap" data-mh>
-      <div class="mh-row mh-search">
-        <label for="mh-q" class="visually-hidden">Search channels</label>
-        <input id="mh-q" data-mh-search-input type="search" placeholder="Search channels…">
-      </div>
-
-      <div class="mh-grid" data-mh-list></div>
-    </section>
 
     <!-- Footer -->
     <footer class="site-footer">

--- a/js/main.js
+++ b/js/main.js
@@ -37,21 +37,28 @@ document.addEventListener('DOMContentLoaded', function () {
     topBar.insertBefore(backBtn, btn.nextSibling);
   }
 
-  // Add top-bar search on all pages, including the media hub.
-  if (topBar) {
+  // Search form setup: use existing form if present, otherwise inject into top bar.
+  var searchForm = document.getElementById('search-form');
+  var input, results;
+
+  if (!searchForm && topBar) {
     var themeBtn = themeToggle;
     var logoTitle = document.querySelector('.logo-title');
-    var searchForm = document.createElement('form');
+    searchForm = document.createElement('form');
     searchForm.id = 'search-form';
     searchForm.className = 'search-form';
     searchForm.setAttribute('autocomplete', 'off');
-    var input = document.createElement('input');
+    input = document.createElement('input');
     input.type = 'search';
     input.id = 'search-input';
     input.placeholder = 'Search...';
     input.setAttribute('aria-label', 'Search');
     input.setAttribute('autocomplete', 'off');
     searchForm.appendChild(input);
+    results = document.createElement('div');
+    results.id = 'search-results';
+    results.className = 'search-results';
+    searchForm.appendChild(results);
 
     input.addEventListener('focus', function () {
       searchForm.classList.add('active');
@@ -63,11 +70,17 @@ document.addEventListener('DOMContentLoaded', function () {
       if (logoTitle) logoTitle.removeAttribute('hidden');
     });
 
-    var results = document.createElement('div');
-    results.id = 'search-results';
-    results.className = 'search-results';
-    searchForm.appendChild(results);
+    if (themeBtn) {
+      topBar.insertBefore(searchForm, themeBtn);
+    } else {
+      topBar.appendChild(searchForm);
+    }
+  } else if (searchForm) {
+    input = searchForm.querySelector('#search-input') || searchForm.querySelector('input[type="search"]');
+    results = searchForm.querySelector('#search-results') || searchForm.querySelector('.search-results');
+  }
 
+  if (searchForm && input && results) {
     var searchData = [];
     var loaded = false;
     function loadData() {
@@ -124,12 +137,6 @@ document.addEventListener('DOMContentLoaded', function () {
         results.innerHTML = '';
       }
     });
-
-    if (themeBtn) {
-      topBar.insertBefore(searchForm, themeBtn);
-    } else {
-      topBar.appendChild(searchForm);
-    }
   }
 
   if (themeToggle) {


### PR DESCRIPTION
## Summary
- adopt landing hero with prominent search and suggestions
- restyle search components to match new design
- allow existing search form to be used instead of injecting into top bar

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a98c917cf08320898a927eb6f04ffe