### PR TITLE
Add Jekyll plugins and canonical skip for noindex pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
 title: PakStream Blog
 baseurl: ""
 url: "https://pakstream.com"
+plugins:
+  - jekyll-sitemap
+  - jekyll-redirect-from

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,9 @@
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,9 @@
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows" />
   <meta name="author" content="PakStream by Chatdroid AB" />
   <meta name="robots" content="{{ page.robots | default: 'index, follow' }}" />
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
   <!-- Open Graph / Facebook -->


### PR DESCRIPTION
## Summary
- ensure site config defines required Jekyll plugins
- only render canonical link for indexable pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68ac3340585083208a0e8c231e113385