### PR TITLE
Implement media hub embed TODOs

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1030,6 +1030,10 @@ button:hover,
   text-align: center;
 }
 
+.station-live-status {
+  text-align: center;
+}
+
 /* Station header: flex aligns title with avatar center */
 .station-header {
   display: flex;

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1018,6 +1018,10 @@ button:hover,
   text-align: center;
 }
 
+.station-live-status {
+  text-align: center;
+}
+
 /* Station header: flex aligns title with avatar center */
 .station-header {
   display: flex;

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -50,13 +50,13 @@
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none;">
-            <div class="station-info"> <!--TODO: Left align this div-->
+            <div class="station-info" style="text-align:left;">
               <div class="station-header">
                 <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">
                 <span id="current-station" class="station-title">Select a station</span>
               </div>
             </div>
-            <div class="station-info"> <!--TODO: rename this class to station-live-status-->
+            <div class="station-live-status">
               <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
               <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
             </div>


### PR DESCRIPTION
## Summary
- Align station header to the left and rename live status container for clarity
- Add styling for the new `station-live-status` class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68aaeaee20d08320bfca185e6b4b46b7