### PR TITLE
Remove station header padding

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1043,7 +1043,6 @@ button:hover,
   display: flex;
   align-items: center;   /* vertical alignment */
   gap: 12px;
-  padding: 0.5rem 0;
   min-width: 0;          /* enables text truncation */
 }
 

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1031,7 +1031,6 @@ button:hover,
   display: flex;
   align-items: center;   /* vertical alignment */
   gap: 12px;
-  padding: 0.5rem 0;
   min-width: 0;          /* enables text truncation */
 }
 


### PR DESCRIPTION
## Summary
- Remove top and bottom padding from `.station-header` to tighten layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68aaedfc981c83208e899b7d7c458a56