### PR TITLE
Fix mobile nav offset for mobile screens

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1339,10 +1339,11 @@ table tbody tr.favorite {
 
   .top-bar nav {
     position: fixed;
-    top: 56px;
+    top: 0;
     left: 0;
     bottom: 0;
-    width: 250px;
+    width: 80%;
+    max-width: 300px;
     background: var(--surface);
     color: var(--on-surface);
     transform: translateX(-100%);
@@ -1353,6 +1354,7 @@ table tbody tr.favorite {
     flex-direction: column;
     padding: 16px;
     gap: 8px;
+    overflow-y: auto;
   }
 
   .top-bar nav a {

--- a/css/style-org.css
+++ b/css/style-org.css
@@ -1327,10 +1327,11 @@ table tbody tr.favorite {
 
   .top-bar nav {
     position: fixed;
-    top: 56px;
+    top: 0;
     left: 0;
     bottom: 0;
-    width: 250px;
+    width: 80%;
+    max-width: 300px;
     background: var(--surface);
     color: var(--on-surface);
     transform: translateX(-100%);
@@ -1341,6 +1342,7 @@ table tbody tr.favorite {
     flex-direction: column;
     padding: 16px;
     gap: 8px;
+    overflow-y: auto;
   }
 
   .top-bar nav a {


### PR DESCRIPTION
## Summary
- ensure mobile navigation slides from the top and covers screen
- constrain drawer width and allow vertical scrolling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa1fa08d3c8320aea51801bf885f6a