### PR TITLE
fix: allow top bar navigation when menu open

### DIFF
--- a/js/leftmenu.js
+++ b/js/leftmenu.js
@@ -124,8 +124,10 @@
       !channelList.contains(e.target) &&
       !channelToggleBtn.contains(e.target)
     ) {
-      e.preventDefault();
-      e.stopPropagation();
+      if (!e.target.closest(".top-bar")) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
       channelList.classList.remove("open");
       if (typeof updateScrollLock === "function") updateScrollLock();
       if (removeChannelFocusTrap) removeChannelFocusTrap();
@@ -226,8 +228,10 @@
       !detailsList.contains(e.target) &&
       !detailsToggleBtn.contains(e.target)
     ) {
-      e.preventDefault();
-      e.stopPropagation();
+      if (!e.target.closest(".top-bar")) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
       detailsList.classList.remove("open");
       if (typeof updateScrollLock === "function") updateScrollLock();
       if (removeDetailsFocusTrap) removeDetailsFocusTrap();


### PR DESCRIPTION
## Summary
- allow brand and other top bar links to navigate immediately even when channel or details menu is open

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9dde9ca608320aac15bcf753b329f