### PR TITLE
fix: keep top bar items in one line on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,7 +82,7 @@ body.no-scroll {
 .top-bar-left {
   display: flex;
   align-items: center;
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .brand {


### PR DESCRIPTION
## Summary
- prevent top-bar left section from shrinking so the hamburger and logo stay on one line

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9e8e602e48320b7b6be93ac8699b5