### PR TITLE
Align text styling across pages with index design

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,16 +67,13 @@
   }
   </script>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/index.css">
   <link rel="stylesheet" href="/css/ads.css">
   <link rel="stylesheet" href="/assets/css/carousel.css">
   <link rel="stylesheet" href="/css/toast.css">
   <link rel="stylesheet" href="/assets/css/mh-lite.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap">
   
 </head>
 <body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -56,14 +56,11 @@
   }
   </script>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/index.css">
   <link rel="stylesheet" href="/css/ads.css">
   <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   
 <link rel="manifest" href="/manifest.webmanifest" type="application/manifest+json">
 <meta name="theme-color" content="#ffffff">

--- a/media-hub.html
+++ b/media-hub.html
@@ -13,18 +13,15 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <title>PakStream Media Hub</title>
   <meta name="description" content="PakStream Media Hub - Live TV, Free Press, Radio and Creators in one place." />
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
-  <link rel="stylesheet" href="/css/style.css" />
-  <link rel="stylesheet" href="/css/theme.css" />
+  <link rel="stylesheet" href="/css/index.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link rel="stylesheet" href="/assets/css/carousel.css" />
   <link rel="stylesheet" href="/css/toast.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
 </head>
 <body>
   <!-- Top bar (same as site) -->


### PR DESCRIPTION
## Summary
- use index.css in default and post layouts for consistent top-bar typography
- simplify media hub head links, removing redundant fonts and theme styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9e20b1d0c83209ec52db4b2b101c4