### PR TITLE
feat: personalize channel search placeholder

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -331,6 +331,10 @@ document.addEventListener("DOMContentLoaded", async () => {
       const isActive = t.dataset.mode === mode;
       t.classList.toggle("active", isActive);
       t.setAttribute("aria-pressed", isActive ? "true" : "false");
+      if (isActive && searchEl) {
+        const tabName = t.textContent.trim().toLowerCase();
+        searchEl.placeholder = `Search ${tabName}...`;
+      }
     });
 
     const videoPlaying = playerIF && playerIF.src && playerIF.src !== "about:blank";

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -24,7 +24,7 @@
     <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">
         <div class="search-wrap">
-          <input id="mh-search-input" type="text" placeholder="Search…" />
+          <input id="mh-search-input" type="text" placeholder="Search all..." />
         </div>
       </div>
     </div>

--- a/media-hub.html
+++ b/media-hub.html
@@ -46,7 +46,7 @@
       <!-- NEW: search at the top of left menu -->
       <div class="left-rail-header">
         <div class="search-wrap">
-          <input id="mh-search-input" type="text" placeholder="Search…" />
+          <input id="mh-search-input" type="text" placeholder="Search all..." />
         </div>
       </div>
       <!-- list gets injected here -->


### PR DESCRIPTION
## Summary
- Personalize channel list search placeholder with the active tab name
- Default search placeholders in Media Hub pages now start with "Search all..."

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9d98a1de0832097e019f7908d49cc