### PR TITLE
Align info pages with index style

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,13 +57,8 @@
   </script>
 
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/assets/css/carousel.css">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/css/index.css">
   
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -57,13 +57,8 @@
   </script>
 
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/assets/css/carousel.css">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/css/index.css">
   
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -57,13 +57,8 @@
   </script>
 
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/assets/css/carousel.css">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/css/index.css">
   
 </head>
 <body>

--- a/terms.html
+++ b/terms.html
@@ -57,13 +57,8 @@
   </script>
 
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/assets/css/carousel.css">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
+  <link rel="stylesheet" href="/css/index.css">
   
 </head>
 <body>


### PR DESCRIPTION
## Summary
- style about, contact, privacy, terms pages with `/css/index.css`
- remove legacy theme and font includes from informational pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa204ddc0c8320b138c1d12e25175e