### PR TITLE
Skip canonical on noindex dev pages

### DIFF
--- a/dev/onboard-channel.html
+++ b/dev/onboard-channel.html
@@ -15,7 +15,9 @@ sitemap: false
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Generate JSON for adding a YouTube channel to all_streams.json.">
   <meta name="robots" content="noindex, nofollow">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">

--- a/dev/stream-checker.html
+++ b/dev/stream-checker.html
@@ -14,7 +14,9 @@ sitemap: false
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="stylesheet" href="/css/theme.css">
   <link rel="stylesheet" href="/css/style.css">
 </head>

--- a/dev/youtube-playground.html
+++ b/dev/youtube-playground.html
@@ -15,7 +15,9 @@ sitemap: false
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Experiment with YouTube channels to list current live streams.">
   <meta name="robots" content="noindex, nofollow">
-  {% include canonical.html %}
+  {%- unless page.robots and page.robots contains 'noindex' -%}
+    {% include canonical.html %}
+  {%- endunless -%}
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="manifest" href="/manifest.webmanifest">
   <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
## Summary
- Wrap canonical include in dev pages to skip when `page.robots` contains `noindex`

## Testing
- `bundle exec jekyll build --dry-run` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4858e5648320989dea21e8a15f3a