### PR TITLE
Sync feature card links with embed channel selection

### DIFF
--- a/assets/js/feature-cards.js
+++ b/assets/js/feature-cards.js
@@ -21,6 +21,18 @@
         if (iframe) {
           iframe.style.height = `${e.data.height}px`;
         }
+      } else if (e.origin === location.origin && e.data?.type === 'c-change') {
+        const iframe = Array.from(document.querySelectorAll('.feature-card iframe'))
+          .find(f => f.contentWindow === e.source);
+        if (iframe) {
+          const card = iframe.closest('.feature-card');
+          const link = card?.querySelector('a[href^="/media-hub.html"]');
+          if (link) {
+            const url = new URL(link.getAttribute('href'), location.origin);
+            url.searchParams.set('c', e.data.value);
+            link.setAttribute('href', url.pathname + url.search);
+          }
+        }
       }
     });
     const sendMuteMessage = (iframe, muted) => {

--- a/js/media-hub.js
+++ b/js/media-hub.js
@@ -867,9 +867,12 @@ async function renderLatestVideosRSS(channelId) {
     if (isSame) return;
 
     currentVideoKey = item.key;
-    params.set("m", mode);
-    params.set("c", item.key);
-    history.replaceState(null, "", "?" + params.toString());
+      params.set("m", mode);
+      params.set("c", item.key);
+      history.replaceState(null, "", "?" + params.toString());
+      if (window.parent !== window) {
+        parent.postMessage({ type: 'c-change', value: params.get('c') }, location.origin);
+      }
 
     if (videoList) videoList.innerHTML = "";
     currentVideoChannelId = null;
@@ -1023,8 +1026,11 @@ async function renderLatestVideosRSS(channelId) {
     if (currentLabel) currentLabel.textContent = name;
 
       params.set('m', mode === 'favorites' ? 'favorites' : mode);
-    params.set('c', audio.id);
-    history.replaceState(null, '', '?' + params.toString());
+      params.set('c', audio.id);
+      history.replaceState(null, '', '?' + params.toString());
+      if (window.parent !== window) {
+        parent.postMessage({ type: 'c-change', value: params.get('c') }, location.origin);
+      }
 
     if (window.innerWidth <= 768) {
       const list = document.querySelector('.channel-list');


### PR DESCRIPTION
## Summary
- Update feature card listener to handle `c-change` messages from embedded media hub iframes and adjust card links accordingly
- Send `c-change` messages from media hub when channel selection changes

## Testing
- `npm run build:data`

------
https://chatgpt.com/codex/tasks/task_e_68ac52f8075c8320a9a53173ec2cf14a