### PR TITLE
Make live status fill radio player space

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1034,6 +1034,11 @@ button:hover,
 
 .station-live-status {
   text-align: center;
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Station header: flex aligns title with avatar center */
@@ -1096,25 +1101,34 @@ button:hover,
   display: none;
 }
 
-.live-badge {
-  display: inline-flex;
+.live-badge,
+.not-live-badge {
+  display: flex;
   align-items: center;
-  margin-top: 4px;
-  padding: 2px 8px;
+  justify-content: center;
+  margin-top: 0;
+  width: 100%;
+  height: 100%;
   border: 2px solid currentColor;
-  border-radius: 9999px;
+  border-radius: 12px;
   background: transparent;
-  color: #ff0000;
-  font-size: 0.75rem;
+  font-size: clamp(1rem, 8vh, 3rem);
   font-weight: 600;
 }
 
-.live-badge .dot {
-  width: 8px;
-  height: 8px;
+.live-badge { color: #ff0000; }
+.not-live-badge { color: var(--on-surface); }
+
+.live-badge .dot,
+.not-live-badge .dot {
+  width: 0.8em;
+  height: 0.8em;
   background: currentColor;
   border-radius: 50%;
-  margin-right: 4px;
+  margin-right: 0.5em;
+}
+
+.live-badge .dot {
   animation: live-pulse 1.5s infinite;
 }
 
@@ -1130,26 +1144,6 @@ button:hover,
   }
 }
 
-.not-live-badge {
-  display: inline-flex;
-  align-items: center;
-  margin-top: 4px;
-  padding: 2px 8px;
-  border: 2px solid currentColor;
-  border-radius: 9999px;
-  background: transparent;
-  color: var(--on-surface);
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.not-live-badge .dot {
-  width: 8px;
-  height: 8px;
-  background: currentColor;
-  border-radius: 50%;
-  margin-right: 4px;
-}
 
 :root {
   --radio-btn-size: clamp(36px, 8vw, 54px);

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -1022,6 +1022,11 @@ button:hover,
 
 .station-live-status {
   text-align: center;
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Station header: flex aligns title with avatar center */
@@ -1079,30 +1084,40 @@ button:hover,
   margin-top: 0;
 }
 
+
 .radio-player.compact .live-badge,
 .radio-player.compact .not-live-badge {
   display: none;
 }
 
-.live-badge {
-  display: inline-flex;
+.live-badge,
+.not-live-badge {
+  display: flex;
   align-items: center;
-  margin-top: 4px;
-  padding: 2px 8px;
+  justify-content: center;
+  margin-top: 0;
+  width: 100%;
+  height: 100%;
   border: 2px solid currentColor;
-  border-radius: 9999px;
+  border-radius: 12px;
   background: transparent;
-  color: #ff0000;
-  font-size: 0.75rem;
+  font-size: clamp(1rem, 8vh, 3rem);
   font-weight: 600;
 }
 
-.live-badge .dot {
-  width: 8px;
-  height: 8px;
+.live-badge { color: #ff0000; }
+.not-live-badge { color: var(--on-surface); }
+
+.live-badge .dot,
+.not-live-badge .dot {
+  width: 0.8em;
+  height: 0.8em;
   background: currentColor;
   border-radius: 50%;
-  margin-right: 4px;
+  margin-right: 0.5em;
+}
+
+.live-badge .dot {
   animation: live-pulse 1.5s infinite;
 }
 
@@ -1118,26 +1133,6 @@ button:hover,
   }
 }
 
-.not-live-badge {
-  display: inline-flex;
-  align-items: center;
-  margin-top: 4px;
-  padding: 2px 8px;
-  border: 2px solid currentColor;
-  border-radius: 9999px;
-  background: transparent;
-  color: var(--on-surface);
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.not-live-badge .dot {
-  width: 8px;
-  height: 8px;
-  background: currentColor;
-  border-radius: 50%;
-  margin-right: 4px;
-}
 
 :root {
   --radio-btn-size: clamp(36px, 8vw, 54px);


### PR DESCRIPTION
## Summary
- Allow station-live-status area to grow and center within radio player
- Stretch live/not-live badges with responsive sizing to occupy available space

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaf1c276448320b0174560f42afbc8