### PR TITLE
Center live badges on mobile

### DIFF
--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -20,6 +20,18 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap">
   <style>
     .media-hub-section .video-section { height: auto; }
+    @media (max-width: 768px) {
+      /* Left align station header but center badges on small screens */
+      #player-container.radio-player .station-header {
+        justify-content: flex-start;
+      }
+      #player-container.radio-player #live-badge,
+      #player-container.radio-player #not-live-badge {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+      }
+    }
   </style>
 </head>
 <body style="overflow:hidden;padding-left:0;padding-right:0">


### PR DESCRIPTION
## Summary
- Align station header left and center live/not-live badges on small screens for media-hub embed

## Testing
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68aae8eec17c8320846a64349756d984