### PR TITLE
Use site.url for canonical URLs

### DIFF
--- a/_includes/canonical.html
+++ b/_includes/canonical.html
@@ -1,6 +1,8 @@
-{%- assign base = "https://pakstream.com" -%}
-{%- capture page_path -%}
-  {%- if page.url == "/" -%}/{%- else -%}{{ page.url | replace: "index.html", "" | replace: "//", "/" }}{%- endif -%}
-{%- endcapture -%}
-{%- assign canon = base | append: page_path -%}
+{%- assign raw = page.url -%}
+{%- if raw == "/" -%}
+  {%- assign norm = "/" -%}
+{%- else -%}
+  {%- assign norm = raw | replace: "index.html", "" | replace: "//", "/" -%}
+{%- endif -%}
+{%- assign canon = norm | absolute_url -%}
 <link rel="canonical" href="{{ canon }}" />


### PR DESCRIPTION
## Summary
- build canonical links via `page.url` and Jekyll's `absolute_url`
- keep `canon` variable for OG/Twitter tags

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68ac49c5258c8320876a47617d622508