### PR TITLE
fix: keep search input focused after first click

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -84,6 +84,18 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // Ensure the search input keeps focus even if other scripts steal it
+    function ensureSearchFocus(e) {
+      if (document.activeElement !== input) {
+        if (e) e.preventDefault();
+        setTimeout(function () {
+          input.focus();
+        }, 0);
+      }
+    }
+    input.addEventListener('mousedown', ensureSearchFocus);
+    input.addEventListener('touchstart', ensureSearchFocus, { passive: false });
+
     input.addEventListener('input', function () {
       var q = input.value.trim().toLowerCase();
       results.innerHTML = '';


### PR DESCRIPTION
## Summary
- ensure search bar retains focus even when other scripts attempt to steal it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9ebd4b2f8832084690e026c97eecd