### PR TITLE
refactor media hub embed styles

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -2057,3 +2057,44 @@ footer{margin:34px 0 20px;text-align:center;color:var(--muted)}
 .ad-slot.noscript-placeholder {
   min-height: 120px;
 }
+
+/* Media hub embed essential styles migrated from style.css */
+.youtube-section .button-row,
+.media-hub-section .button-row {
+  display: flex;
+  gap: 8px;
+  margin: 8px;
+}
+
+.button-row .spacer {
+  flex: 1;
+}
+
+.channel-toggle,
+.details-toggle {
+  background: var(--primary);
+  color: var(--on-primary);
+  border: none;
+  border-radius: 12px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+button:hover,
+.channel-toggle:hover,
+.details-toggle:hover {
+  background: var(--primary-container);
+}
+
+button:hover,
+.channel-toggle:hover {
+  transform: scale(1.03);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  box-shadow: var(--shadow-xxl);
+}
+
+.live-player iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -11,7 +11,7 @@
   <title>PakStream Media Hub Embed</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/style.css" />
+  <link rel="stylesheet" href="/css/index.css" />
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link rel="stylesheet" href="/assets/css/carousel.css" />


### PR DESCRIPTION
## Summary
- inline essential styles for media-hub embed into index.css
- drop style.css import from media-hub-embed.html

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9fb1fe79883209b2f464b7f590469