### PR TITLE
Align radio player markup across hub pages

### DIFF
--- a/media-hub.html
+++ b/media-hub.html
@@ -67,9 +67,13 @@
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none;">
-            <div class="station-info">
-              <img id="station-logo" src="/images/default_radio.png" alt="Station logo" loading="lazy">
-              <h3 id="current-station" class="station-title">Select a station</h3>
+            <div class="station-info" style="text-align:left;">
+              <div class="station-header">
+                <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">
+                <span id="current-station" class="station-title">Select a station</span>
+              </div>
+            </div>
+            <div class="station-live-status">
               <div id="live-badge" class="live-badge" hidden><span class="dot"></span>Live</div>
               <div id="not-live-badge" class="not-live-badge"><span class="dot"></span>Not live</div>
             </div>


### PR DESCRIPTION
## Summary
- Sync radio player HTML in `media-hub.html` with the updated embed layout

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aaec1ee9ac8320bff940db5de86917