### PR TITLE
fix: maintain search focus on autoplay

### DIFF
--- a/js/youtube.js
+++ b/js/youtube.js
@@ -5,6 +5,10 @@
 
   const YT_IFRAME_SRC = 'https://www.youtube.com/iframe_api';
   let apiReady = false, pending = [];
+  let lastFocusedEl = null;
+  document.addEventListener('focusin', (e) => {
+    lastFocusedEl = e.target;
+  });
 
   function loadYT() {
     if (window.YT && window.YT.Player) { apiReady = true; flush(); return; }
@@ -117,7 +121,19 @@
             // Hide any previous error overlay once the player state changes
             try { window.PAKSTREAM?.ErrorOverlay?.hide(container); } catch {}
             // 1 = playing, 2 = paused, 0 = ended
-            if (e.data === 1) { SS.play(id); container?.classList.add('is-playing'); }
+            if (e.data === 1) {
+              SS.play(id);
+              container?.classList.add('is-playing');
+              if (
+                document.activeElement === iframe &&
+                lastFocusedEl &&
+                lastFocusedEl !== iframe &&
+                lastFocusedEl.isConnected &&
+                typeof lastFocusedEl.focus === 'function'
+              ) {
+                lastFocusedEl.focus({ preventScroll: true });
+              }
+            }
             if (e.data === 2) { container?.classList.remove('is-playing'); }
             if (e.data === 0) { container?.classList.remove('is-playing'); if (SS.getCurrentId() === id) SS.stopAll(null); }
           },


### PR DESCRIPTION
## Summary
- keep last focused element when YouTube autoplay steals focus

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9dba234948320bf7f36a90ea9d992