### PR TITLE
chore: exclude utility pages from sitemap

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,8 @@ layout: default
 title: "Page Not Found"
 permalink: /404.html
 description: "The page you requested could not be found."
-robots: noindex, follow
+robots: noindex, nofollow
+sitemap: false
 ---
 
 <section class="not-found">

--- a/dev/iftest.html
+++ b/dev/iftest.html
@@ -1,5 +1,6 @@
 ---
-robots: "noindex, nofollow"
+robots: noindex, nofollow
+sitemap: false
 ---
 <!DOCTYPE html>
 <html>

--- a/dev/onboard-channel.html
+++ b/dev/onboard-channel.html
@@ -1,4 +1,6 @@
 ---
+robots: noindex, nofollow
+sitemap: false
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/dev/stream-checker.html
+++ b/dev/stream-checker.html
@@ -1,4 +1,6 @@
 ---
+robots: noindex, nofollow
+sitemap: false
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/dev/youtube-playground.html
+++ b/dev/youtube-playground.html
@@ -1,4 +1,6 @@
 ---
+robots: noindex, nofollow
+sitemap: false
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/maintenance.html
+++ b/maintenance.html
@@ -1,5 +1,6 @@
 ---
-robots: noindex,nofollow
+robots: noindex, nofollow
+sitemap: false
 ---
 <!doctype html>
 <html lang="en">

--- a/offline.html
+++ b/offline.html
@@ -1,5 +1,6 @@
 ---
-robots: noindex
+robots: noindex, nofollow
+sitemap: false
 ---
 <!doctype html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- prevent indexing and sitemap inclusion of maintenance, error, offline, and dev pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac37f4e134832083a0e879cda2cf51