### PR TITLE
Inline CSS for home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,15 +68,2388 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
 
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/css/ads.css">
-  <link rel="stylesheet" href="/assets/css/carousel.css">
-  <link rel="stylesheet" href="/assets/css/mh-lite.css">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap">
+  <style>
+/* ===== Elegant Emerald Theme ===== */
+
+/* -------- Light Theme -------- */
+:root {
+  --primary: #0e221a;
+  --on-primary: #eaf5ef;
+  --primary-container: rgba(255,255,255,0.06);
+  --on-primary-container: #eaf5ef;
+
+  --secondary: #19c37d;
+  --on-secondary: #03130c;
+
+  --background: #0b1a14;
+  --on-background: #eaf5ef;
+
+  --surface: #0e221a;
+  --on-surface: #eaf5ef;
+
+  --error: #B3261E;
+  --on-error: #FFFFFF;
+  --error-container: #8C1D18;
+  --on-error-container: #FFDAD6;
+
+  --outline: rgba(255,255,255,0.06);
+  --surface-variant: #0e221a;
+  --on-surface-variant: #a8c7b6;
+
+  --accent-link: #19c37d;
+  --accent-link-visited: #0f6b45;
+  --accent-live: #19c37d;
+  --accent-success: #19c37d;
+  --accent-info: #a8c7b6;
+  --favorite-row: var(--primary);
+  --active-row: color-mix(in srgb, var(--primary) 10%, transparent);
+  --hover-primary: color-mix(in srgb, var(--primary) 85%, var(--on-primary));
+  --hover-link: color-mix(in srgb, var(--accent-link) 85%, var(--on-surface));
+  --scrollbar-track: var(--surface-variant);
+  --scrollbar-thumb: var(--outline);
+  --shadow-xs: 0 1px 3px rgba(0,0,0,0.5);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.4);
+  --shadow-md: 0 4px 10px rgba(0,0,0,0.45);
+  --shadow-lg: 0 10px 20px rgba(0,0,0,0.55);
+  --shadow-xl: 0 4px 6px rgba(0,0,0,0.7);
+  --shadow-side-right: 2px 0 5px rgba(0,0,0,0.7);
+  --shadow-side-left: -2px 0 5px rgba(0,0,0,0.7);
+  --overlay-bg: rgba(0,0,0,0.6);
+  --overlay-strong: rgba(0,0,0,0.8);
+  --shadow-hover: 0 4px 12px rgba(0,0,0,0.8);
+  --shadow-xxl: 0 8px 20px rgba(0,0,0,0.4);
+}
+
+/* -------- Dark Theme -------- */
+[data-theme="dark"] {
+  --primary: #0e221a;
+  --on-primary: #eaf5ef;
+  --primary-container: rgba(255,255,255,0.06);
+  --on-primary-container: #eaf5ef;
+
+  --secondary: #19c37d;
+  --on-secondary: #03130c;
+
+  --background: #0b1a14;
+  --on-background: #eaf5ef;
+
+  --surface: #0e221a;
+  --on-surface: #eaf5ef;
+
+  --error: #B3261E;
+  --on-error: #FFFFFF;
+  --error-container: #8C1D18;
+  --on-error-container: #FFDAD6;
+
+  --outline: rgba(255,255,255,0.06);
+  --surface-variant: #0e221a;
+  --on-surface-variant: #a8c7b6;
+
+  --accent-link: #19c37d;
+  --accent-link-visited: #0f6b45;
+  --accent-live: #19c37d;
+  --accent-success: #19c37d;
+  --accent-info: #a8c7b6;
+  --favorite-row: var(--primary);
+  --active-row: color-mix(in srgb, var(--primary) 30%, transparent);
+  --hover-primary: color-mix(in srgb, var(--primary) 80%, var(--on-primary));
+  --hover-link: color-mix(in srgb, var(--accent-link) 70%, var(--on-surface));
+  --scrollbar-track: var(--surface);
+  --scrollbar-thumb: var(--outline);
+  --shadow-xs: 0 1px 3px rgba(0,0,0,0.5);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.4);
+  --shadow-md: 0 4px 10px rgba(0,0,0,0.45);
+  --shadow-lg: 0 10px 20px rgba(0,0,0,0.55);
+  --shadow-xl: 0 4px 6px rgba(0,0,0,0.7);
+  --shadow-side-right: 2px 0 5px rgba(0,0,0,0.7);
+  --shadow-side-left: -2px 0 5px rgba(0,0,0,0.7);
+  --overlay-bg: rgba(0,0,0,0.6);
+  --overlay-strong: rgba(0,0,0,0.8);
+  --shadow-hover: 0 4px 12px rgba(0,0,0,0.8);
+  --shadow-xxl: 0 8px 20px rgba(0,0,0,0.4);
+}
+
+/* Accessible, high-contrast focus ring */
+:where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 3px solid var(--accent-link);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-link) 25%, transparent);
+}
+/* Refactored style.css with improved readability & polished UI/UX */
+/* Inter font loaded asynchronously via HTML link tags */
+
+* {
+  transition: background-color 0.3s, color 0.3s, box-shadow 0.3s, transform 0.2s;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+[hidden] {
+  display: none !important;
+}
+
+a {
+  color: var(--accent-link);
+}
+a:visited {
+  color: var(--accent-link-visited);
+}
+
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border-radius: 4px;
+  border: 2px solid var(--scrollbar-track);
+}
+
+
+body {
+  font-family: 'Inter', system-ui, sans-serif;
+  background: var(--background);
+  color: var(--on-surface);
+  padding: 0;
+  margin: 0;
+  transition: background 0.3s, color 0.3s;
+}
+
+body.no-scroll {
+  overflow: hidden;
+}
+
+/* Top app bar */
+.top-bar {
+  background: linear-gradient(180deg, rgba(11, 26, 20, 0.9), rgba(11, 26, 20, 0.55) 60%, transparent);
+  color: var(--on-primary);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  height: 56px;
+  border-bottom: 1px solid var(--outline);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 1002;
+}
+
+.logo-title {
+  font-size: 1.125rem;
+  margin: 0;
+  color: var(--on-primary);
+}
+
+.nav-toggle {
+  background: none;
+  border: 0;
+  color: var(--on-surface-variant);
+  font-size: 1.5rem;
+  margin-right: 16px;
+  cursor: pointer;
+}
+
+.brand {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.logo {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: conic-gradient(from 140deg, #23e08c, #0f6b45, #0b1a14);
+  box-shadow: inset 0 0 0 2px #0b1a14, 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.back-button {
+  color: var(--on-primary);
+  font-size: 1.25rem;
+  margin-right: 16px;
+  text-decoration: none;
+}
+
+.top-bar nav {
+  flex-grow: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  transition: transform 0.4s ease-in-out;
+}
+
+.top-bar nav a {
+  color: var(--on-surface-variant);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 12px 14px;
+  border-radius: 10px;
+}
+
+.top-bar nav a:hover,
+.post-share a:hover,
+footer nav a:hover {
+  color: var(--accent-link);
+  text-decoration: underline;
+}
+
+.top-bar nav a:hover,
+.top-bar nav a:focus {
+  color: var(--on-primary);
+  text-decoration: underline;
+}
+
+  .top-bar nav a.active,
+  .top-bar nav a[aria-current="page"] {
+    background: color-mix(in oklab, var(--primary) 12%, transparent);
+  }
+
+
+.search-form {
+  margin-left: 16px;
+  position: relative;
+  flex: 1;
+  max-width: 300px;
+  min-width: 0;
+}
+
+.search-form input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--primary-container);
+}
+
+.search-form.active {
+  max-width: none;
+}
+
+@media (max-width: 600px) {
+  .search-form {
+    margin-left: 8px;
+    max-width: none;
+  }
+  .logo-title {
+    display: none;
+  }
+}
+
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--surface);
+  color: var(--on-surface);
+  border: 1px solid var(--primary-container);
+  border-radius: 4px;
+  box-shadow: var(--shadow-md);
+  width: 100%;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1003;
+}
+
+.search-results a {
+  display: block;
+  padding: 6px 8px;
+  text-decoration: none;
+  color: var(--on-surface);
+}
+
+.search-results a:hover,
+.search-results a:focus {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+}
+
+/* Keep existing styles untouched below here */
+/* The rest of the existing style.css remains the same... */
+
+
+/* Generic sections */
+section {
+  background: var(--surface);
+  margin: 20px auto;
+  padding: 16px;
+  border-radius: 4px;
+  box-shadow: var(--shadow-sm);
+  max-width: 960px;
+}
+
+  .hero {
+    text-align: center;
+    padding: 40px 20px;
+    background: var(--primary);
+    color: var(--on-primary);
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
+    margin: 20px auto;
+  }
+
+.hero img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 16px;
+}
+
+/* Hero banner with image overlay */
+.hero-banner {
+  position: relative;
+  text-align: center;
+  margin: 20px auto;
+  max-width: 960px;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-banner img {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+}
+
+.hero-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--overlay-strong);
+  color: var(--on-primary);
+  padding: 24px;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* Improve contrast for tagline in dark mode */
+[data-theme="dark"] .hero-text {
+  color: var(--on-primary-container);
+}
+
+.station-scroller-wrap {
+  margin-block: 1.5rem;
+  max-width: 960px;
+  margin-inline: auto;
+}
+
+.scroller-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .5rem;
+}
+
+.scroller-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--on-surface);
+}
+
+.scroller-toggle {
+  padding: .4rem .75rem;
+  border-radius: .5rem;
+  background: var(--surface-variant);
+  color: var(--on-surface-variant);
+  border: 1px solid var(--outline);
+  cursor: pointer;
+}
+
+.station-scroller {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  overflow: hidden;
+  position: relative;
+  user-select: none;
+  touch-action: pan-y;
+}
+
+.station-scroller [role="listitem"] {
+  flex: 0 0 auto;
+}
+
+.station-scroller::before,
+.station-scroller::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 40px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.station-scroller::before {
+  left: 0;
+  background: linear-gradient(to right, var(--surface), transparent);
+}
+
+.station-scroller::after {
+  right: 0;
+  background: linear-gradient(to left, var(--surface), transparent);
+}
+
+.station-scroller .scroller-track {
+  display: flex;
+  width: max-content;
+  will-change: transform;
+}
+
+.station-scroller .scroller-track a {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  position: relative;
+}
+
+.station-scroller .channel-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+  margin-right: 16px;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.station-scroller .scroller-track a:hover .channel-thumb {
+  transform: scale(1.15);
+  box-shadow: var(--shadow-hover);
+  z-index: 2;
+}
+
+.station-scroller .scroll-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: var(--surface-variant);
+  color: var(--on-surface-variant);
+  z-index: 2;
+  opacity: 0.6;
+  transition: opacity 0.3s;
+}
+
+.station-scroller .scroll-btn:hover {
+  opacity: 1;
+}
+
+.station-scroller .scroll-btn.prev { left: 8px; }
+.station-scroller .scroll-btn.next { right: 8px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .station-scroller .scroller-track {
+    transition: none;
+  }
+}
+
+/* Feature card layout */
+.feature-cards {
+  max-width: 1200px;
+  margin: 40px auto;
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+
+.feature-card {
+  background: linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02));
+  border: 1px solid var(--outline);
+  border-radius: 20px;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.feature-card iframe {
+  width: 100%;
+  aspect-ratio: 16/9;
+  border: 0;
+  border-bottom: 1px solid var(--outline);
+}
+
+.feature-card-content {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.feature-card h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  color: var(--on-surface);
+}
+
+.feature-card p {
+  margin: 0 0 12px;
+  color: var(--on-surface-variant);
+  font-size: 14px;
+  flex: 1;
+}
+
+.feature-card .cta-btn {
+  align-self: flex-start;
+  background: var(--secondary);
+  color: var(--on-secondary);
+  padding: 8px 14px;
+  border-radius: 10px;
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: background 0.2s ease;
+}
+
+.feature-card .cta-btn:hover {
+  background: color-mix(in srgb, var(--secondary) 85%, black);
+}
+
+@media (max-width: 768px) {
+  .feature-cards {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 0 16px;
+    margin: 28px auto;
+  }
+
+  .feature-card {
+    border-radius: 16px;
+  }
+
+  .feature-card-content {
+    padding: 12px;
+  }
+
+  .feature-card h3 {
+    font-size: 16px;
+  }
+
+  .feature-card p {
+    font-size: 13px;
+  }
+
+  .feature-card .cta-btn {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+/* Blog list styling */
+.blog-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.blog-post-item {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--surface-variant);
+}
+
+.blog-post-item:last-child {
+  border-bottom: none;
+}
+
+.blog-post-item a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.blog-post-item a:hover {
+  text-decoration: underline;
+  color: var(--hover-link);
+}
+
+.blog-post-item .post-date {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.95rem;
+  color: var(--on-surface-variant);
+}
+
+/* Channel navigation layout */
+.youtube-section {
+  display: flex;
+}
+
+/* maintain horizontal spacing between flex items
+.youtube-section > * + * {
+  margin-left: 16px;
+} */
+
+/* remove gap when the channel list is collapsed */
+.youtube-section .channel-list.collapsed + .video-section {
+  margin-left: 0;
+  padding-left:5px;
+  padding-right:5px;
+}
+
+.youtube-section .channel-list,
+.youtube-section .details-container,
+.media-hub-section .channel-list,
+.media-hub-section .details-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 220px;
+}
+.youtube-section .details-container,
+.media-hub-section .details-container {
+  width: 300px;
+}
+.youtube-section .details-container .details-list,
+.media-hub-section .details-container .details-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.youtube-section .button-row,
+.media-hub-section .button-row {
+  display: flex;
+  gap: 8px;
+  margin: 8px;
+}
+
+.button-row .spacer {
+  flex: 1;
+}
+
+.youtube-section .channel-card,
+.media-hub-section .channel-card,
+.youtube-section .detail-item,
+.media-hub-section .detail-item {
+  background: var(--surface);
+  padding: 8px 16px;
+  min-height: 56px;
+  border-radius: 20px;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: box-shadow 0.2s, background 0.2s;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.youtube-section .channel-card .channel-thumb,
+.media-hub-section .channel-card .channel-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.youtube-section .channel-card .channel-name,
+.media-hub-section .channel-card .channel-name {
+  flex: 1;
+  min-width: 0;
+  line-height: 1.2;
+  max-height: 2.4em;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+
+.fav-btn,
+.youtube-section .channel-card .play-btn,
+.media-hub-section .channel-card .play-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.youtube-section .channel-card .play-btn,
+.media-hub-section .channel-card .play-btn {
+  position: relative;
+}
+
+.youtube-section .channel-card:hover,
+.media-hub-section .channel-card:hover {
+  box-shadow: var(--shadow-xl);
+}
+
+.youtube-section .channel-card.active,
+.media-hub-section .channel-card.active {
+  background: var(--primary);
+  color: var(--on-primary);
+}
+
+.youtube-section .channel-card.favorite,
+.media-hub-section .channel-card.favorite {
+  background: var(--favorite-row);
+  color: var(--on-primary);
+}
+
+.channel-card.favorite .fav-btn {
+  color: var(--on-primary);
+}
+
+.video-section {
+  margin-top: 16px;
+}
+
+.youtube-section .video-section,
+.media-hub-section .video-section {
+  flex: 1;
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 120px);
+}
+
+.video-section iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: 4px;
+}
+
+.video-section .video-list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+
+.video-list .video-item {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid var(--surface-variant);
+  cursor: pointer;
+}
+
+.video-list .video-item img,
+.video-list .video-thumb {
+  width: 120px;
+  height: 67px;
+  flex: 0 0 120px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.video-list .video-item.active {
+  background: var(--active-row);
+}
+
+.video-list .video-item .video-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.video-list .video-item .video-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.video-list .video-item .video-meta {
+  font-size: 0.875rem;
+  color: var(--on-surface-variant);
+}
+
+/* Responsive behaviour for channel list */
+@media (max-width: 768px) {
+  .youtube-section {
+    display: block;
+  }
+  .youtube-section > * + * {
+    margin-left: 0;
+  }
+  .youtube-section .channel-list,
+  .media-hub-section .channel-list {
+    position: fixed;
+    top: 56px;
+    left: 0;
+    bottom: 0;
+    width: 260px;
+    max-width: 80%;
+    background: var(--surface);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    box-shadow: var(--shadow-side-right);
+    overflow-y: auto;
+    padding: 16px 8px;
+    z-index: 1004;
+    flex-direction: column;
+    padding: 16px;
+    gap: 8px;
+  }
+  .youtube-section .details-container,
+  .media-hub-section .details-container {
+    width: auto;
+  }
+  .youtube-section .details-list,
+  .media-hub-section .details-list {
+    position: fixed;
+    top: 56px;
+    right: 0;
+    bottom: 0;
+    width: 260px;
+    max-width: 80%;
+    background: var(--surface);
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    box-shadow: var(--shadow-side-left);
+    overflow-y: auto;
+    padding: 16px 8px;
+    z-index: 1004;
+    flex-direction: column;
+    padding: 16px;
+    gap: 8px;
+  }
+  .youtube-section .channel-list.open,
+  .media-hub-section .channel-list.open {
+    transform: translateX(0);
+  }
+  .youtube-section .details-list.open,
+  .media-hub-section .details-list.open {
+    transform: translateX(0);
+  }
+}
+
+
+@media (min-width: 769px) {
+  .youtube-section .channel-list,
+  .media-hub-section .channel-list {
+    position: sticky;
+    top: 72px;
+    height: calc(100vh - 120px);
+    overflow-y: auto;
+  }
+  .youtube-section .details-container,
+  .media-hub-section .details-container {
+    position: sticky;
+    top: 72px;
+    height: calc(100vh - 120px);
+  }
+  .youtube-section .details-container .details-list,
+  .media-hub-section .details-container .details-list {
+    overflow-y: auto;
+    flex: 1;
+  }
+  .youtube-section .channel-list.collapsed,
+  .media-hub-section .channel-list.collapsed {
+    width: 72px;
+  }
+  .youtube-section .channel-list.collapsed .channel-card,
+  .media-hub-section .channel-list.collapsed .channel-card {
+    padding: 8px;
+    justify-content: center;
+    border-radius: 50%;
+    box-sizing: border-box;
+  }
+  .youtube-section .channel-list.collapsed .channel-card .channel-thumb,
+  .media-hub-section .channel-list.collapsed .channel-card .channel-thumb {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+  .youtube-section .channel-list.collapsed .channel-card .channel-name,
+  .media-hub-section .channel-list.collapsed .channel-card .channel-name,
+  .youtube-section .channel-list.collapsed .channel-card .play-btn,
+  .media-hub-section .channel-list.collapsed .channel-card .play-btn,
+  .youtube-section .channel-list.collapsed .channel-card .fav-btn,
+  .media-hub-section .channel-list.collapsed .channel-card .fav-btn {
+    display: none;
+  }
+  .youtube-section .details-container.collapsed,
+  .media-hub-section .details-container.collapsed {
+    width: 24px;
+  }
+  .youtube-section .details-container.collapsed .details-list,
+  .media-hub-section .details-container.collapsed .details-list {
+    display: none;
+  }
+}
+
+.details-content h3 {
+  margin: 8px 0;
+  font-size: 1.1rem;
+}
+
+.details-content p {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+}
+
+.details-content .meta div {
+  margin-bottom: 4px;
+  font-size: 0.9rem;
+}
+
+.profiles {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.profile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.8rem;
+  transition: color 0.2s ease;
+  flex: 0 0 auto;
+}
+
+.profile-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--surface-variant);
+  border: 1px solid var(--outline);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
+
+.profile-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.profile:hover {
+  color: var(--accent-link);
+}
+
+.profile:hover .profile-icon {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-hover);
+}
+
+/* Buttons */
+button,
+.channel-toggle,
+.details-toggle {
+  background: var(--primary);
+  color: var(--on-primary);
+  border: none;
+  border-radius: 12px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+button:hover,
+.channel-toggle:hover,
+.details-toggle:hover {
+  background: var(--primary-container);
+}
+
+
+button:hover,
+.channel-toggle:hover {
+  transform: scale(1.03);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  box-shadow: var(--shadow-xxl);
+}
+
+.play-pause-btn {
+  position: relative;
+}
+
+/* Ensure embedded videos keep a 16:9 aspect ratio */
+.live-player iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  display: block;
+  border: 0;
+}
+
+/* Radio player controls */
+.radio-card,
+.radio-container,
+.radio-player,
+[data-radio-container] {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  max-width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.radio-player {
+  background: linear-gradient(180deg, var(--surface), var(--surface-variant));
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  margin-bottom: 0; /* controls are inside now */
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.radio-list #player-container {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.station-info {
+  text-align: center;
+}
+
+/* Station header: flex aligns title with avatar center */
+.station-header {
+  display: flex;
+  align-items: center;   /* vertical alignment */
+  gap: 12px;
+  padding: 0.5rem 0;
+  min-width: 0;          /* enables text truncation */
+}
+
+/* Round avatar, no distortion */
+.station-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: #eee;      /* fallback if no image */
+}
+
+/* Station title: one line, truncate with ellipsis */
+.station-title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.2;       /* keeps vertical balance */
+  color: var(--text-color, #263238);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;    /* force one line */
+  flex: 1;                /* take available space */
+  display: block;         /* stable box model for ellipsis */
+}
+
+/* Station info image fallback when not using avatar */
+.station-info img:not(.station-avatar) {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  margin-bottom: 8px;
+}
+
+/* Compact version for narrow screens */
+@media (max-width: 360px) {
+  .station-avatar { width: 40px; height: 40px; }
+  .station-title  { font-size: 0.95rem; }
+}
+
+/* Compact layout when the player overflows */
+.radio-player.compact {
+  padding: 8px;
+}
+
+.radio-player.compact .controls {
+  margin-top: 0;
+}
+
+.radio-player.compact .live-badge,
+.radio-player.compact .not-live-badge {
+  display: none;
+}
+
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 12px;
+  background: var(--error-container);
+  color: var(--error);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.live-badge .dot {
+  width: 8px;
+  height: 8px;
+  background: var(--error);
+  border-radius: 50%;
+  margin-right: 4px;
+}
+
+.not-live-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 12px;
+  background: var(--surface-variant);
+  color: var(--on-surface);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.not-live-badge .dot {
+  width: 8px;
+  height: 8px;
+  background: var(--on-surface);
+  border-radius: 50%;
+  margin-right: 4px;
+}
+
+:root {
+  --radio-btn-size: clamp(36px, 8vw, 54px);
+  --radio-icon-size: clamp(18px, 4vw, 26px);
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 12px;
+}
+
+.controls button,
+.controls .fav-btn,
+.controls .play-pause-btn,
+.controls .mute-btn {
+  width: var(--radio-btn-size);
+  height: var(--radio-btn-size);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex: 0 1 auto;
+  box-sizing: border-box;
+  border: none;
+  background: var(--primary);
+  color: var(--on-primary);
+  cursor: pointer;
+}
+
+.controls .material-symbols-outlined,
+.controls button .label {
+  font-size: var(--radio-icon-size);
+}
+
+.controls .play-pause-btn .spinner {
+  width: calc(var(--radio-icon-size) * 0.9);
+  height: calc(var(--radio-icon-size) * 0.9);
+}
+
+.controls .fav-btn,
+.controls .play-pause-btn,
+.controls .mute-btn {
+  flex-shrink: 1;
+}
+
+.controls button:hover {
+  background: var(--hover-primary);
+}
+
+.controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px;
+  border-bottom: 1px solid var(--surface-variant);
+}
+
+th {
+  text-align: left;
+}
+
+table tbody tr:not(:first-child) {
+  cursor: pointer;
+}
+
+table tbody tr.favorite {
+  background-color: var(--favorite-row);
+  color: var(--on-primary);
+}
+/* Hover highlight for station rows on desktops */
+@media (hover: hover) and (pointer: fine) {
+  .radio-list table tbody tr:not(:first-child) {
+    transition: background-color 0.2s ease-in-out;
+  }
+
+  .radio-list table tbody tr:not(:first-child):hover {
+    background-color: var(--hover-primary);
+  }
+}
+
+.radio-list td:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.radio-list td:first-child audio {
+  display: none;
+}
+
+.station-row-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.station-row-logo.missing {
+  background: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2040%2040%27%3E%3Crect%20width%3D%2740%27%20height%3D%2740%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%275%27%20y%3D%2714%27%20width%3D%2730%27%20height%3D%2718%27%20rx%3D%272%27%20ry%3D%272%27%20fill%3D%27%23888888%27/%3E%3Ccircle%20cx%3D%2714%27%20cy%3D%2723%27%20r%3D%274%27%20fill%3D%27%23BDBDBD%27/%3E%3Crect%20x%3D%2722%27%20y%3D%2719%27%20width%3D%2710%27%20height%3D%278%27%20fill%3D%27%23BDBDBD%27/%3E%3C/svg%3E") center/cover no-repeat;
+}
+
+/* Post layout */
+.post-container {
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+  box-sizing: border-box;
+}
+
+.post {
+  background: var(--surface);
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+}
+
+.post h1 {
+  font-size: 2em;
+  margin-bottom: 10px;
+  color: var(--on-surface);
+}
+
+.post-meta,
+.post-author {
+  color: var(--on-surface-variant);
+  font-size: 0.95rem;
+  margin-bottom: 8px;
+}
+
+.post-featured-image {
+  width: 100%;
+  height: auto;
+  margin: 20px 0;
+  border-radius: 8px;
+}
+
+.post-content {
+  line-height: 1.7;
+  font-size: 1rem;
+  color: var(--on-surface);
+}
+
+.post-share {
+  margin-top: 30px;
+  font-size: 0.9em;
+  padding-top: 15px;
+  border-top: 1px solid var(--outline);
+}
+
+.post-share a {
+  text-decoration: none;
+  margin-right: 10px;
+  color: var(--accent-link);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .post h1 {
+    font-size: 1.5em;
+  }
+
+  .post-container {
+    padding: 15px;
+  }
+
+  .post-content {
+    font-size: 0.95rem;
+  }
+
+  .post-featured-image {
+    margin: 15px 0;
+  }
+
+  .top-bar nav {
+    position: fixed;
+    top: 56px;
+    left: 0;
+    bottom: 0;
+    width: 250px;
+    background: var(--surface);
+    color: var(--on-surface);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease-in-out;
+    will-change: transform;
+    box-shadow: var(--shadow-side-right);
+    z-index: 1004;
+    flex-direction: column;
+    padding: 16px;
+    gap: 8px;
+  }
+
+  .top-bar nav a {
+    color: var(--on-surface);
+    display: block;
+    padding: 12px 14px;
+    border-radius: 10px;
+  }
+
+  .top-bar nav a:hover,
+  .top-bar nav a:focus {
+    color: var(--accent-link);
+  }
+
+}
+
+@media (min-width: 601px) {
+  .nav-toggle {
+    display: none;
+  }
+  .back-button {
+    display: none;
+  }
+  .top-bar nav {
+    margin-left: auto;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
+}
+
+/* Spinner styles for radio play buttons and main player */
+.play-btn .spinner,
+.play-pause-btn .spinner {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+
+.play-btn.loading .spinner,
+.play-pause-btn.loading .spinner {
+  display: inline-block;
+}
+
+.play-btn.loading .label,
+.play-pause-btn.loading .label {
+  visibility: hidden;
+}
+
+@keyframes spin {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+/* Utility page for nadraimage */
+.utility-page {
+  text-align: center;
+  padding: 2rem;
+}
+
+.utility-page video,
+.utility-page canvas,
+.utility-page img {
+  max-width: 100%;
+  border: 1px solid var(--outline);
+  margin-top: 1rem;
+  border-radius: 4px;
+}
+
+.utility-page button {
+  margin: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 16px;
+  margin-top: 40px;
+  color: var(--on-surface);
+}
+
+footer nav {
+  margin-bottom: 8px;
+}
+
+footer nav a {
+  color: var(--on-surface);
+  margin: 0 8px;
+  text-decoration: none;
+}
+
+footer nav a:hover {
+  text-decoration: underline;
+  color: var(--hover-link);
+}
+
+.support-text {
+  margin-top: 8px;
+}
+
+.bmc-button {
+  display: inline-block;
+  background-color: var(--secondary);
+  color: var(--on-secondary);
+  padding: 8px 12px;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 500;
+  margin-top: 8px;
+  transition: background-color 0.3s;
+  white-space: nowrap;
+}
+
+.bmc-button:hover {
+  background-color: color-mix(in srgb, var(--secondary) 85%, var(--on-secondary));
+}
+
+.top-bar .bmc-button {
+  margin-left: 16px;
+  margin-top: 0;
+}
+
+.ad-container {
+  margin: 20px 0;
+  text-align: center;
+}
+
+#stream-list {
+  /* Utilize existing video-list styles */
+  margin: 0;
+  padding: 0;
+}
+
+/* Discovery rails */
+.rail-section {
+  margin: 20px auto;
+  max-width: 960px;
+}
+.rail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.rail-cards {
+  display: flex;
+  overflow-x: auto;
+  gap: 12px;
+}
+.rail-card {
+  flex: 0 0 160px;
+  background: var(--surface);
+  border-radius: 8px;
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+  color: inherit;
+  padding: 4px;
+}
+.rail-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+}
+.rail-title {
+  font-size: 0.875rem;
+  margin-top: 4px;
+}
+.clear-btn {
+  background: none;
+  border: none;
+  color: var(--accent-link);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.875rem;
+}
+.rail-progress {
+  position: relative;
+  height: 4px;
+  background: var(--surface-variant);
+  border-radius: 2px;
+  margin-top: 4px;
+}
+.rail-progress-inner {
+  height: 100%;
+  background: var(--primary);
+  border-radius: 2px;
+}
+
+.site-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease;
+  z-index: 900;
+}
+.site-overlay.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+.site-nav {
+  transition: transform .2s ease;
+}
+.is-menu-open {
+  overflow: hidden;
+}
+.is-menu-open .site-nav {
+  transform: translateX(0);
+}
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+/* Error overlay (additive) */
+.ps-error-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0,0,0,.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease;
+  z-index: 950;
+}
+.ps-error-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.ps-error-card {
+  max-width: 420px;
+  width: calc(100% - 2rem);
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.2);
+  padding: 16px 18px;
+  text-align: center;
+}
+.ps-error-title { font-weight: 700; margin-bottom: 6px; }
+.ps-error-msg { font-size: 0.95rem; opacity: .85; margin-bottom: 12px; }
+.ps-error-actions { display: flex; justify-content: center; gap: 8px; }
+.ps-error-retry {
+  appearance: none;
+  border: 0;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #1e88e5;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ps-error-retry:focus { outline: 2px solid #000; outline-offset: 2px; }
+
+/* Ensure stream containers establish a positioning context (non-breaking) */
+[data-stream-container] { position: relative; }
+
+[data-radio-container].is-playing,
+[data-youtube-container].is-playing { outline: 2px solid rgba(0,0,0,.2); }
+
+/* Make the radio card a SIZE container so we get both cqw and cqh */
+.radio-player {
+  /* ...existing styles... */
+  container-type: size; /* was inline-size */
+}
+
+/* Fallback (old browsers) – viewport based */
+:root {
+  --radio-btn-size: clamp(32px, 8vw, 52px);
+  --radio-icon-size: clamp(16px, 4vw, 24px);
+  --controls-gap: 10px;
+  --card-pad: 16px;
+}
+
+/* Prefer container-relative sizing.
+   Use the MIN of width- and height-based units so buttons shrink
+   when HEIGHT is the bottleneck in the 16:9 box. */
+@supports (width: 1cqw) and (height: 1cqh) {
+  .radio-player {
+    --radio-btn-size: min(
+      clamp(32px, 12cqw, 52px),
+      clamp(32px, 14cqh, 52px)
+    );
+    --radio-icon-size: min(
+      clamp(16px, 6cqw, 24px),
+      clamp(16px, 7cqh, 24px)
+    );
+    /* pad and gaps also scale with card height */
+    --controls-gap: clamp(6px, 4cqh, 12px);
+    --card-pad: clamp(8px, 5cqh, 16px);
+  }
+}
+
+/* Use the scalable padding */
+.radio-player {
+  padding: var(--card-pad);
+}
+
+/* Controls grid: use scalable gap and allow it to compress */
+.controls {
+  display: grid;
+  justify-content: center;
+  justify-items: center;
+  align-items: center;
+  align-content: start;
+  gap: var(--controls-gap);
+  grid-template-columns: repeat(auto-fit, minmax(var(--radio-btn-size), 1fr));
+  grid-auto-rows: 1fr;
+  padding: calc(var(--controls-gap) * 0.8) var(--controls-gap) 0;
+  box-sizing: border-box;
+  overflow: hidden;
+  min-height: 0; /* allow shrink inside fixed-aspect card */
+}
+
+.radio-player .controls {
+  overflow: visible;
+  padding-bottom: var(--controls-gap);
+}
+
+/* Uniform circular buttons that can shrink */
+.controls button,
+.controls .fav-btn,
+.controls .play-pause-btn,
+.controls .mute-btn {
+  width: var(--radio-btn-size);
+  height: var(--radio-btn-size);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+  flex: 0 1 auto;
+  flex-shrink: 1 !important;
+  box-sizing: border-box;
+}
+
+/* Icons scale with button size */
+.controls .material-symbols-outlined,
+.controls button .label {
+  font-size: var(--radio-icon-size);
+}
+
+.controls .play-pause-btn .spinner {
+  width: calc(var(--radio-icon-size) * 0.9);
+  height: calc(var(--radio-icon-size) * 0.9);
+}
+
+/* Header tightens up on small cards to free vertical space */
+.station-header {
+  gap: calc(var(--controls-gap) * 0.9);
+  min-height: 0; /* avoid forcing extra height */
+}
+.station-title { line-height: 1.15; }
+
+/* Extra squeeze on very narrow screens */
+@media (max-width: 360px) {
+  .controls { gap: calc(var(--controls-gap) * 0.8); }
+}
+
+/* --- PATCH: Prevent control buttons from being cut in media-hub embed --- */
+.media-hub-section .radio-card,
+.media-hub-section .radio-container,
+.media-hub-section .radio-player,
+.media-hub-section [data-radio-container]{
+  aspect-ratio: auto !important;
+  overflow: visible !important;
+}
+.media-hub-section .radio-player { 
+  min-height: unset !important;
+}
+
+/* Ensure the control row itself never clips inside the embed */
+.media-hub-section .controls { 
+  overflow: visible !important;
+  padding-bottom: var(--controls-gap); /* a little breathing room */
+}
+
+/* Make grid rows size to content so circles never get cropped */
+.media-hub-section .controls {
+  grid-auto-rows: min-content !important;
+  overflow: visible !important; /* you already added this — keep it */
+}
+
+/* Ensure the card itself isn’t constraining height */
+.media-hub-section .radio-player {
+  height: auto !important;
+}
+
+.media-hub-section .radio-player { padding-bottom: calc(var(--card-pad) + 4px); }
+
+/* Ensure the radio card grows to fit its children */
+#player-container.radio-player {
+  height: auto !important;
+  min-height: max-content;     /* force wrap to content height */
+  overflow: visible !important;/* undo group overflow:hidden */
+}
+
+/* Grid rows should size to their content (not stretch/compress) */
+#player-container.radio-player .controls {
+  grid-auto-rows: min-content !important;
+  overflow: visible !important;
+  padding-bottom: var(--controls-gap);
+}
+
+/* --- END PATCH --- */
+
+/* Footer (index.html) */
+footer.site-footer {
+  background: var(--surface);
+  border-top: 1px solid var(--outline);
+  color: var(--on-surface-variant);
+  padding: 28px 24px;
+  margin: 34px 0 20px;
+  text-align: center;
+}
+
+footer.site-footer .footer-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+footer.site-footer .footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+}
+
+footer.site-footer .footer-links a {
+  color: var(--on-surface-variant);
+  font-size: 14px;
+  text-decoration: none;
+}
+
+footer.site-footer .footer-links a:hover {
+  color: var(--accent-link);
+}
+
+footer.site-footer .copy {
+  font-size: 13px;
+  color: var(--on-surface-variant);
+}
+
+@media (max-width: 768px) {
+  footer.site-footer {
+    padding: 16px;
+  }
+}
+
+/* Landing hero with search */
+.landing-hero {
+  padding: 56px 20px 36px;
+  text-align: center;
+  border-bottom: 1px solid var(--outline);
+  background: radial-gradient(circle at top, var(--surface), var(--background) 80%);
+}
+.landing-hero h1 {
+  font-size: 48px;
+  line-height: 1.15;
+  margin: 0;
+}
+.landing-hero p {
+  margin: 8px auto 16px;
+  color: var(--on-surface-variant);
+  max-width: 760px;
+}
+.search-xl {
+  margin: 16px auto 0;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  border: 1px solid var(--outline);
+  border-radius: 18px;
+  padding: 10px 12px;
+  box-shadow: var(--shadow-lg);
+  max-width: 720px;
+  position: relative;
+  transition: box-shadow .2s ease, border-color .2s ease;
+}
+.search-xl:focus-within {
+  border-color: var(--secondary);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--secondary) 35%, transparent), var(--shadow-lg);
+}
+.search-xl input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--on-surface);
+  font-size: 17px;
+  padding: 12px;
+}
+.search-xl input::placeholder {
+  color: var(--on-surface-variant);
+}
+.search-xl:focus-within input::placeholder {
+  color: color-mix(in srgb, var(--on-surface) 85%, white);
+}
+.search-xl .search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--surface);
+  border: 1px solid var(--outline);
+  border-radius: 12px;
+  margin-top: 4px;
+  box-shadow: var(--shadow-lg);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+.search-xl .search-results a {
+  display: block;
+  padding: 8px 12px;
+  color: var(--on-surface);
+  text-decoration: none;
+}
+.search-xl .search-results a:hover {
+  background: color-mix(in srgb, var(--on-surface) 12%, transparent);
+}
+.btn {
+  appearance: none;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.btn-primary {
+  background: var(--secondary);
+  color: var(--on-secondary);
+}
+.btn-ghost {
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  color: var(--on-surface);
+  border: 1px solid var(--outline);
+}
+.suggest {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 12px;
+}
+.chip {
+  border: 1px solid var(--outline);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .landing-hero {
+    padding: 36px 16px 24px;
+  }
+  .landing-hero h1 {
+    font-size: 32px;
+    line-height: 1.2;
+  }
+  .landing-hero p {
+    font-size: 14px;
+    max-width: 100%;
+  }
+  .search-xl {
+    max-width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    border-radius: 14px;
+    padding: 10px;
+  }
+  .search-xl input {
+    padding: 12px 10px;
+    font-size: 16px;
+  }
+  .search-xl .btn {
+    width: 100%;
+  }
+  .suggest {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding: 0 2px;
+    gap: 8px;
+  }
+  .suggest .chip {
+    white-space: nowrap;
+  }
+}
+/* Ads: CLS-safe placeholders (additive) */
+.ad-slot {
+  position: relative;
+  box-sizing: border-box;
+  display: block;
+  margin: 16px auto;
+  width: 100%;
+  max-width: 100%;
+  background: #f8f9fa;
+  border: 1px dashed rgba(0,0,0,.08);
+  border-radius: 10px;
+}
+
+.ad-slot.is-ready {
+  border-style: solid;
+  border-color: rgba(0,0,0,.06);
+}
+
+.ad-slot .ad-placeholder {
+  display: grid;
+  place-items: center;
+  font-size: .85rem;
+  color: #6b7280;
+  height: 100%;
+  width: 100%;
+  padding: 8px;
+  text-align: center;
+}
+
+/* Responsive helpers (optional) */
+@media (min-width: 768px) {
+  .ad-slot[data-ad-type="leaderboard"] { max-width: 728px; min-height: 90px; }
+}
+@media (max-width: 767.98px) {
+  .ad-slot[data-ad-type="leaderboard"] { max-width: 320px; min-height: 50px; }
+}
+
+/* “Fluid” slots: fill container width; height via aspect ratio or custom CSS */
+.ad-slot[data-ad-type="fluid"] {
+  width: 100%;
+  min-height: 1px;
+}
+/* Carousel (additive) */
+.ps-carousel {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 8px;
+}
+
+.ps-crs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ps-crs-title { margin: 0; font-size: 1.1rem; }
+
+.ps-crs-ctrls { display: flex; gap: 6px; }
+.ps-crs-btn {
+  appearance: none;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  border-radius: 10px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-weight: 700;
+}
+.ps-crs-btn:disabled { opacity: .45; cursor: not-allowed; }
+
+.ps-crs-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(240px, 1fr);
+  gap: 12px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 6px;
+}
+.ps-crs-track::-webkit-scrollbar { height: 8px; }
+.ps-crs-track::-webkit-scrollbar-thumb { background: #d1d5db; border-radius: 8px; }
+
+.ps-crs-item {
+  scroll-snap-align: start;
+}
+
+.ps-crs-track.is-dragging { cursor: grabbing; }
+
+/* If you place MH cards inside, they already have styles from mh-lite.css */
+
+/* Minimal Media Hub styles (additive) */
+.mh-wrap { display: grid; gap: 16px; }
+.mh-row { display: grid; gap: 12px; }
+.mh-search { display: flex; align-items: center; gap: 8px; }
+.mh-search input[type="search"] {
+  width: 100%; padding: 10px 12px; border-radius: 10px;
+  border: 1px solid #e0e0e0; font: inherit;
+}
+
+.mh-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.mh-card {
+  background: #fff; border-radius: 12px; box-shadow: var(--ps-shadow-1,0 6px 18px rgba(0,0,0,.12));
+  padding: 12px; display: grid; gap: 10px;
+}
+.mh-head { display: grid; grid-template-columns: 56px 1fr; gap: 10px; align-items: center; }
+.mh-thumb { width: 56px; height: 56px; object-fit: cover; border-radius: 8px; background: #f3f4f6; }
+.mh-title { margin: 0; font-size: 1rem; line-height: 1.2; }
+.mh-sub { font-size: .85rem; opacity: .7; }
+.mh-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+.mh-tag { font-size: .75rem; background: #f1f5f9; padding: 2px 6px; border-radius: 6px; }
+
+.mh-media iframe,
+.mh-media audio { width: 100%; border: 0; }
+.mh-play {
+  appearance: none; border: 0; border-radius: 10px; padding: 8px 12px; font-weight: 700;
+  background: var(--ps-color-primary,#1e88e5); color: #fff; cursor: pointer;
+}
+.mh-empty { padding: 24px; text-align: center; opacity: .75; }
+/* Auto-generated overrides to apply Elegant Emerald theme onto current markup */
+
+    :root{
+      --bg:#0b1a14;
+      --bg2:#0e221a;
+      --ink:#eaf5ef;
+      --muted:#a8c7b6;
+      --brand:#19c37d;
+      --ring:rgba(25,195,125,.35);
+      --radius:16px;
+      --shadow:0 12px 32px rgba(0,0,0,.35);
+      --hair:rgba(255,255,255,.06);
+    }
+
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.6 'Inter',system-ui,sans-serif}
+    a{text-decoration:none;color:var(--ink)}
+    h1,h2,h3{margin:0;font-weight:800}
+
+    header{position:sticky;top:0;z-index:30;background:linear-gradient(180deg,rgba(11,26,20,.9),rgba(11,26,20,.55) 60%,transparent);backdrop-filter:blur(8px);border-bottom:1px solid var(--hair)}
+    .top{max-width:1200px;margin:auto;display:flex;gap:16px;align-items:center;justify-content:space-between;padding:16px 24px}
+    .brand{display:flex;gap:10px;align-items:center}
+    .logo{width:38px;height:38px;border-radius:12px;background:conic-gradient(from 140deg,#23e08c,#0f6b45,#0b1a14);box-shadow:inset 0 0 0 2px #0b1a14,0 8px 20px rgba(0,0,0,.35)}
+    .brand h1{font-size:18px;letter-spacing:.3px}
+    nav a{color:var(--muted);margin-left:14px}
+
+    /* HERO */
+    .hero,.landing-hero{padding:56px 20px 36px;border-bottom:1px solid var(--hair);text-align:center;background:radial-gradient(circle at top,var(--bg2),var(--bg) 80%)}
+    body .hero h1, body .landing-hero h1{font-size:64px;line-height:1.05;font-weight:800;letter-spacing:.2px;margin:0 0 12px}
+    body .hero p, body .landing-hero p{margin:8px auto 12px;color:#a8c7b6;max-width:840px;font-size:18px}
+    body .search-xl{margin:16px auto 0;display:flex;gap:10px;align-items:center;background:linear-gradient(180deg,#0b1a14,#0f221a);border:1px solid rgba(25,195,125,.25);border-radius:18px;padding:10px;box-shadow:0 2px 10px rgba(0,0,0,.35);max-width:820px;position:relative}
+    body .search-xl:focus-within{border-color:#19c37d;box-shadow:0 0 0 4px rgba(25,195,125,.25),0 10px 24px rgba(0,0,0,.45)}
+    .search-xl input:focus-visible{outline:none}
+    body .search-xl{margin:16px auto 0;display:flex;gap:10px;align-items:center;background:linear-gradient(180deg,#0b1a14,#0f221a);border:1px solid rgba(25,195,125,.25);border-radius:18px;padding:10px;box-shadow:0 2px 10px rgba(0,0,0,.35);max-width:820px;position:relative}
+    .search-xl:focus-within input::placeholder{color:#d6f5e6}
+    body .search-xl input{flex:1;border:0;outline:0;background:transparent;font:500 18px/1.2 'Inter',system-ui,sans-serif;color:#eaf5ef;padding:12px 14px;border-radius:12px}
+    .search-xl .search-results{position:absolute;top:100%;left:0;right:0;background:var(--bg2);border:1px solid var(--hair);border-radius:12px;margin-top:4px;box-shadow:var(--shadow);max-height:240px;overflow-y:auto;z-index:100}
+    .search-xl .search-results a{display:block;padding:8px 12px;color:var(--ink)}
+    .search-xl .search-results a:hover{background:rgba(255,255,255,.08)}
+    .btn{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}
+    .btn-primary{background:var(--brand);color:#03130c}
+    .btn-ghost{background:rgba(255,255,255,.06);color:var(--ink);border:1px solid var(--hair)}
+    .suggest{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;margin-top:12px}
+    .chip{border:1px solid var(--hair);background:rgba(255,255,255,.06);border-radius:999px;padding:8px 12px;font-size:14px}
+
+    /* Feature Grid */
+    .features{max-width:1200px;margin:40px auto;padding:0 24px;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:24px}
+    .feature-card{background:linear-gradient(180deg,rgba(255,255,255,.05),rgba(255,255,255,.02));border:1px solid var(--hair);border-radius:20px;box-shadow:var(--shadow);overflow:hidden;display:flex;flex-direction:column}
+    .feature-card iframe{width:100%;aspect-ratio:16/9;border:0;border-bottom:1px solid var(--hair)}
+    .feature-card-content{padding:16px;display:flex;flex-direction:column;flex:1}
+    .feature-card h3{margin:0 0 6px;font-size:18px;color:var(--ink)}
+    .feature-card p{margin:0 0 12px;color:var(--muted);font-size:14px;flex:1}
+    .feature-card a{align-self:flex-start;background:var(--brand);color:#03130c;padding:8px 14px;border-radius:10px;font-weight:600;text-decoration:none}
+
+    footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
+
+    /* ===================== */
+/* Mobile adjustments    */
+/* ===================== */
+@media (max-width: 768px){
+  /* Header */
+  .top{padding:12px 16px}
+  .brand h1{font-size:16px}
+  nav a{margin-left:12px; font-size:14px}
+
+  /* Hero */
+  .hero,.landing-hero{padding:36px 16px 24px}
+  body .hero h1, body .landing-hero h1{font-size:64px;line-height:1.05;font-weight:800;letter-spacing:.2px;margin:0 0 12px}
+  body .hero p, body .landing-hero p{margin:8px auto 12px;color:#a8c7b6;max-width:840px;font-size:18px}
+
+  /* Search: stack vertically */
+  body .search-xl{margin:16px auto 0;display:flex;gap:10px;align-items:center;background:linear-gradient(180deg,#0b1a14,#0f221a);border:1px solid rgba(25,195,125,.25);border-radius:18px;padding:10px;box-shadow:0 2px 10px rgba(0,0,0,.35);max-width:820px;position:relative}
+  body .search-xl input{flex:1;border:0;outline:0;background:transparent;font:500 18px/1.2 'Inter',system-ui,sans-serif;color:#eaf5ef;padding:12px 14px;border-radius:12px}
+  .search-xl .btn{width:100%}
+
+  /* Suggestion chips: horizontal scroll */
+  .suggest{justify-content:flex-start; overflow-x:auto; padding:0 2px; gap:8px}
+  .suggest .chip{white-space:nowrap}
+
+  /* Feature grid: single column */
+  .features{
+    grid-template-columns:1fr;
+    gap:16px;
+    padding:0 16px;
+    margin:28px auto;
+  }
+  .feature-card{border-radius:16px}
+  .feature-card-content{padding:12px}
+  .feature-card h3{font-size:16px}
+  .feature-card p{font-size:13px}
+  .feature-card a{width:100%; text-align:center}
+
+  /* Iframes: keep aspect; lighter shadows for perf */
+  .feature-card iframe{box-shadow:none}
+
+  /* Footer */
+  footer{padding:16px; font-size:13px}
+}
+    footer{background:var(--bg2);border-top:1px solid var(--hair);color:var(--muted);padding:28px 24px}
+    .footer-inner{max-width:1200px;margin:0 auto;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px}
+    .footer-links{display:flex;flex-wrap:wrap;gap:16px}
+    .footer-links a{color:var(--muted);font-size:14px}
+    .footer-links a:hover{color:var(--brand)}
+    .copy{font-size:13px;color:var(--muted)}
+
   
-  <link rel="stylesheet" href="/css/elegant-emerald-overrides.css?v=3">
+.search-xl .btn-browse{min-width:160px;border-radius:14px;padding:12px 16px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);font-weight:600;color:#e4f1ea}
+
+.quick-tags{display:flex;gap:16px;flex-wrap:wrap;justify-content:center;margin-top:16px}
+.quick-tags .chip{display:inline-flex;align-items:center;gap:8px;padding:8px 14px;border-radius:999px;background:#152721;border:1px solid rgba(255,255,255,.06);box-shadow:0 4px 10px rgba(0,0,0,.25)}
+
+/* v3 overrides with higher specificity */
+/* --- Top hero + search: force match to index1.html --- */
+
+/* Headline + subhead (match index1 scale/spacing) */
+body .landing-hero h1,
+body .hero h1{
+  font-size: 56px;          /* was larger; match mock */
+  line-height: 1.06;
+  font-weight: 800;
+  letter-spacing: .2px;
+  margin: 0 0 12px;
+}
+
+body .landing-hero p,
+body .hero p{
+  margin: 8px auto 12px;
+  color: #a8c7b6;
+  max-width: 840px;
+  font-size: 18px;
+}
+
+/* Outer search container is the ONLY thing with border/ring */
+body .search-xl{
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  max-width: 820px;
+  margin: 16px auto 0;
+  padding: 10px;
+  border-radius: 18px;
+  background: linear-gradient(180deg,#0b1a14,#0f221a);
+  border: 1px solid rgba(25,195,125,.25);
+  box-shadow: 0 2px 10px rgba(0,0,0,.35);
+  position: relative;
+}
+
+/* Kill any decorative lines previously added via pseudo elements */
+body .search-xl::before,
+body .search-xl::after{
+  content: none !important;
+}
+
+/* Nuke ALL inner borders/shadows/outlines so they don't stack */
+body .search-xl input,
+body .search-xl select,
+body .search-xl textarea,
+body .search-xl a,
+body .search-xl button,
+body .search-xl .btn,
+body .search-xl > *{
+  border: 0 !important;
+  outline: 0 !important;
+  box-shadow: none !important;
+  background: transparent;
+}
+
+/* Input text + placeholder */
+body .search-xl input{
+  flex: 1;
+  padding: 12px 14px;
+  border-radius: 12px;
+  color: #eaf5ef;
+  font: 500 18px/1.2 'Inter',system-ui,sans-serif;
+}
+body .search-xl input::placeholder{ color:#86a79a; }
+
+/* Secondary "Browse All" pill */
+body .search-xl a{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 160px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(255,255,255,.04);
+  border: 1px solid rgba(255,255,255,.08) !important;
+  color: #e4f1ea;
+  font-weight: 600;
+}
+
+/* Primary "Search" button */
+body .search-xl button{
+  padding: 12px 18px;
+  border-radius: 14px;
+  font-weight: 700;
+  background: #19c37d;
+  color: #0b1a14;
+  box-shadow: 0 6px 16px rgba(0,0,0,.35);
+}
+
+/* Focus ring ONLY on the container (not on the input) */
+body .search-xl:focus-within{
+  border-color: #19c37d;
+  box-shadow: 0 0 0 4px rgba(25,195,125,.25), 0 10px 24px rgba(0,0,0,.45);
+}
+
+/* --- Hero headline: force identical typography to index1.html --- */
+body .landing-hero h1,
+body .hero h1{
+  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial, 'Noto Sans', 'Liberation Sans', sans-serif !important;
+  font-weight: 800 !important;                 /* exact weight from mock */
+  font-variation-settings: "wght" 800;         /* for variable Inter */
+  font-size: 56px;                              /* match mock */
+  line-height: 1.06;
+  letter-spacing: 0.2px;
+  color: #EAF5EF;
+  text-shadow: none !important;                 /* kill any glow */
+  font-synthesis-weight: none;                  /* don't fake bold */
+  font-synthesis-style: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@font-face {
+      font-family: 'Material Symbols Outlined';
+      font-style: normal;
+      font-weight: 400;
+      src: url(https://fonts.gstatic.com/s/materialsymbolsoutlined/v271/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOem.ttf) format('truetype');
+    }
+    .material-symbols-outlined {
+      font-family: 'Material Symbols Outlined';
+      font-weight: normal;
+      font-style: normal;
+      font-size: 24px;
+      line-height: 1;
+      letter-spacing: normal;
+      text-transform: none;
+      display: inline-block;
+      white-space: nowrap;
+      word-wrap: normal;
+      direction: ltr;
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 400;
+      font-display: swap;
+      src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf) format('truetype');
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 500;
+      font-display: swap;
+      src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuI6fMZg.ttf) format('truetype');
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 700;
+      font-display: swap;
+      src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZg.ttf) format('truetype');
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 800;
+      font-display: swap;
+      src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuDyYMZg.ttf) format('truetype');
+    }
+  </style>
 </head>
 <body>
 {% include google-tag-manager-body.html %}


### PR DESCRIPTION
## Summary
- Embed all site stylesheets directly into `index.html`
- Remove Liquid `include_relative` directives to eliminate external CSS imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9a1a4183483209d7459c9f2783d77