### PR TITLE
Centralize canonical URLs and normalize meta tags

### DIFF
--- a/_includes/canonical.html
+++ b/_includes/canonical.html
@@ -1,0 +1,6 @@
+{%- assign base = "https://pakstream.com" -%}
+{%- capture page_path -%}
+  {%- if page.url == "/" -%}/{%- else -%}{{ page.url | replace: "index.html", "" | replace: "//", "/" }}{%- endif -%}
+{%- endcapture -%}
+{%- assign canon = base | append: page_path -%}
+<link rel="canonical" href="{{ canon }}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,14 +30,14 @@
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}">
-  <link rel="canonical" href="{{ page.url | absolute_url }}" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ page.url | absolute_url }}">
+  <meta property="og:url" content="{{ canon }}">
   <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}">
   <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
@@ -45,7 +45,7 @@
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="{{ page.url | absolute_url }}">
+  <meta name="twitter:url" content="{{ canon }}">
   <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}">
   <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,12 +21,12 @@
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
   <meta name="author" content="PakStream by Chatdroid AB" />
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}" />
-  <link rel="canonical" href="{{ page.url | absolute_url }}" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ page.url | absolute_url }}" />
+  <meta property="og:url" content="{{ canon }}" />
   <meta property="og:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
   <meta property="og:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
   <meta property="og:image" content="/assets/pakstream-banner.jpg" />
@@ -34,7 +34,7 @@
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="{{ page.url | absolute_url }}" />
+  <meta name="twitter:url" content="{{ canon }}" />
   <meta name="twitter:title" content="{{ page.title | default: 'PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press' }}" />
   <meta name="twitter:description" content="{{ page.description | default: 'Stream Pakistani TV channels, radio stations, and independent Free Press talk shows—everything in one place. Stay connected wherever you are.' }}" />
   <meta name="twitter:image" content="/assets/pakstream-banner.jpg" />

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="canonical" href="https://pakstream.com/about.html" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
@@ -25,11 +25,12 @@
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
-  <meta property="og:url" content="https://pakstream.com/">
+  <meta property="og:url" content="{{ canon }}">
   <meta property="og:type" content="website">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="{{ canon }}">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">

--- a/contact.html
+++ b/contact.html
@@ -16,7 +16,7 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="canonical" href="https://pakstream.com/contact.html" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
@@ -25,11 +25,12 @@
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
-  <meta property="og:url" content="https://pakstream.com/">
+  <meta property="og:url" content="{{ canon }}">
   <meta property="og:type" content="website">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="{{ canon }}">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">

--- a/dev/iftest.html
+++ b/dev/iftest.html
@@ -1,5 +1,10 @@
+---
+---
 <!DOCTYPE html>
 <html>
+<head>
+  {% include canonical.html %}
+</head>
 <body style="margin:0">
 <script>
 const channelId = "UCaszgR2TH3qNw_CxLHAd2S"; // Imran Riaz Khan

--- a/dev/onboard-channel.html
+++ b/dev/onboard-channel.html
@@ -13,7 +13,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Generate JSON for adding a YouTube channel to all_streams.json.">
   <meta name="robots" content="noindex, nofollow">
-  <link rel="canonical" href="https://pakstream.com/onboard-channel.html" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/dev/stream-checker.html
+++ b/dev/stream-checker.html
@@ -12,6 +12,7 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
+  {% include canonical.html %}
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
 </head>

--- a/dev/youtube-playground.html
+++ b/dev/youtube-playground.html
@@ -13,7 +13,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Experiment with YouTube channels to list current live streams.">
   <meta name="robots" content="noindex, nofollow">
-  <link rel="canonical" href="https://pakstream.com/youtube-playground.html" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/index.html
+++ b/index.html
@@ -22,14 +22,14 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://pakstream.com/" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://pakstream.com/">
+  <meta property="og:url" content="{{ canon }}">
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
   <meta property="og:description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows, everything in one place. Stay connected wherever you are.">
   <meta property="og:image" content="https://pakstream.com/assets/pakstream-banner.jpg">
@@ -37,7 +37,7 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="https://pakstream.com/">
+  <meta name="twitter:url" content="{{ canon }}">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani TV, Radio &amp; Free Press">
   <meta name="twitter:description" content="Stream Pakistani TV channels, radio stations, and independent Free Press talk shows, everything in one place. Stay connected wherever you are.">
   <meta name="twitter:image" content="https://pakstream.com/assets/pakstream-banner.jpg">

--- a/maintenance.html
+++ b/maintenance.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
@@ -5,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>PakStream — Maintenance</title>
   <meta name="robots" content="noindex,nofollow"/>
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="/assets/css/tokens.css">
   <link rel="stylesheet" href="/assets/css/a11y-focus.css">

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
+  {% include canonical.html %}
   <title>PakStream Media Hub Embed</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/media-hub.html
+++ b/media-hub.html
@@ -17,6 +17,7 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
+  {% include canonical.html %}
   <link rel="stylesheet" href="/css/index.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link rel="stylesheet" href="/assets/css/carousel.css" />

--- a/nav.html
+++ b/nav.html
@@ -12,6 +12,7 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
+  {% include canonical.html %}
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/theme.css">

--- a/offline.html
+++ b/offline.html
@@ -1,9 +1,12 @@
+---
+---
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Offline — PakStream</title>
+  {% include canonical.html %}
   <style>
     :root { color-scheme: light dark; }
     body {

--- a/privacy.html
+++ b/privacy.html
@@ -16,7 +16,7 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="canonical" href="https://pakstream.com/privacy.html" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
@@ -25,11 +25,12 @@
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
-  <meta property="og:url" content="https://pakstream.com/">
+  <meta property="og:url" content="{{ canon }}">
   <meta property="og:type" content="website">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="{{ canon }}">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">

--- a/terms.html
+++ b/terms.html
@@ -16,7 +16,7 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  <link rel="canonical" href="https://pakstream.com/terms.html" />
+  {% include canonical.html %}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
@@ -25,11 +25,12 @@
   <meta property="og:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta property="og:description" content="Stream TV, radio, and independent news content from Pakistan. Watch live channels and talk shows anywhere in the world.">
   <meta property="og:image" content="/favicon.ico">
-  <meta property="og:url" content="https://pakstream.com/">
+  <meta property="og:url" content="{{ canon }}">
   <meta property="og:type" content="website">
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="{{ canon }}">
   <meta name="twitter:title" content="PakStream - Your Gateway to Pakistani Media Abroad">
   <meta name="twitter:description" content="PakStream helps you stay connected to Pakistani culture, TV, radio, and independent news wherever you live.">
   <meta name="twitter:image" content="/favicon.ico">


### PR DESCRIPTION
## Summary
- add `_includes/canonical.html` to build absolute HTTPS canonical URLs
- include canonical snippet in layouts and key pages; update OG/Twitter to reference it
- normalize various pages and utility screens to use the shared canonical

## Testing
- `jekyll build -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac308893608320a9d8af4d6b570a2f