### PR TITLE
Hide channel toggle until channels available

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -20,6 +20,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (leftRail) leftRail.style.display = "none";
     if (channelsBtn) channelsBtn.style.display = "none";
     if (mediaHubSection) mediaHubSection.classList.add("no-channels");
+  } else {
+    if (channelsBtn) channelsBtn.style.display = "";
   }
   const listEl = showChannels ? leftRail : null; // left menu is the list container
   const playerIF  = document.getElementById("playerFrame");

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -31,7 +31,7 @@
 
     <div class="video-section">
       <div class="button-row">
-        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list" style="display:none;">
           <span class="label">Channels</span>
         </button>
         <div class="spacer"></div>

--- a/media-hub.html
+++ b/media-hub.html
@@ -55,7 +55,7 @@
     <!-- CENTER -->
     <div class="video-section">
       <div class="button-row">
-        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list" style="display:none;">
           <span class="label">Channels</span>
         </button>
         <div class="spacer"></div>


### PR DESCRIPTION
## Summary
- Keep channel toggle hidden by default in media hub pages
- Reveal channel toggle only when channels list is enabled

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a999e1ba4483208fe50ec1ecd56589