### PR TITLE
Add Gemfile for Jekyll dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+# Pin Jekyll 4.x for local/CI builds
+gem "jekyll", "~> 4.4"
+
+# Jekyll plugins used by the site
+group :jekyll_plugins do
+  gem "jekyll-sitemap", "~> 1.4"
+  gem "jekyll-redirect-from", "~> 0.16"
+end
+
+# Needed for `jekyll serve` on Ruby >= 3
+gem "webrick", "~> 1.9", require: false


### PR DESCRIPTION
## Summary
- add Gemfile pinning Jekyll 4.4 and required plugins

## Testing
- `bundle install --path vendor/bundle`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68ac404deedc83208d550ae4d9bb3962