### PR TITLE
style: match media hub and blog backgrounds to hero

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -531,6 +531,9 @@ section {
 }
 
 /* Blog list styling */
+.blog-list {
+  background: radial-gradient(circle at top,var(--bg2),var(--bg) 80%);
+}
 .blog-list ul {
   list-style: none;
   margin: 0;

--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -7,6 +7,7 @@
   grid-template-areas:
     "tabs tabs tabs"
     "left center right";
+  background: radial-gradient(circle at top,var(--bg2),var(--bg) 80%);
 }
 .media-hub-section.channels-collapsed {
   grid-template-columns: 72px 1fr 300px;

--- a/css/style-org.css
+++ b/css/style-org.css
@@ -519,6 +519,9 @@ section {
 }
 
 /* Blog list styling */
+.blog-list {
+  background: radial-gradient(circle at top,var(--bg2),var(--bg) 80%);
+}
 .blog-list ul {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- apply radial gradient background to `.media-hub-section` matching the hero section
- apply radial gradient background to `.blog-list` for visual consistency with hero and media hub

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9fa8bbdb48320b1e3f24ef6be4c6a