### PR TITLE
Align content width across pages

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -345,6 +345,12 @@ footer nav a:hover {
 /* The rest of the existing style.css remains the same... */
 
 
+main {
+  max-width: 960px;
+  margin: 20px auto;
+  padding: 0 16px;
+}
+
 /* Generic sections */
 section {
   background: var(--surface);
@@ -1464,8 +1470,15 @@ footer nav a:hover {
 }
 
 .ad-container {
-  margin: 20px 0;
+  margin: 20px auto;
   text-align: center;
+  max-width: 960px;
+}
+
+.source-note {
+  max-width: 960px;
+  margin: 20px auto;
+  padding: 0 16px;
 }
 
 #stream-list {

--- a/css/style.css
+++ b/css/style.css
@@ -234,6 +234,12 @@ footer nav a:hover {
 /* The rest of the existing style.css remains the same... */
 
 
+main {
+  max-width: 960px;
+  margin: 20px auto;
+  padding: 0 16px;
+}
+
 /* Generic sections */
 section {
   background: var(--surface);
@@ -1450,8 +1456,15 @@ footer nav a:hover {
 }
 
 .ad-container {
-  margin: 20px 0;
+  margin: 20px auto;
   text-align: center;
+  max-width: 960px;
+}
+
+.source-note {
+  max-width: 960px;
+  margin: 20px auto;
+  padding: 0 16px;
 }
 
 #stream-list {


### PR DESCRIPTION
## Summary
- Limit `<main>` element width and add padding for consistent layout
- Center ads and source notes with matching max-width

## Testing
- ⚠️ `npm test` *(missing script: test)*
- ✅ `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68a9f674335083208c80d5301fd21910