### PR TITLE
Align toggle buttons with primary button style

### DIFF
--- a/creators.html
+++ b/creators.html
@@ -57,7 +57,7 @@
     <div class="channel-list"></div>
 
     <div class="video-section">
-      <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+      <button class="channel-toggle btn btn-primary" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
         <span class="label">Channels</span>
       </button>
 

--- a/freepress-old.html
+++ b/freepress-old.html
@@ -71,10 +71,10 @@
     <div class="channel-list"></div>
     <div class="video-section">
       <div class="button-row">
-        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <button class="channel-toggle btn btn-primary" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
+        <button class="details-toggle btn btn-primary" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
           <span class="label">About</span>
         </button>
       </div>

--- a/freepress.html
+++ b/freepress.html
@@ -71,10 +71,10 @@
     <div class="channel-list"></div>
     <div class="video-section">
       <div class="button-row">
-        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <button class="channel-toggle btn btn-primary" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
+        <button class="details-toggle btn btn-primary" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display: none;">
           <span class="label">About</span>
         </button>
       </div>

--- a/livetv.html
+++ b/livetv.html
@@ -72,7 +72,7 @@
   <section class="youtube-section">
     <div class="channel-list"></div>
     <div class="video-section">
-      <button id="toggle-channels" class="channel-toggle" onclick="toggleChannelList()" aria-label="Toggle channel list">
+      <button id="toggle-channels" class="channel-toggle btn btn-primary" onclick="toggleChannelList()" aria-label="Toggle channel list">
         <span class="label">Channels</span>
       </button>
     </div>

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -31,11 +31,11 @@
 
     <div class="video-section">
       <div class="button-row">
-        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <button class="channel-toggle btn btn-primary" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
         <div class="spacer"></div>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
+        <button class="details-toggle btn btn-primary" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
           <span class="label">About</span>
         </button>
       </div>

--- a/media-hub.html
+++ b/media-hub.html
@@ -55,11 +55,11 @@
     <!-- CENTER -->
     <div class="video-section">
       <div class="button-row">
-        <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
+        <button class="channel-toggle btn btn-primary" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle channel list">
           <span class="label">Channels</span>
         </button>
         <div class="spacer"></div>
-        <button class="details-toggle" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
+        <button class="details-toggle btn btn-primary" id="toggle-details" onclick="toggleDetailsList()" aria-label="Toggle details list" style="display:none;">
           <span class="label">About</span>
         </button>
       </div>

--- a/radio.html
+++ b/radio.html
@@ -72,7 +72,7 @@
   <section class="youtube-section">
     <div class="channel-list"></div>
     <div class="video-section">
-      <button class="channel-toggle" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle station list">
+      <button class="channel-toggle btn btn-primary" id="toggle-channels" onclick="toggleChannelList()" aria-label="Toggle station list">
         <span class="label">Stations</span>
       </button>
       <div class="live-player">


### PR DESCRIPTION
## Summary
- Ensure channel and details toggle buttons use `btn btn-primary` classes for consistent styling across pages.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9b75519e883209f3c7c8d15dfdf51