### PR TITLE
Load default video playlist for VLC player

### DIFF
--- a/assets/default_playlist.json
+++ b/assets/default_playlist.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "The Bourne Identity",
+    "src": "https://dn721806.ca.archive.org/0/items/the.-bourne.-identity.-2002.720p.-br-rip.x-264.-yify/The.Bourne.Identity.2002.720p.BrRip.x264.YIFY.mp4"
+  },
+  {
+    "name": "The Legend Of Bagger Vance",
+    "src": "https://ia800509.us.archive.org/7/items/the.-legend.-of.-bagger.-vance.-2000.1080p.-webrip.x-264-yts.-am/The.Legend.Of.Bagger.Vance.2000.1080p.WEBRip.x264-%5BYTS.AM%5D.mp4"
+  }
+]

--- a/vlc.html
+++ b/vlc.html
@@ -242,6 +242,22 @@
       });
     }
 
+    async function loadDefaults(){
+      try{
+        const res = await fetch('assets/default_playlist.json');
+        const list = await res.json();
+        if(Array.isArray(list)){
+          list.forEach(ep=>{
+            if(!playlist.some(p=>p.src===ep.src)){
+              const id='ep'+Math.random().toString(36).slice(2);
+              playlist.push({id, name: ep.name || ep.src.split('/').pop(), src: ep.src, poster: ep.poster||'', subs: ep.subs||''});
+            }
+          });
+          savePlaylist();
+        }
+      }catch(e){}
+    }
+
     function setQualityMenuFromHls(hls){
       const levels = hls.levels.map(l=>l.height).filter(Boolean).sort((a,b)=>a-b);
       plyr.options.quality = {
@@ -371,31 +387,35 @@
     });
 
     // ---------- Boot: restore previous session ----------
-    loadState();
-    renderPlaylist();
-    if(playlist.length){
-      if(current>=0 && current<playlist.length){
-        const ep = playlist[current];
-        const lastSrc = localStorage.getItem(LS_KEYS.lastsrc);
-        const lastIdx = parseInt(localStorage.getItem(LS_KEYS.idx)||'-1',10);
-        const saved = getTimeFor(ep.src);
-        const sameItem = ep.src===lastSrc && current===lastIdx && saved>0;
-        if(sameItem){
-          const resume = confirm(`Resume from ${fmtTime(saved)}?`);
-          if(resume){
-            playIndex(current, {resumeIfSame:false, startTime:saved});
+    async function init(){
+      loadState();
+      await loadDefaults();
+      renderPlaylist();
+      if(playlist.length){
+        if(current>=0 && current<playlist.length){
+          const ep = playlist[current];
+          const lastSrc = localStorage.getItem(LS_KEYS.lastsrc);
+          const lastIdx = parseInt(localStorage.getItem(LS_KEYS.idx)||'-1',10);
+          const saved = getTimeFor(ep.src);
+          const sameItem = ep.src===lastSrc && current===lastIdx && saved>0;
+          if(sameItem){
+            const resume = confirm(`Resume from ${fmtTime(saved)}?`);
+            if(resume){
+              playIndex(current, {resumeIfSame:false, startTime:saved});
+            } else {
+              clearTimeForCurrent();
+              playIndex(current, {resumeIfSame:false});
+            }
           } else {
-            clearTimeForCurrent();
-            playIndex(current, {resumeIfSame:false});
+            playIndex(current, {resumeIfSame:true});
           }
-        } else {
-          playIndex(current, {resumeIfSame:true});
         }
+      } else {
+        // Seed a starter card so the page looks alive
+        addToPlaylist({name:'Sample Trailer', src:'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4', poster:'https://picsum.photos/seed/poster1/600/900'});
       }
-    } else {
-      // Seed a starter card so the page looks alive
-      addToPlaylist({name:'Sample Trailer', src:'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4', poster:'https://picsum.photos/seed/poster1/600/900'});
     }
+    init();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch default video list from `assets/default_playlist.json`
- merge defaults into local playlist on startup while keeping user-added URLs in local storage
- added initial playlist file with two example videos

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5fc22a288320a536962edd96560d