### PR TITLE
Sync left rail height with video section on mobile

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -793,12 +793,16 @@ section {
   .youtube-section > * + * {
     margin-left: 0;
   }
+  .youtube-section .video-section,
+  .media-hub-section .video-section {
+    min-height: auto;
+  }
   .youtube-section .channel-list,
   .media-hub-section .channel-list {
     position: fixed;
     top: 56px;
     left: 0;
-    bottom: 0;
+    bottom: auto;
     width: 260px;
     max-width: 80%;
     background: var(--surface);
@@ -851,7 +855,6 @@ section {
   .media-hub-section .channel-list {
     position: sticky;
     top: 72px;
-    height: calc(100vh - 120px);
     overflow-y: auto;
   }
   .youtube-section .details-container,

--- a/css/media-hub.css
+++ b/css/media-hub.css
@@ -213,7 +213,6 @@
 /* reuse your card list visuals */
 /* Match height with Free Press channel list */
 .channel-list {
-  height: calc(100vh - 120px);
   overflow-y: auto;
 }
 .channel-card {

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const videoListEl = document.getElementById("videoList");
   if (!showVideoList && videoListEl) videoListEl.style.display = "none";
   const videoList = showVideoList ? videoListEl : null;
+  const videoSection = document.querySelector(".video-section");
   const detailsContainer = document.querySelector(".details-container");
   const details   = showDetails ? document.querySelector(".details-list") : null;
   const tabs      = document.querySelectorAll(".tab-btn");
@@ -40,6 +41,27 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   if (!showChannels && !showDetails && buttonRow) {
     buttonRow.style.display = "none";
+  }
+
+  function setLeftRailHeight() {
+    if (!leftRail || !videoSection) return;
+    if (window.innerWidth <= 768) {
+      leftRail.style.height = `${videoSection.offsetHeight}px`;
+      leftRail.style.bottom = 'auto';
+    } else {
+      leftRail.style.height = '';
+      leftRail.style.bottom = '';
+    }
+  }
+
+  setLeftRailHeight();
+  window.addEventListener('load', setLeftRailHeight);
+  window.addEventListener('resize', setLeftRailHeight);
+  if (videoSection) {
+    const observer = new MutationObserver(setLeftRailHeight);
+    observer.observe(videoSection, { childList: true, subtree: true });
+    const resizeObserver = new ResizeObserver(setLeftRailHeight);
+    resizeObserver.observe(videoSection);
   }
 
   // Radio player elements


### PR DESCRIPTION
## Summary
- Derive mobile left-rail height from `.video-section`
- Update height on load, resize, and video section mutations

## Testing
- ❌ `npm test` (Missing script: "test")
- ✅ `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ab9281192c8320bc0c032b2e341e3a