### PR TITLE
style: match media hub background to hero

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -7,6 +7,7 @@
   grid-template-areas:
     "tabs tabs tabs"
     "left center right";
+  background: radial-gradient(circle at top,var(--bg2),var(--bg) 80%);
 }
 .media-hub-section.channels-collapsed {
   grid-template-columns: 72px 1fr 300px;


### PR DESCRIPTION
## Summary
- apply radial gradient background to `.media-hub-section` matching the hero section

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9fa8bbdb48320b1e3f24ef6be4c6a