### PR TITLE
Use Inter font on homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,7 +76,7 @@
   <link rel="stylesheet" href="/css/toast.css">
   <link rel="stylesheet" href="/assets/css/mh-lite.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap">
   
 </head>
 <body>

--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 /* Refactored style.css with improved readability & polished UI/UX */
-/* Roboto font loaded asynchronously via HTML link tags */
+/* Inter font loaded asynchronously via HTML link tags */
 
 * {
   transition: background-color 0.3s, color 0.3s, box-shadow 0.3s, transform 0.2s;
@@ -37,7 +37,7 @@ a:visited {
 
 
 body {
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
   background: var(--background);
   color: var(--on-surface);
   padding: 0;

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <link rel="stylesheet" href="/assets/css/carousel.css">
   <link rel="stylesheet" href="/assets/css/mh-lite.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap">
   
 </head>
 <body>


### PR DESCRIPTION
## Summary
- swap Roboto for Inter on the homepage for a cleaner look
- update default layout and stylesheet to load Inter fonts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9944af6588320b0c2f3ccc8ba5cfd