### PR TITLE
Sync left rail height with video section

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -798,7 +798,7 @@ section {
     position: fixed;
     top: 56px;
     left: 0;
-    bottom: 0;
+    bottom: auto;
     width: 260px;
     max-width: 80%;
     background: var(--surface);

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -42,6 +42,26 @@ document.addEventListener("DOMContentLoaded", async () => {
     buttonRow.style.display = "none";
   }
 
+  const videoSection = document.querySelector('.video-section');
+
+  function setLeftRailHeight() {
+    if (!leftRail) return;
+    if (window.innerWidth <= 768 && videoSection) {
+      leftRail.style.bottom = 'auto';
+      leftRail.style.height = `${videoSection.offsetHeight}px`;
+    } else {
+      leftRail.style.height = '';
+      leftRail.style.bottom = '';
+    }
+  }
+
+  setLeftRailHeight();
+  window.addEventListener('resize', setLeftRailHeight);
+  if (videoSection) {
+    const observer = new MutationObserver(setLeftRailHeight);
+    observer.observe(videoSection, { childList: true, subtree: true });
+  }
+
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");


### PR DESCRIPTION
## Summary
- allow JS to override left rail bottom when matching video section height
- let mobile channel list use auto bottom to honor script-defined height

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ab9281192c8320bc0c032b2e341e3a