### PR TITLE
Stick player controls to bottom

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1785,6 +1785,7 @@ footer nav a:hover {
   grid-auto-rows: min-content !important;
   overflow: visible !important;
   padding-bottom: var(--controls-gap);
+  margin-top: auto; /* Ensure controls stay at the bottom */
 }
 
 /* --- END PATCH --- */

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1771,6 +1771,7 @@ footer nav a:hover {
   grid-auto-rows: min-content !important;
   overflow: visible !important;
   padding-bottom: var(--controls-gap);
+  margin-top: auto; /* Ensure controls stay at the bottom */
 }
 
 /* --- END PATCH --- */


### PR DESCRIPTION
## Summary
- Ensure radio player controls sit at the bottom of the player container
- Mirror styling change in legacy CSS file

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaeebe353c8320850c2e323ef6fb95