### PR TITLE
Align station scroller width with features

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -263,8 +263,9 @@ section {
 
 .station-scroller-wrap {
   margin-block: 1.5rem;
-  max-width: 960px;
+  max-width: 1200px;
   margin-inline: auto;
+  padding: 0 24px;
 }
 
 .scroller-header {
@@ -377,6 +378,12 @@ section {
 
 .station-scroller .scroll-btn.prev { left: 8px; }
 .station-scroller .scroll-btn.next { right: 8px; }
+
+@media (max-width: 768px) {
+  .station-scroller-wrap {
+    padding: 0 16px;
+  }
+}
 
 @media (prefers-reduced-motion: reduce) {
   .station-scroller .scroller-track {

--- a/index.html
+++ b/index.html
@@ -444,8 +444,9 @@ section {
 
 .station-scroller-wrap {
   margin-block: 1.5rem;
-  max-width: 960px;
+  max-width: 1200px;
   margin-inline: auto;
+  padding: 0 24px;
 }
 
 .scroller-header {
@@ -1855,6 +1856,9 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
   /* Suggestion chips: horizontal scroll */
   .suggest{justify-content:flex-start; overflow-x:auto; padding:0 2px; gap:8px}
   .suggest .chip{white-space:nowrap}
+
+  /* Trending scroller: match feature width */
+  .station-scroller-wrap{padding:0 16px}
 
   /* Feature grid: single column */
   .features{


### PR DESCRIPTION
## Summary
- Increase `.station-scroller-wrap` max-width and add padding so the trending scroller matches the feature grid width
- Add responsive padding for the scroller on small screens

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9badd8bb083208c5b2ce198d5bee8