### PR TITLE
Handle iframe menu scroll locking from parent

### DIFF
--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -52,6 +52,9 @@
       (detailsList && detailsList.classList.contains("open"));
     document.body.classList.toggle("no-scroll", locked);
     overlay.classList.toggle("is-active", locked);
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ type: "mh-lock", locked }, "*");
+    }
   }
   window.updateScrollLock = updateScrollLock;
 
@@ -93,6 +96,25 @@
 
   let removeChannelFocusTrap = null;
   let removeDetailsFocusTrap = null;
+
+  window.addEventListener("message", (e) => {
+    if (e.data && e.data.type === "mh-close") {
+      let changed = false;
+      if (channelList?.classList.contains("open")) {
+        channelList.classList.remove("open");
+        if (removeChannelFocusTrap) removeChannelFocusTrap();
+        channelToggleBtn?.focus();
+        changed = true;
+      }
+      if (detailsList?.classList.contains("open")) {
+        detailsList.classList.remove("open");
+        if (removeDetailsFocusTrap) removeDetailsFocusTrap();
+        detailsToggleBtn?.focus();
+        changed = true;
+      }
+      if (changed && typeof updateScrollLock === "function") updateScrollLock();
+    }
+  });
 
   function toggleChannelList() {
     if (!channelList || !channelToggleBtn) return;

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,48 @@ if (window.PAKSTREAM?.Flags?.isOn('adsEnabled')) {
   // initAds();
 }
 
+// Cross-iframe scroll lock coordination
+(function () {
+  let overlay = document.getElementById('mh-parent-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'mh-parent-overlay';
+    overlay.className = 'site-overlay';
+    overlay.style.zIndex = '998';
+    document.body.appendChild(overlay);
+  }
+
+  let sourceWindow = null;
+
+  overlay.addEventListener('click', () => {
+    if (sourceWindow) {
+      sourceWindow.postMessage({ type: 'mh-close' }, '*');
+    }
+  });
+
+  window.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'mh-lock') {
+      const locked = !!event.data.locked;
+      document.body.classList.toggle('no-scroll', locked);
+      overlay.classList.toggle('is-active', locked);
+      if (locked) {
+        sourceWindow = event.source;
+        if (sourceWindow && sourceWindow.frameElement) {
+          const frame = sourceWindow.frameElement;
+          frame.style.position = 'relative';
+          frame.style.zIndex = '999';
+          overlay.style.zIndex = '998';
+        }
+      } else {
+        if (sourceWindow && sourceWindow.frameElement) {
+          sourceWindow.frameElement.style.zIndex = '';
+        }
+        sourceWindow = null;
+      }
+    }
+  });
+})();
+
 document.addEventListener('DOMContentLoaded', function () {
   var topBar = document.querySelector('.top-bar');
   var btn = document.querySelector('[data-nav-toggle]');


### PR DESCRIPTION
## Summary
- Notify parent when iframe menus lock scroll, enabling parent overlay
- Add parent overlay that toggles body scroll and relays close events to iframe
- Listen for parent close messages in menu script to hide open menus

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9bd42fcfc8320b2f7ba6bfff09add