### PR TITLE
Hide empty search results container

### DIFF
--- a/css/elegant-emerald-overrides.css
+++ b/css/elegant-emerald-overrides.css
@@ -35,6 +35,7 @@
     .search-xl:focus-within input::placeholder{color:#d6f5e6}
     body .search-xl input{flex:1;border:0;outline:0;background:transparent;font:500 18px/1.2 'Inter',system-ui,sans-serif;color:#eaf5ef;padding:12px 14px;border-radius:12px}
     .search-xl .search-results{position:absolute;top:100%;left:0;right:0;background:var(--bg2);border:1px solid var(--hair);border-radius:12px;margin-top:4px;box-shadow:var(--shadow);max-height:240px;overflow-y:auto;z-index:100}
+    .search-xl .search-results:empty{display:none}
     .search-xl .search-results a{display:block;padding:8px 12px;color:var(--ink)}
     .search-xl .search-results a:hover{background:rgba(255,255,255,.08)}
     .btn{appearance:none;border:0;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer}

--- a/css/style.css
+++ b/css/style.css
@@ -180,6 +180,10 @@ footer nav a:hover {
   z-index: 1003;
 }
 
+.search-results:empty {
+  display: none;
+}
+
 .search-results a {
   display: block;
   padding: 6px 8px;

--- a/index.html
+++ b/index.html
@@ -360,6 +360,10 @@ footer nav a:hover {
   z-index: 1003;
 }
 
+.search-results:empty {
+  display: none;
+}
+
 .search-results a {
   display: block;
   padding: 6px 8px;


### PR DESCRIPTION
## Summary
- Hide empty search results box using `:empty` CSS rule
- Apply rule in global and theme override styles

## Testing
- `npm test` *(fails: missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b1be3ffc83208c32200c49e13847