### PR TITLE
fix: ensure feature section width matches

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
 /* Inter font loaded asynchronously via HTML link tags */
 
 * {
+  box-sizing: border-box;
   transition: background-color 0.3s, color 0.3s, box-shadow 0.3s, transform 0.2s;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);


### PR DESCRIPTION
## Summary
- Apply global `box-sizing: border-box` so the `features` section width matches `index1.html`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9bb38acec83209e0a3ca75b5e6839