### PR TITLE
Limit autoplay to first stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -2096,7 +2096,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
   <!-- Featured cards -->
     <section class="features">
       <div class="feature-card" id="freepress">
-        <iframe src="https://pakstream.com/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=1&list=0&channels=1&about=1" title="Free Press"></iframe>
+        <iframe src="https://pakstream.com/media-hub-embed.html?m=freepress&c=wajahatsaeedkhan&muted=0&list=0&channels=1&about=1" title="Free Press"></iframe>
         <div class="feature-card-content">
           <h3>Free Press</h3>
           <p>Diverse perspectives from Pakistani creators.</p>
@@ -2104,7 +2104,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         </div>
       </div>
       <div class="feature-card" id="radio">
-        <iframe src="https://pakstream.com/media-hub-embed.html?m=radio&c=merafm&muted=1&list=0&channels=1&about=0" title="Mera FM"></iframe>
+        <iframe src="https://pakstream.com/media-hub-embed.html?m=radio&c=merafm&muted=1&autoplay=0&list=0&channels=1&about=0" title="Mera FM"></iframe>
         <div class="feature-card-content">
           <h3>Live Pakistani Radio</h3>
           <p>Stream Mera FM, City FM89, Mast FM & more.</p>
@@ -2112,7 +2112,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         </div>
       </div>
       <div class="feature-card" id="tv">
-        <iframe src="https://pakstream.com/media-hub-embed.html?m=tv&c=geo&muted=1&list=0&channels=1&about=0" title="Geo News"></iframe>
+        <iframe src="https://pakstream.com/media-hub-embed.html?m=tv&c=geo&muted=1&autoplay=0&list=0&channels=1&about=0" title="Geo News"></iframe>
         <div class="feature-card-content">
           <h3>Live News & TV</h3>
           <p>Watch Pakistani news, dramas, and morning shows.</p>
@@ -2120,7 +2120,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         </div>
       </div>
       <div class="feature-card">
-        <iframe src="https://pakstream.com/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&list=0&channels=1&about=0" title="Hum TV"></iframe>
+        <iframe src="https://pakstream.com/media-hub-embed.html?m=creator&c=zeeshanusmani&muted=1&autoplay=0&list=0&channels=1&about=0" title="Hum TV"></iframe>
         <div class="feature-card-content">
           <h3>Trending Creators</h3>
           <p>Drama serials and entertainment shows.</p>
@@ -2128,7 +2128,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         </div>
       </div>
       <div class="feature-card">
-        <iframe src="https://pakstream.com/media-hub-embed.html?m=all&c=aftabiqbal&muted=1&list=0&channels=1&about=0" title="City FM89"></iframe>
+        <iframe src="https://pakstream.com/media-hub-embed.html?m=all&c=aftabiqbal&muted=1&autoplay=0&list=0&channels=1&about=0" title="City FM89"></iframe>
         <div class="feature-card-content">
           <h3>All Streams</h3>
           <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
@@ -2136,7 +2136,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         </div>
       </div>
       <div class="feature-card" id="favorites">
-        <iframe src="https://pakstream.com/media-hub-embed.html?m=favorites&c=imranriazkhan&muted=1&list=0&channels=1&about=0" title="Favorites"></iframe>
+        <iframe src="https://pakstream.com/media-hub-embed.html?m=favorites&c=imranriazkhan&muted=1&autoplay=0&list=0&channels=1&about=0" title="Favorites"></iframe>
         <div class="feature-card-content">
           <h3>Your Favorites</h3>
           <p>Pin your go‑to channels for one‑tap playback.</p>


### PR DESCRIPTION
## Summary
- Add `autoplay` query flag and logic in media hub player
- Disable autoplay on secondary feature streams and allow audio on the first

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9c73937dc8320acb288f77417ab95