### PR TITLE
Improve live badge styling on dark background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1030,10 +1030,11 @@ button:hover,
   display: inline-flex;
   align-items: center;
   margin-top: 4px;
-  padding: 2px 6px;
-  border-radius: 12px;
-  background: var(--error-container);
-  color: var(--error);
+  padding: 2px 8px;
+  border: 2px solid currentColor;
+  border-radius: 9999px;
+  background: transparent;
+  color: #ff0000;
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -1041,18 +1042,32 @@ button:hover,
 .live-badge .dot {
   width: 8px;
   height: 8px;
-  background: var(--error);
+  background: currentColor;
   border-radius: 50%;
   margin-right: 4px;
+  animation: live-pulse 1.5s infinite;
+}
+
+@keyframes live-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 0.6;
+  }
 }
 
 .not-live-badge {
   display: inline-flex;
   align-items: center;
   margin-top: 4px;
-  padding: 2px 6px;
-  border-radius: 12px;
-  background: var(--surface-variant);
+  padding: 2px 8px;
+  border: 2px solid currentColor;
+  border-radius: 9999px;
+  background: transparent;
   color: var(--on-surface);
   font-size: 0.75rem;
   font-weight: 600;
@@ -1061,7 +1076,7 @@ button:hover,
 .not-live-badge .dot {
   width: 8px;
   height: 8px;
-  background: var(--on-surface);
+  background: currentColor;
   border-radius: 50%;
   margin-right: 4px;
 }

--- a/index.html
+++ b/index.html
@@ -1113,10 +1113,11 @@ button:hover,
   display: inline-flex;
   align-items: center;
   margin-top: 4px;
-  padding: 2px 6px;
-  border-radius: 12px;
-  background: var(--error-container);
-  color: var(--error);
+  padding: 2px 8px;
+  border: 2px solid currentColor;
+  border-radius: 9999px;
+  background: transparent;
+  color: #ff0000;
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -1124,18 +1125,32 @@ button:hover,
 .live-badge .dot {
   width: 8px;
   height: 8px;
-  background: var(--error);
+  background: currentColor;
   border-radius: 50%;
   margin-right: 4px;
+  animation: live-pulse 1.5s infinite;
+}
+
+@keyframes live-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 0.6;
+  }
 }
 
 .not-live-badge {
   display: inline-flex;
   align-items: center;
   margin-top: 4px;
-  padding: 2px 6px;
-  border-radius: 12px;
-  background: var(--surface-variant);
+  padding: 2px 8px;
+  border: 2px solid currentColor;
+  border-radius: 9999px;
+  background: transparent;
   color: var(--on-surface);
   font-size: 0.75rem;
   font-weight: 600;
@@ -1144,7 +1159,7 @@ button:hover,
 .not-live-badge .dot {
   width: 8px;
   height: 8px;
-  background: var(--on-surface);
+  background: currentColor;
   border-radius: 50%;
   margin-right: 4px;
 }

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -1044,6 +1044,8 @@ async function renderLatestVideosRSS(channelId) {
       if (playPauseLabel) playPauseLabel.textContent = 'play_arrow';
       if (playPauseBtn) playPauseBtn.setAttribute('aria-label', 'Play');
       if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused';
+      if (liveBadge) liveBadge.hidden = true;
+      if (notLiveBadge) notLiveBadge.hidden = false;
       if (currentBtn) {
         const lbl = currentBtn.querySelector('.label'); if (lbl) lbl.textContent = 'play_arrow';
         currentBtn.setAttribute('aria-label', 'Play');
@@ -1054,6 +1056,8 @@ async function renderLatestVideosRSS(channelId) {
       if (playPauseLabel) playPauseLabel.textContent = 'play_arrow';
       if (playPauseBtn) playPauseBtn.setAttribute('aria-label', 'Play');
       if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'none';
+      if (liveBadge) liveBadge.hidden = true;
+      if (notLiveBadge) notLiveBadge.hidden = false;
       if (currentBtn) resetButton(currentBtn);
     });
   }


### PR DESCRIPTION
## Summary
- Swap to transparent background with bright red text and border for live badge
- Use currentColor for pulsing dot to match red border
- Switch back to "Not live" badge when playback pauses or ends
- Match "Not live" badge styling with border and padding to prevent height shifts

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9c18d470c8320bf574cfb292a1efd