### PR TITLE
Handle nonexistent routes with 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,3 @@
-<link rel="manifest" href="/manifest.webmanifest" type="application/manifest+json">
-<meta name="theme-color" content="#ffffff">
-<meta name="apple-mobile-web-app-capable" content="yes">
-<link rel="apple-touch-icon" href="/images/icons/icon-192-maskable.png">
 ---
 layout: default
 title: "Page Not Found"
@@ -11,8 +7,9 @@ robots: noindex, follow
 ---
 
 <section class="not-found">
-  <h2>Page Not Found</h2>
+  <h2 id="nf-title" tabindex="-1">Page Not Found</h2>
   <p>Sorry, the page you are looking for doesn’t exist or has been moved.</p>
-  <p><a href="/">Return to the homepage</a>.</p>
+  <p><a href="/" data-analytics="home">Return to the homepage</a>.</p>
+  <div id="nf-recent"></div>
 </section>
-<script src="/js/pwa.js" defer></script>
+<script src="/js/404.js" defer></script>

--- a/sw.js
+++ b/sw.js
@@ -26,6 +26,7 @@ const PRECACHE_URLS = [
   "/images/icons/icon-192-maskable.png",
   "/images/icons/icon-512-maskable.png",
   "/index.html",
+  "/404.html",
   "/js/404.js",
   "/manifest.webmanifest",
   "/offline.html"
@@ -71,8 +72,12 @@ self.addEventListener('fetch', (event) => {
     event.respondWith((async () => {
       try {
         const fresh = await fetch(req);
-        // Optionally update cache
         const cache = await caches.open(CACHE_NAME);
+        if (fresh.status === 404) {
+          const notFound = await cache.match('/404.html');
+          return notFound || fresh;
+        }
+        // Optionally update cache
         cache.put(req, fresh.clone());
         return fresh;
       } catch (e) {


### PR DESCRIPTION
## Summary
- Add structured 404 page with analytics hooks and recent history suggestions
- Precache 404 page and serve it when navigation fetches return 404

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aaf7625c5483208ff0625a774b95a2