### PR TITLE
Add stream checker page

### DIFF
--- a/stream-checker.html
+++ b/stream-checker.html
@@ -1,0 +1,124 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include google-tag-manager-head.html %}
+  <meta charset="UTF-8">
+  <title>PakStream - Stream Checker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Automated checker for PakStream streams.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  {% include google-tag-manager-body.html %}
+  {% include top-bar.html %}
+    <main class="container">
+      <h2>Stream status</h2>
+      <p id="progress"></p>
+      <pre id="log">Loading…</pre>
+    </main>
+    <script>
+    async function testMediaStream(url, type) {
+      const el = document.createElement(type === 'audio' ? 'audio' : 'video');
+      el.src = url;
+      el.muted = true;
+      el.playsInline = true;
+      return new Promise(resolve => {
+        const cleanup = (result) => {
+          clearTimeout(timer);
+          // stop and release the stream so only one plays at a time
+          el.pause();
+          el.removeAttribute('src');
+          el.load();
+          resolve(result);
+        };
+        const timer = setTimeout(() => cleanup(false), 8000);
+        el.addEventListener('playing', () => cleanup(true), { once: true });
+        el.addEventListener('error', () => cleanup(false), { once: true });
+        el.play().catch(() => cleanup(false));
+      });
+    }
+
+    function loadYouTubeAPI() {
+      if (window.YT && YT.Player) return Promise.resolve();
+      return new Promise(resolve => {
+        const tag = document.createElement('script');
+        tag.src = 'https://www.youtube.com/iframe_api';
+        document.head.appendChild(tag);
+        window.onYouTubeIframeAPIReady = () => resolve();
+      });
+    }
+
+    async function testYouTubeStream(url) {
+      await loadYouTubeAPI();
+      return new Promise(resolve => {
+        const iframe = document.createElement('iframe');
+        iframe.style.display = 'none';
+        const sep = url.includes('?') ? '&' : '?';
+        iframe.src = `${url}${sep}autoplay=1&mute=1&enablejsapi=1&origin=${location.origin}`;
+        document.body.appendChild(iframe);
+        const player = new YT.Player(iframe, {
+          events: {
+            onReady: () => player.playVideo(),
+            onStateChange: (e) => {
+              if (e.data === YT.PlayerState.PLAYING) cleanup(true);
+            },
+            onError: () => cleanup(false)
+          }
+        });
+        const timer = setTimeout(() => cleanup(false), 8000);
+        function cleanup(result) {
+          clearTimeout(timer);
+          player.destroy();
+          iframe.remove();
+          resolve(result);
+        }
+      });
+    }
+  (async () => {
+    const log = document.getElementById('log');
+    const progress = document.getElementById('progress');
+    try {
+      const res = await fetch('/all_streams.json');
+      const data = await res.json();
+      const total = data.items.length;
+      let checked = 0;
+      progress.textContent = `Checked 0 of ${total} streams`;
+      const results = [];
+      for (const item of data.items) {
+        const endpoint = item.endpoints && item.endpoints[0];
+        results.push(`Checking ${item.name}...`);
+        log.textContent = results.join('\n');
+        if (!endpoint) {
+          results[results.length - 1] = `${item.name}: offline`;
+        } else {
+          let ok = false;
+          if (item.platform === 'youtube') {
+            ok = await testYouTubeStream(endpoint.url);
+          } else {
+            const type = item.platform === 'audio' ? 'audio' : 'video';
+            ok = await testMediaStream(endpoint.url, type);
+          }
+          results[results.length - 1] = `${item.name}: ${ok ? 'online' : 'offline'}`;
+        }
+        checked++;
+        progress.textContent = `Checked ${checked} of ${total} streams (${total - checked} remaining)`;
+        log.textContent = results.join('\n');
+      }
+      progress.textContent = `Finished checking ${total} streams`;
+      log.textContent = results.join('\n');
+    } catch (err) {
+      progress.textContent = '';
+      log.textContent = 'Error loading stream list.';
+      console.error(err);
+    }
+  })();
+    </script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add a simple page that fetches all_streams.json and tests each stream's playback
- show progress of how many streams have been checked
- log each stream as it's tested and close media elements after checking to prevent multiple streams staying open
- use the YouTube IFrame API to verify YouTube endpoints

## Testing
- `npm run build:data`
- `npx -y htmlhint stream-checker.html`


------
https://chatgpt.com/codex/tasks/task_e_68a9e3a892608320bf2be418d9c1a21b