### PR TITLE
Set blog post link color to white

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -547,14 +547,14 @@ section {
 }
 
 .blog-post-item a {
-  color: var(--primary);
+  color: #fff;
   text-decoration: none;
   font-weight: 500;
 }
 
 .blog-post-item a:hover {
   text-decoration: underline;
-  color: var(--hover-link);
+  color: #e0e0e0;
 }
 
 .blog-post-item .post-date {

--- a/css/style.css
+++ b/css/style.css
@@ -535,14 +535,14 @@ section {
 }
 
 .blog-post-item a {
-  color: var(--primary);
+  color: #fff;
   text-decoration: none;
   font-weight: 500;
 }
 
 .blog-post-item a:hover {
   text-decoration: underline;
-  color: var(--hover-link);
+  color: #e0e0e0;
 }
 
 .blog-post-item .post-date {


### PR DESCRIPTION
## Summary
- Improve readability of blog post links by switching them to white
- Adjust hover color for blog post links to a light gray

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9f5c32c748320824776b3aeebded0