### PR TITLE
Sync left rail height with video section

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -793,12 +793,16 @@ section {
   .youtube-section > * + * {
     margin-left: 0;
   }
+  .youtube-section .video-section,
+  .media-hub-section .video-section {
+    min-height: auto;
+  }
   .youtube-section .channel-list,
   .media-hub-section .channel-list {
     position: fixed;
     top: 56px;
     left: 0;
-    bottom: 0;
+    bottom: auto;
     width: 260px;
     max-width: 80%;
     background: var(--surface);

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -42,6 +42,29 @@ document.addEventListener("DOMContentLoaded", async () => {
     buttonRow.style.display = "none";
   }
 
+  const videoSection = document.querySelector('.video-section');
+
+  function setLeftRailHeight() {
+    if (!leftRail) return;
+    if (window.innerWidth <= 768 && videoSection) {
+      leftRail.style.bottom = 'auto';
+      leftRail.style.height = `${videoSection.offsetHeight}px`;
+    } else {
+      leftRail.style.height = '';
+      leftRail.style.bottom = '';
+    }
+  }
+
+  setLeftRailHeight();
+  window.addEventListener('resize', setLeftRailHeight);
+  if (videoSection) {
+    const observer = new MutationObserver(setLeftRailHeight);
+    observer.observe(videoSection, { childList: true, subtree: true });
+    const resizeObserver = new ResizeObserver(setLeftRailHeight);
+    resizeObserver.observe(videoSection);
+    window.addEventListener('load', setLeftRailHeight);
+  }
+
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");


### PR DESCRIPTION
## Summary
- let mobile video section shrink by removing its min-height
- keep left rail height synced with a ResizeObserver and load event

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ab9281192c8320bc0c032b2e341e3a