### PR TITLE
Add SEO guard script and workflow

### DIFF
--- a/.github/workflows/seo-guard.yml
+++ b/.github/workflows/seo-guard.yml
@@ -1,0 +1,14 @@
+name: SEO Guard
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  seo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run SEO checks
+        run: ./scripts/seo-check.sh

--- a/scripts/seo-check.sh
+++ b/scripts/seo-check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running SEO guard checks..."
+
+# Check for index.html links (any href ending with /index.html)
+if grep -R --binary-files=without-match --include="*.html" -n 'href="[^"]*/index\.html"' . > /dev/null; then
+  echo "❌ Found links pointing to /index.html. Use trailing slash instead."
+  exit 1
+fi
+
+# Check for duplicate canonical tags
+violations=0
+while IFS= read -r file; do
+  count=$(grep -c '<link rel="canonical"' "$file" || true)
+  if [ "$count" -gt 1 ]; then
+    echo "❌ $file has $count canonical tags (should be 1)."
+    violations=1
+  fi
+done < <(find . -name "*.html")
+
+if [ "$violations" -ne 0 ]; then
+  exit 1
+fi
+
+echo "✅ SEO checks passed."


### PR DESCRIPTION
## Summary
- add bash script to catch index.html links and duplicate canonical tags
- add GitHub Actions workflow to run SEO checks

## Testing
- `./scripts/seo-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac3957e40c83209e328040c63a8899