### PR TITLE
Make top bar logo link to homepage

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -8,10 +8,10 @@
     <span class="visually-hidden">Toggle menu</span>
     ☰
   </button>
-  <div class="brand">
+  <a class="brand" href="/">
     <div class="logo"></div>
     <h1 class="logo-title">PakStream</h1>
-  </div>
+  </a>
   <nav id="site-nav" class="nav-links site-nav" aria-label="Primary">
     <a href="/media-hub.html">Media Hub</a>
     <a href="/blog.html">Blog</a>

--- a/css/elegant-emerald-overrides.css
+++ b/css/elegant-emerald-overrides.css
@@ -19,7 +19,7 @@
 
     header{position:sticky;top:0;z-index:30;background:linear-gradient(180deg,rgba(11,26,20,.9),rgba(11,26,20,.55) 60%,transparent);backdrop-filter:blur(8px);border-bottom:1px solid var(--hair)}
     .top{max-width:1200px;margin:auto;display:flex;gap:16px;align-items:center;justify-content:space-between;padding:16px 24px}
-    .brand{display:flex;gap:10px;align-items:center}
+    .brand{display:flex;gap:10px;align-items:center;text-decoration:none;color:var(--on-primary)}
     .logo{width:38px;height:38px;border-radius:12px;background:conic-gradient(from 140deg,#23e08c,#0f6b45,#0b1a14);box-shadow:inset 0 0 0 2px #0b1a14,0 8px 20px rgba(0,0,0,.35)}
     .brand h1{font-size:18px;letter-spacing:.3px}
     nav a{color:var(--muted);margin-left:14px}

--- a/css/style.css
+++ b/css/style.css
@@ -83,6 +83,8 @@ body.no-scroll {
   display: flex;
   gap: 10px;
   align-items: center;
+  text-decoration: none;
+  color: var(--on-primary);
 }
 
 .logo {

--- a/index-mine.cleaned.html
+++ b/index-mine.cleaned.html
@@ -102,7 +102,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
 
     header{position:sticky;top:0;z-index:30;background:linear-gradient(180deg,rgba(11,26,20,.9),rgba(11,26,20,.55) 60%,transparent);backdrop-filter:blur(8px);border-bottom:1px solid var(--hair)}
     .top{max-width:1200px;margin:auto;display:flex;gap:16px;align-items:center;justify-content:space-between;padding:16px 24px}
-    .brand{display:flex;gap:10px;align-items:center}
+    .brand{display:flex;gap:10px;align-items:center;text-decoration:none;color:var(--on-primary)}
     .logo{width:38px;height:38px;border-radius:12px;background:conic-gradient(from 140deg,#23e08c,#0f6b45,#0b1a14);box-shadow:inset 0 0 0 2px #0b1a14,0 8px 20px rgba(0,0,0,.35)}
     .brand h1{font-size:18px;letter-spacing:.3px}
     nav a{color:var(--muted);margin-left:14px}

--- a/index.html
+++ b/index.html
@@ -265,6 +265,8 @@ body.no-scroll {
   display: flex;
   gap: 10px;
   align-items: center;
+  text-decoration: none;
+  color: var(--on-primary);
 }
 
 .logo {

--- a/index1.html
+++ b/index1.html
@@ -24,7 +24,7 @@
 
     header{position:sticky;top:0;z-index:30;background:linear-gradient(180deg,rgba(11,26,20,.9),rgba(11,26,20,.55) 60%,transparent);backdrop-filter:blur(8px);border-bottom:1px solid var(--hair)}
     .top{max-width:1200px;margin:auto;display:flex;gap:16px;align-items:center;justify-content:space-between;padding:16px 24px}
-    .brand{display:flex;gap:10px;align-items:center}
+    .brand{display:flex;gap:10px;align-items:center;text-decoration:none;color:var(--on-primary)}
     .logo{width:38px;height:38px;border-radius:12px;background:conic-gradient(from 140deg,#23e08c,#0f6b45,#0b1a14);box-shadow:inset 0 0 0 2px #0b1a14,0 8px 20px rgba(0,0,0,.35)}
     .brand h1{font-size:18px;letter-spacing:.3px}
     nav a{color:var(--muted);margin-left:14px}


### PR DESCRIPTION
## Summary
- Wrap site logo and name in a brand anchor so clicking the top-bar icon navigates home.
- Add link styling rules for the brand to preserve color and remove underline.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9c7f9efb88320bbc02ac9086a0a50