### PR TITLE
Sync left rail height with video section

### DIFF
--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -42,6 +42,24 @@ document.addEventListener("DOMContentLoaded", async () => {
     buttonRow.style.display = "none";
   }
 
+  const videoSection = document.querySelector('.video-section');
+
+  function setLeftRailHeight() {
+    if (!leftRail) return;
+    if (window.innerWidth <= 768 && videoSection) {
+      leftRail.style.height = `${videoSection.offsetHeight}px`;
+    } else {
+      leftRail.style.height = '';
+    }
+  }
+
+  setLeftRailHeight();
+  window.addEventListener('resize', setLeftRailHeight);
+  if (videoSection) {
+    const observer = new MutationObserver(setLeftRailHeight);
+    observer.observe(videoSection, { childList: true, subtree: true });
+  }
+
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");


### PR DESCRIPTION
## Summary
- adjust left rail height to match video section on mobile
- update height on resize and content changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ab9281192c8320bc0c032b2e341e3a