### PR TITLE
Remove ads from blog pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -69,7 +69,9 @@
 
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/index.css">
+  {% unless page.ads == false %}
   <link rel="stylesheet" href="/css/ads.css">
+  {% endunless %}
   <link rel="stylesheet" href="/assets/css/carousel.css">
   <link rel="stylesheet" href="/css/toast.css">
   <link rel="stylesheet" href="/assets/css/mh-lite.css">
@@ -80,11 +82,13 @@
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
 
+  {% unless page.ads == false %}
   <!-- Top banner (responsive) -->
   <div class="ad-slot"
        data-ad-slot
        data-ad-type="leaderboard"
        data-placeholder="Advertisement — 728×90 / 320×50"></div>
+  {% endunless %}
 
   <main>
     {{ content }}
@@ -99,8 +103,10 @@
   <script src="/js/pwa.js" defer></script>
   <script src="/js/utils/flags.js" defer></script>
   <script src="/js/diagnostics.js" defer></script>
+  {% unless page.ads == false %}
   <script src="/js/ads/config.js" defer></script>
   <script src="/js/ads/ads.js" defer></script>
+  {% endunless %}
   <script defer src="/js/main.js"></script>
   <script src="/assets/js/carousel.js" defer></script>
   <script src="/assets/js/mh-featured.js" defer></script>
@@ -108,6 +114,7 @@
   <script src="/assets/js/mh-core.js" defer></script>
   <script src="/assets/js/mh-search.js" defer></script>
   <script src="/assets/js/mh-channels.js" defer></script>
+  {% unless page.ads == false %}
   <!--
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
           crossorigin="anonymous"></script>
@@ -117,12 +124,13 @@
     // and call: (adsbygoogle = window.adsbygoogle || []).push({});
   }
   </script>
-  
+
   <noscript>
     <div class="ad-slot" aria-hidden="true" style="min-height:120px">
       <div class="ad-placeholder">Ads require JavaScript.</div>
     </div>
   </noscript>
   -->
+  {% endunless %}
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -58,7 +58,6 @@
 
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/css/index.css">
-  <link rel="stylesheet" href="/css/ads.css">
   <link rel="stylesheet" href="/assets/css/carousel.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   
@@ -70,12 +69,6 @@
 <body>
 {% include google-tag-manager-body.html %}
   {% include top-bar.html %}
-
-  <!-- Top banner (responsive) -->
-  <div class="ad-slot"
-       data-ad-slot
-       data-ad-type="leaderboard"
-       data-placeholder="Advertisement — 728×90 / 320×50"></div>
 
   <main class="post-container hero-bg">
     <article class="post">
@@ -102,14 +95,6 @@
         {{ content }}
       </div>
 
-      <!-- Inline rectangle -->
-      <div class="ad-slot"
-           data-ad-slot
-           data-ad-type="rectangle"
-           data-ad-width="300"
-           data-ad-height="250"
-           data-placeholder="Advertisement — 300×250"></div>
-
       <!-- Social Sharing -->
       <div class="post-share">
         <p>Share:</p>
@@ -134,26 +119,9 @@
 
   {% include footer.html %}
   <script defer src="/js/main.js"></script>
-  <script src="/js/ads/config.js" defer></script>
-  <script src="/js/ads/ads.js" defer></script>
   <script src="/assets/js/carousel.js" defer></script>
   <script src="/assets/js/mh-featured.js" defer></script>
   <script src="/js/maintenance.js" defer></script>
-  <!--
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-CA-PUB-ID"
-          crossorigin="anonymous"></script>
-  <script>
-  if (window.PAKSTREAM?.Flags?.isOn('adsEnabled')) {
-    // When integrating, replace each .ad-slot innerHTML with your <ins class="adsbygoogle">...</ins>
-    // and call: (adsbygoogle = window.adsbygoogle || []).push({});
-  }
-  </script>
-  -->
-  <noscript>
-    <div class="ad-slot" aria-hidden="true" style="min-height:120px">
-      <div class="ad-placeholder">Ads require JavaScript.</div>
-    </div>
-  </noscript>
 <script src="/js/pwa.js" defer></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -2,6 +2,7 @@
 layout: default
 title: PakStream Blog - News for Overseas Pakistanis
 description: Insightful blogs covering Pakistani media, culture, and diaspora life abroad.
+ads: false
 ---
 
 <section class="blog-list hero-bg">


### PR DESCRIPTION
## Summary
- Strip ad stylesheet, placeholders and scripts from individual blog posts
- Add an `ads: false` flag and conditional logic to disable ads on blog listing page

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68aa1f3065308320ac3da177814e7593