### PR TITLE
Remove history link from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,6 @@
       <a href="/about.html">About Us</a>
       <a href="/contact.html">Contact</a>
       <a href="/privacy.html">Privacy</a>
-      <a href="/history.html">History</a>
       <a href="/terms.html">Terms</a>
     </nav>
     <div class="copy">© PakStream • All rights reserved.</div>


### PR DESCRIPTION
## Summary
- Drop obsolete History entry from the global footer navigation.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa21c6539c8320b82f3babfb20b4c1