### PR TITLE
Align station header left on mobile screens

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1030,6 +1030,13 @@ button:hover,
   text-align: center;
 }
 
+@media (max-width: 768px) {
+  #player-container.radio-player .station-info {
+    align-self: flex-start;
+    text-align: left;
+  }
+}
+
 /* Station header: flex aligns title with avatar center */
 .station-header {
   display: flex;

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1018,6 +1018,13 @@ button:hover,
   text-align: center;
 }
 
+@media (max-width: 768px) {
+  #player-container.radio-player .station-info {
+    align-self: flex-start;
+    text-align: left;
+  }
+}
+
 /* Station header: flex aligns title with avatar center */
 .station-header {
   display: flex;


### PR DESCRIPTION
## Summary
- Ensure station header in the radio player aligns left on small screens.
- Applied responsive overrides for `#player-container.radio-player .station-info` in both `index.css` and `style-orginal.css`.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aae749f2f083208febdc2b2a41cacf