### PR TITLE
Set blog post link color to white with accent hover

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -547,7 +547,7 @@ section {
 }
 
 .blog-post-item a {
-  color: var(--primary);
+  color: #fff;
   text-decoration: none;
   font-weight: 500;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -535,7 +535,7 @@ section {
 }
 
 .blog-post-item a {
-  color: var(--primary);
+  color: #fff;
   text-decoration: none;
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- Keep blog post link text white for better readability
- Restore theme accent color on hover so links retain their original behavior

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9f5c32c748320824776b3aeebded0