### PR TITLE
Add stream checker page

### DIFF
--- a/stream-checker.html
+++ b/stream-checker.html
@@ -1,0 +1,150 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include google-tag-manager-head.html %}
+  <meta charset="UTF-8">
+  <title>PakStream - Stream Checker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Automated checker for PakStream streams.">
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="/css/theme.css">
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  {% include google-tag-manager-body.html %}
+  {% include top-bar.html %}
+    <main class="container">
+      <h2>Stream status</h2>
+      <p id="progress"></p>
+      <pre id="log">Loading…</pre>
+    </main>
+    <script>
+    async function testMediaStream(url, type) {
+      const el = document.createElement(type === 'audio' ? 'audio' : 'video');
+      el.src = url;
+      el.muted = true;
+      el.playsInline = true;
+      return new Promise(resolve => {
+        const cleanup = (result) => {
+          clearTimeout(timer);
+          // stop and release the stream so only one plays at a time
+          el.pause();
+          el.removeAttribute('src');
+          el.load();
+          resolve(result);
+        };
+        const timer = setTimeout(() => cleanup(false), 8000);
+        el.addEventListener('playing', () => cleanup(true), { once: true });
+        el.addEventListener('error', () => cleanup(false), { once: true });
+        el.play().catch(() => cleanup(false));
+      });
+    }
+
+    function loadYouTubeAPI() {
+      if (window.YT && YT.Player) return Promise.resolve();
+      return new Promise(resolve => {
+        const tag = document.createElement('script');
+        tag.src = 'https://www.youtube.com/iframe_api';
+        document.head.appendChild(tag);
+        window.onYouTubeIframeAPIReady = () => resolve();
+      });
+    }
+
+    async function testYouTubeStream(url) {
+      await loadYouTubeAPI();
+      return new Promise(resolve => {
+        const iframe = document.createElement('iframe');
+        iframe.style.display = 'none';
+        const sep = url.includes('?') ? '&' : '?';
+        iframe.src = `${url}${sep}autoplay=1&mute=1&enablejsapi=1&origin=${location.origin}`;
+        document.body.appendChild(iframe);
+        const player = new YT.Player(iframe, {
+          events: {
+            onReady: () => player.playVideo(),
+            onStateChange: (e) => {
+              if (e.data === YT.PlayerState.PLAYING) cleanup(true);
+            },
+            onError: () => cleanup(false)
+          }
+        });
+        const timer = setTimeout(() => cleanup(false), 8000);
+        function cleanup(result) {
+          clearTimeout(timer);
+          player.destroy();
+          iframe.remove();
+          resolve(result);
+        }
+      });
+    }
+
+    function youtubeUploadsId(cid) {
+      return cid && cid.startsWith('UC') ? 'UU' + cid.slice(2) : null;
+    }
+
+    function buildYouTubeUrl(item) {
+      const endpoints = item.endpoints || [];
+      const emb = endpoints.find(e => e.kind === 'embed' && e.provider === 'youtube');
+      if (emb) return emb.url;
+      const channelId = item.ids && item.ids.youtube_channel_id;
+      const upl = youtubeUploadsId(channelId);
+      if (upl) {
+        return `https://www.youtube-nocookie.com/embed/videoseries?list=${upl}`;
+      } else if (channelId) {
+        return `https://www.youtube-nocookie.com/embed/live_stream?channel=${channelId}`;
+      }
+      const ep = endpoints.find(e => e.provider === 'youtube' && e.url);
+      if (ep && /watch\?v=/.test(ep.url)) {
+        try {
+          const v = new URL(ep.url).searchParams.get('v');
+          if (v) return `https://www.youtube-nocookie.com/embed/${v}`;
+        } catch {}
+      }
+      return null;
+    }
+  (async () => {
+    const log = document.getElementById('log');
+    const progress = document.getElementById('progress');
+    try {
+      const res = await fetch('/all_streams.json');
+      const data = await res.json();
+      const total = data.items.length;
+      let checked = 0;
+      progress.textContent = `Checked 0 of ${total} streams`;
+      const results = [];
+      for (const item of data.items) {
+        results.push(`Checking ${item.name}...`);
+        log.textContent = results.join('\n');
+        let url = null;
+        let ok = false;
+        if (item.platform === 'youtube') {
+          url = buildYouTubeUrl(item);
+          ok = url ? await testYouTubeStream(url) : false;
+        } else {
+          const endpoint = (item.endpoints || []).find(e => e.url);
+          url = endpoint && endpoint.url;
+          if (url) {
+            const type = item.platform === 'audio' ? 'audio' : 'video';
+            ok = await testMediaStream(url, type);
+          }
+        }
+        results[results.length - 1] = `${item.name}: ${ok ? 'online' : 'offline'}`;
+        checked++;
+        progress.textContent = `Checked ${checked} of ${total} streams (${total - checked} remaining)`;
+        log.textContent = results.join('\n');
+      }
+      progress.textContent = `Finished checking ${total} streams`;
+      log.textContent = results.join('\n');
+    } catch (err) {
+      progress.textContent = '';
+      log.textContent = 'Error loading stream list.';
+      console.error(err);
+    }
+  })();
+    </script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add a simple page that fetches all_streams.json and tests each stream's playback
- show progress of how many streams have been checked
- log each stream as it's tested and close media elements after checking to prevent multiple streams staying open
- use the YouTube IFrame API to verify YouTube endpoints
- build YouTube embed URLs the same way media-hub does to ensure correct links are tested

## Testing
- `npm run build:data`
- `npx -y htmlhint stream-checker.html`


------
https://chatgpt.com/codex/tasks/task_e_68a9e3a892608320bf2be418d9c1a21b