### PR TITLE
Align left rail height with video list on desktop

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -793,12 +793,16 @@ section {
   .youtube-section > * + * {
     margin-left: 0;
   }
+  .youtube-section .video-section,
+  .media-hub-section .video-section {
+    min-height: auto;
+  }
   .youtube-section .channel-list,
   .media-hub-section .channel-list {
     position: fixed;
     top: 56px;
     left: 0;
-    bottom: 0;
+    bottom: auto;
     width: 260px;
     max-width: 80%;
     background: var(--surface);
@@ -851,7 +855,6 @@ section {
   .media-hub-section .channel-list {
     position: sticky;
     top: 72px;
-    height: calc(100vh - 120px);
     overflow-y: auto;
   }
   .youtube-section .details-container,

--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -213,7 +213,6 @@
 /* reuse your card list visuals */
 /* Match height with Free Press channel list */
 .channel-list {
-  height: calc(100vh - 120px);
   overflow-y: auto;
 }
 .channel-card {

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -42,6 +42,25 @@ document.addEventListener("DOMContentLoaded", async () => {
     buttonRow.style.display = "none";
   }
 
+  function setLeftRailHeight() {
+    if (!leftRail) return;
+    if (window.innerWidth > 768 && videoList) {
+      leftRail.style.height = `${videoList.offsetHeight}px`;
+    } else {
+      leftRail.style.height = '';
+    }
+  }
+
+  setLeftRailHeight();
+  window.addEventListener('resize', setLeftRailHeight);
+  if (videoList) {
+    const observer = new MutationObserver(setLeftRailHeight);
+    observer.observe(videoList, { childList: true, subtree: true });
+    const resizeObserver = new ResizeObserver(setLeftRailHeight);
+    resizeObserver.observe(videoList);
+    window.addEventListener('load', setLeftRailHeight);
+  }
+
   // Radio player elements
   const radioContainer = document.getElementById("player-container");
   const mainPlayer = document.getElementById("radio-player");


### PR DESCRIPTION
## Summary
- Remove fixed desktop height from channel list CSS
- Sync left rail height to video list on larger screens

## Testing
- ❌ `npm test` (Missing script: "test")
- ✅ `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ab9281192c8320bc0c032b2e341e3a