### PR TITLE
Ensure radio station title is visible on dark background

### DIFF
--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -252,6 +252,10 @@
   background: var(--surface);
 }
 
+.live-player .station-title {
+  color: #fff;
+}
+
 .details-list {
   height: calc(100vh - 120px);
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Override station title color inside the live player so the radio station name appears white against dark backgrounds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68aae321661c8320806b9ab5490e2c98