### PR TITLE
Adjust feature card iframe height

### DIFF
--- a/assets/js/feature-cards.js
+++ b/assets/js/feature-cards.js
@@ -13,6 +13,16 @@
         window.location.href = url;
       });
     });
+
+    window.addEventListener('message', e => {
+      if (e.data?.type === 'media-hub-height') {
+        const iframe = Array.from(document.querySelectorAll('.feature-card iframe'))
+          .find(f => f.contentWindow === e.source);
+        if (iframe) {
+          iframe.style.height = `${e.data.height}px`;
+        }
+      }
+    });
     const sendMuteMessage = (iframe, muted) => {
       if (iframe.contentWindow) {
         iframe.contentWindow.postMessage({ type: 'media-hub-set-muted', muted }, '*');

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -18,9 +18,12 @@
   <link rel="stylesheet" href="/css/toast.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <style>
+    .media-hub-section .video-section { height: auto; }
+  </style>
 </head>
-<body style="overflow:hidden;height:100vh;height:100dvh;padding-left:0;padding-right:0">
-  <section class="youtube-section media-hub-section" style="margin:0;height:100%;padding:0;">
+<body style="overflow:hidden;padding-left:0;padding-right:0">
+  <section class="youtube-section media-hub-section" style="margin:0;padding:0;">
     <div class="channel-list open" id="left-rail">
       <div class="left-rail-header">
         <div class="search-wrap">
@@ -78,13 +81,17 @@
   </section>
   <script>
     function postHeight() {
-      var h = window.innerHeight;
-      parent.postMessage({ type: 'media-hub-height', height: h }, '*');
+      var vs = document.querySelector('.video-section');
+      if (vs) {
+        var h = vs.scrollHeight;
+        parent.postMessage({ type: 'media-hub-height', height: h }, '*');
+      }
     }
     window.addEventListener('load', function () {
       postHeight();
-      if (window.ResizeObserver) {
-        new ResizeObserver(postHeight).observe(document.body);
+      var vs = document.querySelector('.video-section');
+      if (window.ResizeObserver && vs) {
+        new ResizeObserver(postHeight).observe(vs);
       }
       window.addEventListener('resize', postHeight);
     });


### PR DESCRIPTION
## Summary
- Allow media-hub embed's video section to size to its content and report that height to the parent.
- Use ResizeObserver to keep feature card iframes tall enough for the full video section.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa00e2df60832089863547ce8df32a