### PR TITLE
Improve live badge styling on dark background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1030,20 +1030,34 @@ button:hover,
   display: inline-flex;
   align-items: center;
   margin-top: 4px;
-  padding: 2px 6px;
+  padding: 2px 8px;
   border-radius: 12px;
-  background: var(--error-container);
-  color: var(--error);
+  background: #b71c1c;
+  color: #fff;
   font-size: 0.75rem;
   font-weight: 600;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
 }
 
 .live-badge .dot {
   width: 8px;
   height: 8px;
-  background: var(--error);
+  background: #ff5252;
   border-radius: 50%;
   margin-right: 4px;
+  animation: live-pulse 1.5s infinite;
+}
+
+@keyframes live-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 0.6;
+  }
 }
 
 .not-live-badge {

--- a/index.html
+++ b/index.html
@@ -1113,20 +1113,34 @@ button:hover,
   display: inline-flex;
   align-items: center;
   margin-top: 4px;
-  padding: 2px 6px;
+  padding: 2px 8px;
   border-radius: 12px;
-  background: var(--error-container);
-  color: var(--error);
+  background: #b71c1c;
+  color: #fff;
   font-size: 0.75rem;
   font-weight: 600;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
 }
 
 .live-badge .dot {
   width: 8px;
   height: 8px;
-  background: var(--error);
+  background: #ff5252;
   border-radius: 50%;
   margin-right: 4px;
+  animation: live-pulse 1.5s infinite;
+}
+
+@keyframes live-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 0.6;
+  }
 }
 
 .not-live-badge {


### PR DESCRIPTION
## Summary
- Enhance live badge colors and styling for visibility on dark backgrounds
- Add animated pulse effect for live indicator dot

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9c18d470c8320bf574cfb292a1efd