### PR TITLE
feat: add custom fullscreen player controls

### DIFF
--- a/assets/css/vlc-fullscreen.css
+++ b/assets/css/vlc-fullscreen.css
@@ -1,0 +1,20 @@
+/* Fullscreen player custom controls */
+.player-wrap{position:relative}
+.player-wrap:fullscreen,
+.player-wrap:-webkit-full-screen{width:100vw;height:100vh}
+.player-wrap:fullscreen video,
+.player-wrap:-webkit-full-screen video{width:100%;height:100%}
+
+.plyr__controls{display:none !important}
+
+.fs-controls{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;opacity:0;pointer-events:none;transition:opacity .3s}
+.fs-controls.show{opacity:1;pointer-events:auto}
+.fs-controls button{background:rgba(0,0,0,.6);color:#fff;border:none;border-radius:50%;padding:10px;cursor:pointer}
+.play-center{font-size:40px}
+.skip-back,.skip-forward{position:absolute;top:50%;transform:translateY(-50%)}
+.skip-back{left:20%}
+.skip-forward{right:20%}
+.toolbar{position:absolute;bottom:0;left:0;right:0;background:rgba(0,0,0,.6);display:flex;gap:8px;align-items:center;padding:8px}
+.toolbar .left{display:flex;gap:6px}
+.toolbar .right{display:flex;gap:6px;margin-left:auto}
+.toolbar input[type=range]{flex:1}

--- a/assets/js/vlc-fullscreen.js
+++ b/assets/js/vlc-fullscreen.js
@@ -1,0 +1,74 @@
+(function(){
+  let video, plyr, wrap, controls,
+      centerBtn, backBtn, fwdBtn, toolbarPlay, fsBtn, progress,
+      hideTimer;
+
+  function syncButtons(){
+    const playing = !video.paused;
+    centerBtn.textContent = playing ? '❚❚' : '▶';
+    toolbarPlay.textContent = playing ? '❚❚' : '▶';
+  }
+
+  function togglePlay(){
+    if(video.paused){ plyr.play(); } else { plyr.pause(); }
+  }
+
+  function skipBack(){ video.currentTime = Math.max(0, video.currentTime - 10); }
+  function skipForward(){ video.currentTime = Math.min(video.currentTime + 10, video.duration || Infinity); }
+
+  function updateProgress(){
+    if(!isNaN(video.duration)){
+      progress.max = video.duration;
+      progress.value = video.currentTime;
+    }
+  }
+
+  function seek(e){ video.currentTime = parseFloat(e.target.value); }
+
+  function toggleFullscreen(){
+    if(document.fullscreenElement){ document.exitFullscreen(); }
+    else if(wrap.requestFullscreen){ wrap.requestFullscreen(); }
+  }
+
+  function showControls(){
+    controls.classList.add('show');
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(()=>controls.classList.remove('show'),2000);
+  }
+
+  function init(opts){
+    video = opts.video; plyr = opts.plyr; wrap = opts.wrap;
+    plyr.togglePlay = togglePlay;
+    controls = document.getElementById('fsControls');
+    centerBtn = document.getElementById('centerPlay');
+    backBtn = document.getElementById('skipBack');
+    fwdBtn = document.getElementById('skipForward');
+    toolbarPlay = document.getElementById('toolbarPlay');
+    fsBtn = document.getElementById('fsToggle');
+    progress = document.getElementById('progress');
+
+    centerBtn.addEventListener('click', togglePlay);
+    toolbarPlay.addEventListener('click', togglePlay);
+    backBtn.addEventListener('click', skipBack);
+    fwdBtn.addEventListener('click', skipForward);
+    fsBtn.addEventListener('click', toggleFullscreen);
+    progress.addEventListener('input', seek);
+
+    video.addEventListener('timeupdate', updateProgress);
+    video.addEventListener('loadedmetadata', updateProgress);
+    video.addEventListener('play', syncButtons);
+    video.addEventListener('pause', syncButtons);
+
+    document.addEventListener('mousemove', showControls);
+    document.addEventListener('keydown', showControls);
+
+    showControls();
+    syncButtons();
+  }
+
+  window.initVlcFullscreen = init;
+  window.togglePlay = togglePlay;
+  window.skipBack = skipBack;
+  window.skipForward = skipForward;
+  window.toggleFullscreen = toggleFullscreen;
+})();

--- a/vlc.html
+++ b/vlc.html
@@ -6,6 +6,7 @@
   <title>PakStream • Player</title>
   <link rel="preconnect" href="https://cdn.plyr.io" />
   <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
+  <link rel="stylesheet" href="assets/css/vlc-fullscreen.css" />
   <style>
     :root{
       --bg:#0b0f14; --panel:#11151d; --panel2:#0e141c; --text:#e6edf3; --muted:#93a4ba; --accent:#e50914; --pill:#2a3342; --ok:#27d49a;
@@ -98,7 +99,25 @@
     <!-- RIGHT: Player -->
     <section class="card player-card">
       <div class="player-wrap" id="playerWrap">
-        <video id="player" playsinline controls></video>
+        <video id="player" playsinline></video>
+        <div class="fs-controls" id="fsControls">
+          <button id="centerPlay" class="play-center">▶</button>
+          <button id="skipBack" class="skip-back">⏪ 10s</button>
+          <button id="skipForward" class="skip-forward">10s ⏩</button>
+          <div class="toolbar">
+            <div class="left">
+              <button id="btnEpisodes">Episodes</button>
+              <button id="btnAudio">Audio &amp; Subtitles</button>
+              <button id="btnShare">Share</button>
+              <button id="btnNext">Next Episode</button>
+            </div>
+            <input type="range" id="progress" value="0" min="0" step="0.1">
+            <div class="right">
+              <button id="toolbarPlay">▶</button>
+              <button id="fsToggle">⛶</button>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="hero-actions">
         <button class="btn" id="playDemo">▶ Play Demo</button>
@@ -144,6 +163,7 @@
 
   <script src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.7/dist/hls.min.js"></script>
+  <script src="assets/js/vlc-fullscreen.js"></script>
   <script>
     // ---------- Persistence Keys ----------
     const LS_KEYS = {
@@ -184,17 +204,18 @@
     const video = document.getElementById('player');
     const plyr = new Plyr(video, {
       ratio: '16:9',
-      controls: ['play-large','play','progress','current-time','duration','mute','volume','captions','settings','pip','airplay','fullscreen'],
+      controls: [],
       settings: ['captions','speed','quality','loop']
     });
+    initVlcFullscreen({ video, plyr, wrap: playerWrap });
 
     // Keyboard shortcuts
     window.addEventListener('keydown', (e)=>{
       if(['INPUT','TEXTAREA'].includes(document.activeElement.tagName)) return;
-      if(e.key===' '){ e.preventDefault(); plyr.togglePlay(); }
-      if(e.key==='f'){ plyr.fullscreen.toggle(); }
-      if(e.key==='ArrowRight'){ plyr.forward(10); }
-      if(e.key==='ArrowLeft'){ plyr.rewind(10); }
+      if(e.key===' '){ e.preventDefault(); togglePlay(); }
+      if(e.key==='f'){ toggleFullscreen(); }
+      if(e.key==='ArrowRight'){ skipForward(); }
+      if(e.key==='ArrowLeft'){ skipBack(); }
       if(e.key.toLowerCase()==='n'){ playNext(); }
     });
 


### PR DESCRIPTION
## Summary
- replace Plyr UI with custom fullscreen controls overlay
- add JS to sync play state, skipping, progress, and fullscreen
- style custom controls and hide Plyr default controls

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb5b62a0488320aebf59ec24bfed72