### PR TITLE
Ensure video list maintains 16:9 ratio

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -716,7 +716,7 @@ section {
   margin-top: 0;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 120px);
+  min-height: calc(100vh - 120px);
 }
 
 .video-section iframe {
@@ -729,6 +729,19 @@ section {
 .video-section .video-list {
   flex: 1 1 auto;
   overflow-y: auto;
+}
+
+/* Maintain 16:9 ratio when videos are present */
+#videoList:not(:empty) {
+  flex: none;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow-y: auto;
+}
+
+/* Collapse container when empty */
+#videoList:empty {
+  display: none;
 }
 
 .video-list .video-item {

--- a/css/style-orginal.css
+++ b/css/style-orginal.css
@@ -704,7 +704,7 @@ section {
   margin-top: 0;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 120px);
+  min-height: calc(100vh - 120px);
 }
 
 .video-section iframe {
@@ -717,6 +717,19 @@ section {
 .video-section .video-list {
   flex: 1 1 auto;
   overflow-y: auto;
+}
+
+/* Maintain 16:9 ratio when videos are present */
+#videoList:not(:empty) {
+  flex: none;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow-y: auto;
+}
+
+/* Collapse container when empty */
+#videoList:empty {
+  display: none;
 }
 
 .video-list .video-item {


### PR DESCRIPTION
## Summary
- Keep video list content contained by making it scrollable and preserving a 16:9 aspect ratio
- Let the media hub's video section grow beyond the viewport height when the list is populated

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e5f5c60832088baaa3ddff9b352