### PR TITLE
fix: left-align station info

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1027,7 +1027,9 @@ button:hover,
 }
 
 .station-info {
-  text-align: center;
+  text-align: left;
+  align-self: flex-start;
+  width: 100%;
 }
 
 .station-live-status {

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1015,7 +1015,9 @@ button:hover,
 }
 
 .station-info {
-  text-align: center;
+  text-align: left;
+  align-self: flex-start;
+  width: 100%;
 }
 
 .station-live-status {

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -50,7 +50,7 @@
           allowfullscreen
           title="Selected video player"></iframe>
         <div id="player-container" class="radio-player" data-stream-container data-radio-container style="display:none;">
-            <div class="station-info" style="text-align:left;">
+            <div class="station-info">
               <div class="station-header">
                 <img id="station-logo" class="station-avatar" src="/images/default_radio.png" alt="Station logo" loading="lazy">
                 <span id="current-station" class="station-title">Select a station</span>


### PR DESCRIPTION
## Summary
- Left-align station info while keeping live status centered
- Drop redundant inline style from embedded media hub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68aaec8fd4c483208557eb8ab16d97e2