### PR TITLE
feat: add custom fullscreen player controls

### DIFF
--- a/assets/css/vlc-fullscreen.css
+++ b/assets/css/vlc-fullscreen.css
@@ -1,0 +1,29 @@
+/* Fullscreen player custom controls styled like Netflix */
+.player-wrap{position:relative}
+.player-wrap:fullscreen,
+.player-wrap:-webkit-full-screen{width:100vw;height:100vh}
+.player-wrap:fullscreen video,
+.player-wrap:-webkit-full-screen video{width:100%;height:100%;background:#000}
+
+.plyr__controls{display:none !important}
+
+.fs-controls{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;opacity:0;pointer-events:none;transition:opacity .3s}
+.fs-controls.show{opacity:1;pointer-events:auto}
+
+.fs-controls button{border:none;background:rgba(0,0,0,.6);color:#fff;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center}
+.fs-controls button svg{fill:#fff}
+.play-center{width:80px;height:80px}
+.play-center svg{width:40px;height:40px}
+.skip-back,.skip-forward{position:absolute;top:50%;transform:translateY(-50%);width:60px;height:60px}
+.skip-back{left:20%}
+.skip-forward{right:20%}
+.skip-back svg,.skip-forward svg{width:32px;height:32px}
+
+.toolbar button svg{width:24px;height:24px}
+
+.toolbar{position:absolute;left:0;right:0;bottom:0;display:flex;align-items:center;gap:12px;padding:16px;background:linear-gradient(to top,rgba(0,0,0,.8),rgba(0,0,0,0))}
+.toolbar button{background:none;color:#fff;border:none;font-size:20px;width:32px;height:32px;display:flex;align-items:center;justify-content:center}
+
+#progress{flex:1;-webkit-appearance:none;height:4px;border-radius:2px;background:linear-gradient(to right,#e50914 0%,#e50914 var(--progress,0%),#404040 var(--progress,0%),#404040 100%);cursor:pointer}
+#progress::-webkit-slider-thumb{-webkit-appearance:none;width:12px;height:12px;border-radius:50%;background:#fff;margin-top:-4px}
+#progress::-moz-range-thumb{width:12px;height:12px;border-radius:50%;background:#fff;border:none}

--- a/assets/js/vlc-fullscreen.js
+++ b/assets/js/vlc-fullscreen.js
@@ -1,0 +1,93 @@
+(function(){
+  let video, plyr, wrap, controls,
+      centerBtn, backBtn, fwdBtn, toolbarPlay, fsBtn, progress,
+      hideTimer;
+
+  const playIcon = '<svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>';
+  const pauseIcon = '<svg viewBox="0 0 24 24"><path d="M6 19h4V5H6zm8-14v14h4V5z"/></svg>';
+  const fsEnterIcon = '<svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zm12-9h-5v2h3v3h2V5zM7 7h3V5H5v5h2V7zm10 7v3h-3v2h5v-5h-2z"/></svg>';
+  const fsExitIcon = '<svg viewBox="0 0 24 24"><path d="M5 16h3v3h2v-5H5v2zm11 3h3v-3h2v5h-5v-2zM8 5H5v3H3V3h5v2zm11-2h-5v2h3v3h2V3z"/></svg>';
+
+  function syncButtons(){
+    const playing = !video.paused;
+    const icon = playing ? pauseIcon : playIcon;
+    centerBtn.innerHTML = icon;
+    toolbarPlay.innerHTML = icon;
+  }
+
+  function togglePlay(){
+    if(video.paused){ plyr.play(); } else { plyr.pause(); }
+  }
+
+  function skipBack(){ video.currentTime = Math.max(0, video.currentTime - 10); }
+  function skipForward(){ video.currentTime = Math.min(video.currentTime + 10, video.duration || Infinity); }
+
+  function updateProgress(){
+    if(!isNaN(video.duration)){
+      progress.max = video.duration;
+      progress.value = video.currentTime;
+      const percent = (video.currentTime / video.duration) * 100;
+      progress.style.setProperty('--progress', percent + '%');
+    }
+  }
+
+  function seek(e){
+    const val = parseFloat(e.target.value);
+    video.currentTime = val;
+    const percent = (val / progress.max) * 100;
+    progress.style.setProperty('--progress', percent + '%');
+  }
+
+  function syncFsIcon(){
+    fsBtn.innerHTML = document.fullscreenElement ? fsExitIcon : fsEnterIcon;
+  }
+
+  function toggleFullscreen(){
+    if(document.fullscreenElement){ document.exitFullscreen(); }
+    else if(wrap.requestFullscreen){ wrap.requestFullscreen(); }
+  }
+
+  function showControls(){
+    controls.classList.add('show');
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(()=>controls.classList.remove('show'),2000);
+  }
+
+  function init(opts){
+    video = opts.video; plyr = opts.plyr; wrap = opts.wrap;
+    plyr.togglePlay = togglePlay;
+    controls = document.getElementById('fsControls');
+    centerBtn = document.getElementById('centerPlay');
+    backBtn = document.getElementById('skipBack');
+    fwdBtn = document.getElementById('skipForward');
+    toolbarPlay = document.getElementById('toolbarPlay');
+    fsBtn = document.getElementById('fsToggle');
+    progress = document.getElementById('progress');
+
+    centerBtn.addEventListener('click', togglePlay);
+    toolbarPlay.addEventListener('click', togglePlay);
+    backBtn.addEventListener('click', skipBack);
+    fwdBtn.addEventListener('click', skipForward);
+    fsBtn.addEventListener('click', toggleFullscreen);
+    progress.addEventListener('input', seek);
+    document.addEventListener('fullscreenchange', syncFsIcon);
+
+    video.addEventListener('timeupdate', updateProgress);
+    video.addEventListener('loadedmetadata', updateProgress);
+    video.addEventListener('play', syncButtons);
+    video.addEventListener('pause', syncButtons);
+
+    document.addEventListener('mousemove', showControls);
+    document.addEventListener('keydown', showControls);
+
+    syncButtons();
+    syncFsIcon();
+    showControls();
+  }
+
+  window.initVlcFullscreen = init;
+  window.togglePlay = togglePlay;
+  window.skipBack = skipBack;
+  window.skipForward = skipForward;
+  window.toggleFullscreen = toggleFullscreen;
+})();

--- a/vlc.html
+++ b/vlc.html
@@ -6,6 +6,7 @@
   <title>PakStream • Player</title>
   <link rel="preconnect" href="https://cdn.plyr.io" />
   <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
+  <link rel="stylesheet" href="assets/css/vlc-fullscreen.css" />
   <style>
     :root{
       --bg:#0b0f14; --panel:#11151d; --panel2:#0e141c; --text:#e6edf3; --muted:#93a4ba; --accent:#e50914; --pill:#2a3342; --ok:#27d49a;
@@ -98,7 +99,21 @@
     <!-- RIGHT: Player -->
     <section class="card player-card">
       <div class="player-wrap" id="playerWrap">
-        <video id="player" playsinline controls></video>
+        <video id="player" playsinline></video>
+        <div class="fs-controls" id="fsControls">
+          <button id="centerPlay" class="play-center" aria-label="Play/Pause"></button>
+          <button id="skipBack" class="skip-back" aria-label="Back 10 seconds">
+            <svg viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M11.99 5V1l-5 5 5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6h-2c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8zm-1.1 11h-.85v-3.26l-1.01.31v-.69l1.77-.63h.09V16zm4.28-1.76c0 .32-.03.6-.1.82s-.17.42-.29.57-.28.26-.45.33-.37.1-.59.1-.41-.03-.59-.1-.33-.18-.46-.33-.23-.34-.3-.57-.11-.5-.11-.82v-.74c0-.32.03-.6.1-.82s.17-.42.29-.57.28-.26.45-.33.37-.1.59-.1.41.03.59.1.33.18.46.33.23.34.3.57.11.5.11.82v.74zm-.85-.86c0-.19-.01-.35-.04-.48s-.07-.23-.12-.31-.11-.14-.19-.17-.16-.05-.25-.05-.18.02-.25.05-.14.09-.19.17-.09.18-.12.31-.04.29-.04.48v.97c0 .19.01.35.04.48s.07.24.12.32.11.14.19.17.16.05.25.05.18-.02.25-.05.14-.09.19-.17.09-.19.11-.32.04-.29.04-.48v-.97z"/></svg>
+          </button>
+          <button id="skipForward" class="skip-forward" aria-label="Forward 10 seconds">
+            <svg viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0z"/><path d="M18 13c0 3.31-2.69 6-6 6s-6-2.69-6-6 2.69-6 6-6v4l5-5-5-5v4c-4.42 0-8 3.58-8 8 0 4.42 3.58 8 8 8s8-3.58 8-8h-2z"/><polygon points="10.9,16 10.9,11.73 10.81,11.73 9.04,12.36 9.04,13.05 10.05,12.74 10.05,16"/><path d="M14.32 11.78c-.18-.07-.37-.1-.59-.1s-.41.03-.59.1-.33.18-.45.33-.23.34-.29.57-.1.5-.1.82v.74c0 .32.04.6.11.82s.17.42.3.57.28.26.46.33.37.1.59.1.41-.03.59-.1.33-.18.45-.33.22-.34.29-.57.1-.5.1-.82V13.5c0-.32-.04-.6-.11-.82s-.17-.42-.3-.57-.28-.26-.46-.33zM14.33 14.35c0 .19-.01.35-.04.48s-.06.24-.11.32-.11.14-.19.17-.16.05-.25.05-.18-.02-.25-.05-.14-.09-.19-.17-.09-.19-.12-.32-.04-.29-.04-.48v-.97c0-.19.01-.35.04-.48s.06-.23.12-.31.11-.14.19-.17.16-.05.25-.05.18.02.25.05.14.09.19.17.09.18.12.31.04.29.04.48v.97z"/></svg>
+          </button>
+          <div class="toolbar">
+            <button id="toolbarPlay" aria-label="Play/Pause"></button>
+            <input type="range" id="progress" value="0" min="0" step="0.1">
+            <button id="fsToggle" aria-label="Toggle Fullscreen"></button>
+          </div>
+        </div>
       </div>
       <div class="hero-actions">
         <button class="btn" id="playDemo">▶ Play Demo</button>
@@ -144,6 +159,7 @@
 
   <script src="https://cdn.plyr.io/3.7.8/plyr.polyfilled.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.7/dist/hls.min.js"></script>
+  <script src="assets/js/vlc-fullscreen.js"></script>
   <script>
     // ---------- Persistence Keys ----------
     const LS_KEYS = {
@@ -184,17 +200,18 @@
     const video = document.getElementById('player');
     const plyr = new Plyr(video, {
       ratio: '16:9',
-      controls: ['play-large','play','progress','current-time','duration','mute','volume','captions','settings','pip','airplay','fullscreen'],
+      controls: [],
       settings: ['captions','speed','quality','loop']
     });
+    initVlcFullscreen({ video, plyr, wrap: playerWrap });
 
     // Keyboard shortcuts
     window.addEventListener('keydown', (e)=>{
       if(['INPUT','TEXTAREA'].includes(document.activeElement.tagName)) return;
-      if(e.key===' '){ e.preventDefault(); plyr.togglePlay(); }
-      if(e.key==='f'){ plyr.fullscreen.toggle(); }
-      if(e.key==='ArrowRight'){ plyr.forward(10); }
-      if(e.key==='ArrowLeft'){ plyr.rewind(10); }
+      if(e.key===' '){ e.preventDefault(); togglePlay(); }
+      if(e.key==='f'){ toggleFullscreen(); }
+      if(e.key==='ArrowRight'){ skipForward(); }
+      if(e.key==='ArrowLeft'){ skipBack(); }
       if(e.key.toLowerCase()==='n'){ playNext(); }
     });
 


### PR DESCRIPTION
## Summary
- refine fullscreen overlay to mimic Netflix with play, skip 10s, progress, and fullscreen controls
- style controls with white SVG icons and red progress bar
- sync play and fullscreen states across center and toolbar buttons

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb5b62a0488320aebf59ec24bfed72