### PR TITLE
fix: prevent font swap on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -2425,28 +2425,28 @@ body .hero h1{
       font-family: 'Inter';
       font-style: normal;
       font-weight: 400;
-      font-display: swap;
+      font-display: block;
       src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf) format('truetype');
     }
     @font-face {
       font-family: 'Inter';
       font-style: normal;
       font-weight: 500;
-      font-display: swap;
+      font-display: block;
       src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuI6fMZg.ttf) format('truetype');
     }
     @font-face {
       font-family: 'Inter';
       font-style: normal;
       font-weight: 700;
-      font-display: swap;
+      font-display: block;
       src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZg.ttf) format('truetype');
     }
     @font-face {
       font-family: 'Inter';
       font-style: normal;
       font-weight: 800;
-      font-display: swap;
+      font-display: block;
       src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuDyYMZg.ttf) format('truetype');
     }
   </style>


### PR DESCRIPTION
## Summary
- prevent Inter font from swapping in after paint by loading it in block mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9a9a9ca5883208e374ce2926ab7df