### PR TITLE
Remove unused hero image preload

### DIFF
--- a/index-mine.cleaned.html
+++ b/index-mine.cleaned.html
@@ -27,7 +27,6 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
 <link href="/favicon.ico" rel="icon" type="image/x-icon"/>
 <link href="/manifest.webmanifest" rel="manifest"/>
 <meta content="#ffffff" name="theme-color"/>
-<link as="image" fetchpriority="high" href="/images/pakistan-abstract-380.webp" imagesizes="(max-width: 420px) 80vw, 380px" imagesrcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w" rel="preload"/>
 <!-- Open Graph / Facebook -->
 <meta content="website" property="og:type"/>
 <meta content="https://pakstream.com/" property="og:url"/>

--- a/index.html
+++ b/index.html
@@ -27,12 +27,6 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
 
-  <link rel="preload" as="image"
-    href="/images/pakistan-abstract-380.webp"
-    imagesrcset="/images/pakistan-abstract-380.webp 380w, /images/pakistan-abstract-760.webp 760w"
-    imagesizes="(max-width: 420px) 80vw, 380px"
-    fetchpriority="high">
-
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://pakstream.com/">


### PR DESCRIPTION
## Summary
- drop leftover `<link rel="preload">` for the removed hero image on the landing page
- clean up matching preload in the cleaned index variant

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9ce90009c832084d9395244370dcd