### PR TITLE
Ensure video list maintains 16:9 ratio

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -731,6 +731,18 @@ section {
   overflow-y: auto;
 }
 
+/* Maintain 16:9 ratio when videos are present */
+#videoList:not(:empty) {
+  flex: none;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+/* Collapse container when empty */
+#videoList:empty {
+  display: none;
+}
+
 .video-list .video-item {
   display: flex;
   align-items: center;

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -719,6 +719,18 @@ section {
   overflow-y: auto;
 }
 
+/* Maintain 16:9 ratio when videos are present */
+#videoList:not(:empty) {
+  flex: none;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+/* Collapse container when empty */
+#videoList:empty {
+  display: none;
+}
+
 .video-list .video-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Ensure the media hub's video list keeps a 16:9 aspect ratio when populated
- Collapse the video list container when empty to avoid leftover spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68ab8e5f5c60832088baaa3ddff9b352