### PR TITLE
Link feature cards to open streams in Media Hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -2093,7 +2093,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         <div class="feature-card-content">
           <h3>Free Press</h3>
           <p>Diverse perspectives from Pakistani creators.</p>
-          <a href="#">Explore</a>
+          <a href="/media-hub.html?m=freepress&c=wajahatsaeedkhan">Explore</a>
         </div>
       </div>
       <div class="feature-card" id="radio">
@@ -2101,7 +2101,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         <div class="feature-card-content">
           <h3>Live Pakistani Radio</h3>
           <p>Stream Mera FM, City FM89, Mast FM & more.</p>
-          <a href="#">Listen Live</a>
+          <a href="/media-hub.html?m=radio&c=merafm">Listen Live</a>
         </div>
       </div>
       <div class="feature-card" id="tv">
@@ -2109,7 +2109,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         <div class="feature-card-content">
           <h3>Live News & TV</h3>
           <p>Watch Pakistani news, dramas, and morning shows.</p>
-          <a href="#">Watch Now</a>
+          <a href="/media-hub.html?m=tv&c=geo">Watch Now</a>
         </div>
       </div>
       <div class="feature-card">
@@ -2117,7 +2117,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         <div class="feature-card-content">
           <h3>Trending Creators</h3>
           <p>Drama serials and entertainment shows.</p>
-          <a href="#">Watch Now</a>
+          <a href="/media-hub.html?m=creator&c=zeeshanusmani">Watch Now</a>
         </div>
       </div>
       <div class="feature-card">
@@ -2125,7 +2125,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         <div class="feature-card-content">
           <h3>All Streams</h3>
           <p>Explore the full library of Pakistani TV, radio, and creator channels, all organized in one place for easy browsing.</p>
-          <a href="#">Listen Now</a>
+          <a href="/media-hub.html?m=all&c=aftabiqbal">Listen Now</a>
         </div>
       </div>
       <div class="feature-card" id="favorites">
@@ -2133,7 +2133,7 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
         <div class="feature-card-content">
           <h3>Your Favorites</h3>
           <p>Pin your go‑to channels for one‑tap playback.</p>
-          <a href="#">Open Favorites</a>
+          <a href="/media-hub.html?m=favorites&c=imranriazkhan">Open Favorites</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Route Explore/Listen/Watch buttons on homepage to Media Hub with matching mode and channel
- Restore original stream data after running build script

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9caa4113c83209ac9f6f89b58ff2e