### PR TITLE
fix: prevent search box from resizing on focus

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -274,10 +274,6 @@ footer nav a:hover {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-link) 25%, transparent), 0 10px 24px rgba(0,0,0,.45);
 }
 
-.search-form.active {
-  max-width: none;
-}
-
 @media (max-width: 600px) {
   .search-form {
     margin: 0 8px;

--- a/css/style.css
+++ b/css/style.css
@@ -170,10 +170,6 @@ footer nav a:hover {
               0 10px 24px rgba(0, 0, 0, 0.45);
 }
 
-.search-form.active {
-  max-width: none;
-}
-
 @media (max-width: 600px) {
   .search-form {
     margin: 0 8px;


### PR DESCRIPTION
## Summary
- keep top bar search width consistent by removing `.search-form.active` rule

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68a9e86aa28883209f61e42f7e46e210