### PR TITLE
Center top-bar search field

### DIFF
--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -4,14 +4,17 @@
 <link rel="apple-touch-icon" href="/images/icons/icon-192-maskable.png">
 <div class="site-overlay" hidden data-overlay></div>
 <header class="top-bar">
-  <button class="nav-toggle" aria-controls="site-nav" aria-expanded="false" data-nav-toggle>
-    <span class="visually-hidden">Toggle menu</span>
-    ☰
-  </button>
-  <a class="brand" href="/">
-    <div class="logo"></div>
-    <h1 class="logo-title">PakStream</h1>
-  </a>
+  <div class="top-bar-left">
+    <button class="nav-toggle" aria-controls="site-nav" aria-expanded="false" data-nav-toggle>
+      <span class="visually-hidden">Toggle menu</span>
+      ☰
+    </button>
+    <a class="brand" href="/">
+      <div class="logo"></div>
+      <h1 class="logo-title">PakStream</h1>
+    </a>
+  </div>
+  <div class="top-bar-center"></div>
   <nav id="site-nav" class="nav-links site-nav" aria-label="Primary">
     <a href="/media-hub.html">Media Hub</a>
     <a href="/blog.html">Blog</a>

--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,12 @@ body.no-scroll {
   cursor: pointer;
 }
 
+.top-bar-left {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
 .brand {
   display: flex;
   gap: 10px;
@@ -95,12 +101,19 @@ body.no-scroll {
   box-shadow: inset 0 0 0 2px #0b1a14, 0 8px 20px rgba(0, 0, 0, 0.35);
 }
 
+.top-bar-center {
+  flex: 2;
+  display: flex;
+  justify-content: center;
+}
+
 .top-bar nav {
-  flex-grow: 1;
+  flex: 1;
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
   transition: transform 0.4s ease-in-out;
+  justify-content: flex-end;
 }
 
 .top-bar nav a {
@@ -131,10 +144,10 @@ footer nav a:hover {
 
 
 .search-form {
-  margin-left: 16px;
+  margin: 0 16px;
   position: relative;
   flex: 1;
-  max-width: 300px;
+  max-width: 500px;
   min-width: 0;
 }
 
@@ -163,7 +176,7 @@ footer nav a:hover {
 
 @media (max-width: 600px) {
   .search-form {
-    margin-left: 8px;
+    margin: 0 8px;
     max-width: none;
   }
   .logo-title {
@@ -1315,8 +1328,6 @@ table tbody tr.favorite {
     display: none;
   }
   .top-bar nav {
-    margin-left: auto;
-    justify-content: flex-end;
     flex-wrap: nowrap;
   }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -51,7 +51,12 @@ document.addEventListener('DOMContentLoaded', function () {
       if (logoTitle) logoTitle.removeAttribute('hidden');
     });
 
-    topBar.appendChild(searchForm);
+    var center = topBar.querySelector('.top-bar-center');
+    if (center) {
+      center.appendChild(searchForm);
+    } else {
+      topBar.appendChild(searchForm);
+    }
   } else if (searchForm) {
     input = searchForm.querySelector('#search-input') || searchForm.querySelector('input[type="search"]');
     results = searchForm.querySelector('#search-results') || searchForm.querySelector('.search-results');


### PR DESCRIPTION
## Summary
- Add `top-bar-left` and `top-bar-center` containers to structure header and provide a central mount point for search
- Adjust CSS flex layout and search-form margins to center the search bar and align navigation to the right
- Update JS to insert the search form into the new center container

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9d7610e288320a68438dee8230481