### PR TITLE
Open channel list on mobile when switching tabs

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -1133,6 +1133,16 @@ async function renderLatestVideosRSS(channelId) {
     history.replaceState(null, "", "?" + params.toString());
     updateActiveUI();
     renderList(searchEl ? (searchEl.value || "") : "");
+    if (window.innerWidth <= 768) {
+      const channelList = document.querySelector(".channel-list");
+      if (
+        channelList &&
+        !channelList.classList.contains("open") &&
+        typeof toggleChannelList === "function"
+      ) {
+        toggleChannelList();
+      }
+    }
   }));
   if (searchEl) {
     searchEl.addEventListener("input", e => renderList(e.target.value));


### PR DESCRIPTION
## Summary
- Automatically open the channel list on mobile when a mode tab (Live TV, Free Press, etc.) is selected.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9ca20a9a08320a370a0eb14672910