### PR TITLE
fix: left-align station info

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1027,11 +1027,15 @@ button:hover,
 }
 
 .station-info {
-  text-align: center;
+  text-align: left;
+  align-self: flex-start;
+  width: 100%;
 }
 
 .station-live-status {
-  text-align: center;
+  text-align: left;
+  align-self: flex-start;
+  width: 100%;
 }
 
 /* Station header: flex aligns title with avatar center */

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1015,11 +1015,15 @@ button:hover,
 }
 
 .station-info {
-  text-align: center;
+  text-align: left;
+  align-self: flex-start;
+  width: 100%;
 }
 
 .station-live-status {
-  text-align: center;
+  text-align: left;
+  align-self: flex-start;
+  width: 100%;
 }
 
 /* Station header: flex aligns title with avatar center */

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -50,7 +50,7 @@
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none;">
-            <div class="station-info" style="text-align:left;">
+            <div class="station-info">
               <div class="station-header">
                 <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">
                 <span id="current-station" class="station-title">Select a station</span>


### PR DESCRIPTION
## Summary
- Left-align station info and live status blocks via CSS
- Drop redundant inline style from embedded media hub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68aaec8fd4c483208557eb8ab16d97e2