### PR TITLE
Adjust feature card iframe height

### DIFF
--- a/assets/js/feature-cards.js
+++ b/assets/js/feature-cards.js
@@ -13,6 +13,16 @@
         window.location.href = url;
       });
     });
+
+    window.addEventListener('message', e => {
+      if (e.data?.type === 'media-hub-height') {
+        const iframe = Array.from(document.querySelectorAll('.feature-card iframe'))
+          .find(f => f.contentWindow === e.source);
+        if (iframe) {
+          iframe.style.height = `${e.data.height}px`;
+        }
+      }
+    });
     const sendMuteMessage = (iframe, muted) => {
       if (iframe.contentWindow) {
         iframe.contentWindow.postMessage({ type: 'media-hub-set-muted', muted }, '*');


### PR DESCRIPTION
## Summary
- Dynamically resize feature-card iframes based on embedded content height to ensure channel toggle button is visible.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa00e2df60832089863547ce8df32a