### PR TITLE
Remove padding from radio player controls

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1698,7 +1698,6 @@ footer nav a:hover {
 
 .radio-player .controls {
   overflow: visible;
-  padding-bottom: var(--controls-gap);
 }
 
 /* Uniform circular buttons that can shrink */
@@ -1784,7 +1783,6 @@ footer nav a:hover {
 #player-container.radio-player .controls {
   grid-auto-rows: min-content !important;
   overflow: visible !important;
-  padding-bottom: var(--controls-gap);
   margin-top: auto; /* Ensure controls stay at the bottom */
 }
 

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1684,7 +1684,6 @@ footer nav a:hover {
 
 .radio-player .controls {
   overflow: visible;
-  padding-bottom: var(--controls-gap);
 }
 
 /* Uniform circular buttons that can shrink */
@@ -1770,7 +1769,6 @@ footer nav a:hover {
 #player-container.radio-player .controls {
   grid-auto-rows: min-content !important;
   overflow: visible !important;
-  padding-bottom: var(--controls-gap);
   margin-top: auto; /* Ensure controls stay at the bottom */
 }
 


### PR DESCRIPTION
## Summary
- Remove bottom padding from `.radio-player .controls`
- Remove redundant padding override on `#player-container.radio-player .controls`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaf05abc288320bf7485f9b94f94bd