### PR TITLE
Center top bar search bar

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -191,6 +191,12 @@ body.no-scroll {
   cursor: pointer;
 }
 
+.top-bar-left {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
 .brand {
   display: flex;
   gap: 10px;
@@ -208,11 +214,12 @@ body.no-scroll {
 }
 
 .top-bar nav {
-  flex-grow: 1;
+  flex: 1;
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
   transition: transform 0.4s ease-in-out;
+  justify-content: flex-end;
 }
 
 .top-bar nav a {
@@ -285,6 +292,25 @@ footer nav a:hover {
   }
   .logo-title {
     display: none;
+  }
+}
+
+@media (min-width: 600px) {
+  .top-bar-left,
+  .top-bar nav {
+    flex: 0 0 auto;
+  }
+
+  .top-bar nav {
+    margin-left: auto;
+  }
+
+  .top-bar-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 500px;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -102,7 +102,7 @@ body.no-scroll {
 }
 
 .top-bar-center {
-  flex: 2;
+  flex: 1;
   display: flex;
   justify-content: center;
 }
@@ -144,9 +144,9 @@ footer nav a:hover {
 
 
 .search-form {
-  margin: 0 16px;
+  margin: 0 auto;
   position: relative;
-  flex: 1;
+  width: 100%;
   max-width: 500px;
   min-width: 0;
 }
@@ -181,6 +181,25 @@ footer nav a:hover {
   }
   .logo-title {
     display: none;
+  }
+}
+
+@media (min-width: 600px) {
+  .top-bar-left,
+  .top-bar nav {
+    flex: 0 0 auto;
+  }
+
+  .top-bar nav {
+    margin-left: auto;
+  }
+
+  .top-bar-center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 500px;
   }
 }
 


### PR DESCRIPTION
## Summary
- scope left and right sections to their content so the top-bar search form can sit in the middle
- absolutely center the search container at wider breakpoints for consistent alignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9e71b96448320a8253dc3e1c5791b