### PR TITLE
Add stream checker page

### DIFF
--- a/stream-checker.html
+++ b/stream-checker.html
@@ -1,0 +1,71 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include google-tag-manager-head.html %}
+  <meta charset="UTF-8">
+  <title>PakStream - Stream Checker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Automated checker for PakStream streams.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  {% include google-tag-manager-body.html %}
+  {% include top-bar.html %}
+    <main class="container">
+      <h2>Stream status</h2>
+      <p id="progress"></p>
+      <pre id="log">Loading…</pre>
+    </main>
+    <script>
+    async function testStream(url, type) {
+    const el = document.createElement(type === 'audio' ? 'audio' : 'video');
+    el.src = url;
+    el.muted = true;
+    el.playsInline = true;
+    return new Promise(resolve => {
+      const timer = setTimeout(() => resolve(false), 8000);
+      el.addEventListener('playing', () => { clearTimeout(timer); resolve(true); }, { once: true });
+      el.addEventListener('error', () => { clearTimeout(timer); resolve(false); }, { once: true });
+      el.play().catch(() => { clearTimeout(timer); resolve(false); });
+    });
+  }
+  (async () => {
+    const log = document.getElementById('log');
+    const progress = document.getElementById('progress');
+    try {
+      const res = await fetch('/all_streams.json');
+      const data = await res.json();
+      const total = data.items.length;
+      let checked = 0;
+      progress.textContent = `Checked 0 of ${total} streams`;
+      const results = [];
+      for (const item of data.items) {
+        const endpoint = item.endpoints && item.endpoints[0];
+        if (!endpoint) {
+          results.push(`${item.name}: offline`);
+        } else {
+          const type = item.platform === 'audio' ? 'audio' : 'video';
+          const ok = await testStream(endpoint.url, type);
+          results.push(`${item.name}: ${ok ? 'online' : 'offline'}`);
+        }
+        checked++;
+        progress.textContent = `Checked ${checked} of ${total} streams (${total - checked} remaining)`;
+      }
+      progress.textContent = `Finished checking ${total} streams`;
+      log.textContent = results.join('\n');
+    } catch (err) {
+      progress.textContent = '';
+      log.textContent = 'Error loading stream list.';
+      console.error(err);
+    }
+  })();
+    </script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add a simple page that fetches all_streams.json and tests each stream's playback
- show progress of how many streams have been checked and how many remain

## Testing
- `npm run build:data`
- `npx -y htmlhint stream-checker.html`


------
https://chatgpt.com/codex/tasks/task_e_68a9e3a892608320bf2be418d9c1a21b