### PR TITLE
Guard canonicals and align OG/Twitter URLs

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,7 +16,9 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/contact.html
+++ b/contact.html
@@ -16,7 +16,9 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@ window.__PAKSTREAM_FLAGS = Object.assign(window.__PAKSTREAM_FLAGS || {}, {
   <meta name="keywords" content="Pakistani TV, Pakistani Radio, Pakistani Free Press, Pakistan News, Urdu Channels, Pakistani Media Abroad, Live Pakistani News, Watch Pakistani TV Online, Pakistani Talk Shows">
   <meta name="author" content="PakStream by Chatdroid AB">
   <meta name="robots" content="index, follow">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/media-hub-embed.html
+++ b/media-hub-embed.html
@@ -8,7 +8,11 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
+  <meta property="og:url" content="{{ canon }}">
+  <meta name="twitter:url" content="{{ canon }}">
   <title>PakStream Media Hub Embed</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/media-hub.html
+++ b/media-hub.html
@@ -17,7 +17,11 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
+  <meta property="og:url" content="{{ canon }}">
+  <meta name="twitter:url" content="{{ canon }}">
   <link rel="stylesheet" href="/css/index.css" />
   <link rel="stylesheet" href="/css/media-hub.css" />
   <link rel="stylesheet" href="/assets/css/carousel.css" />

--- a/nav.html
+++ b/nav.html
@@ -12,7 +12,11 @@
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
+  <meta property="og:url" content="{{ canon }}">
+  <meta name="twitter:url" content="{{ canon }}">
   <title>Navigation</title>
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/theme.css">

--- a/privacy.html
+++ b/privacy.html
@@ -16,7 +16,9 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/terms.html
+++ b/terms.html
@@ -16,7 +16,9 @@
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
## Summary
- wrap canonical include with noindex guard on standalone pages
- point og:url and twitter:url meta tags at `{{ canon }}` where missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `bundle exec jekyll build` *(fails: jekyll executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac424dff6083208f543f2c53f7ca1d