### PR TITLE
Refine VLC player page

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -23,16 +23,9 @@
     .btn:active{transform:translateY(1px)}
     .ghost{background:transparent;border:1px solid rgba(255,255,255,.16)}
 
-    .layout{max-width:1200px;margin:14px auto;padding:0 16px;display:grid;grid-template-columns:350px 1fr;gap:16px}
-    @media (max-width:1000px){.layout{grid-template-columns:1fr}}
+    .layout{max-width:1200px;margin:14px auto;padding:0 16px;}
 
-    /* LEFT: details */
     .card{background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));border:1px solid rgba(255,255,255,.08);border-radius:var(--radius);overflow:hidden}
-    .poster{aspect-ratio:2/3;background:var(--panel2) center/cover no-repeat}
-    .meta{padding:16px}
-    .title{font-size:22px;font-weight:800;margin:0 0 6px}
-    .row{display:flex;gap:8px;align-items:center;color:var(--muted);font-size:13px;margin-bottom:8px}
-    .pill{background:var(--pill);padding:4px 8px;border-radius:999px;color:#cfe0ff}
 
     /* RIGHT: player + rail */
     .player-card{padding:12px}
@@ -51,15 +44,6 @@
     .ep .name{font-weight:700}
     .ep .sub{color:var(--muted);font-size:12px}
     .ep.active{outline:2px solid var(--accent)}
-
-    /* Rail */
-    .rail{padding:8px 12px 20px}
-    .rail h3{margin:10px 0}
-    .tiles{display:grid;grid-template-columns:repeat(5,1fr);gap:10px}
-    @media (max-width:1100px){.tiles{grid-template-columns:repeat(3,1fr)}}
-    @media (max-width:700px){.tiles{grid-template-columns:repeat(2,1fr)}}
-    .tile{aspect-ratio:16/9;background:#0e141c center/cover no-repeat;border-radius:12px;border:1px solid rgba(255,255,255,.08);position:relative;overflow:hidden}
-    .tile::after{content:"";position:absolute;inset:0;box-shadow:inset 0 -60px 100px rgba(0,0,0,.6)}
 
     /* Modal */
     .modal{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;padding:16px}
@@ -81,22 +65,6 @@
   </nav>
 
   <div class="layout">
-    <!-- LEFT: Poster + meta -->
-    <aside class="card">
-      <div id="poster" class="poster" style="background-image:url('https://image.tmdb.org/t/p/w500/9KQgG8GMDIS9ZhDJW60TrNRXS6a.jpg');"></div>
-      <div class="meta">
-        <h2 class="title" id="title">The Legend of Bagger Vance</h2>
-        <div class="row">
-          <span class="pill">2000</span>
-          <span class="pill">2h 7m</span>
-          <span class="pill">Drama</span>
-        </div>
-        <div class="row">Press <b>Space</b> to play/pause • <b>F</b> fullscreen • <b>→/←</b> seek • <b>N</b> next</div>
-        <div class="row hint">Add your own link with <b>+ Add From URL</b>. MP4/WebM work best. HLS needs CORS.</div>
-      </div>
-    </aside>
-
-    <!-- RIGHT: Player -->
     <section class="card player-card">
       <div class="player-wrap" id="playerWrap">
         <video id="player" playsinline></video>
@@ -124,17 +92,6 @@
       <div class="episodes">
         <h3>Playlist</h3>
         <div id="epList" class="ep-list"></div>
-      </div>
-
-      <div class="rail">
-        <h3>Because you watched</h3>
-        <div class="tiles">
-          <div class="tile" style="background-image:url('https://picsum.photos/seed/ps1/800/450')"></div>
-          <div class="tile" style="background-image:url('https://picsum.photos/seed/ps2/800/450')"></div>
-          <div class="tile" style="background-image:url('https://picsum.photos/seed/ps3/800/450')"></div>
-          <div class="tile" style="background-image:url('https://picsum.photos/seed/ps4/800/450')"></div>
-          <div class="tile" style="background-image:url('https://picsum.photos/seed/ps5/800/450')"></div>
-        </div>
       </div>
     </section>
   </div>
@@ -181,7 +138,7 @@
     function loadState(){
       try{
         const p = JSON.parse(localStorage.getItem(LS_KEYS.playlist) || '[]');
-        if(Array.isArray(p) && p.length) playlist = p;
+        if(Array.isArray(p) && p.length) playlist = p.map(ep=>({...ep, name: cleanName(ep.name||'')}));
         const idxStr = localStorage.getItem(LS_KEYS.idx);
         if(idxStr!==null) current = parseInt(idxStr,10);
       }catch(e){}
@@ -192,8 +149,6 @@
 
     // ---------- UI Elements ----------
     const tip = document.getElementById('tip');
-    const posterEl = document.getElementById('poster');
-    const titleEl = document.getElementById('title');
     const epList = document.getElementById('epList');
     const playerWrap = document.getElementById('playerWrap');
 
@@ -219,9 +174,24 @@
     let playlist = [];
     let current = -1;
 
+    function cleanName(raw){
+      if(!raw) return '';
+      let name = decodeURIComponent(raw);
+      name = name.replace(/\.[^./]+$/, '');
+      name = name.replace(/[._-]+/g, ' ');
+      name = name.replace(/\[[^\]]*\]/g, ' ');
+      const trash = ['WEBRip','WEB-DL','HDRip','BluRay','BRRip','DVDRip','x264','x265','h264','h265','YTS','YIFY','1080p','720p','480p'];
+      trash.forEach(t=>{
+        const re = new RegExp('\\b'+t.replace(/[.*+?^${}()|[\\]\\]/g,'\\$&')+'\\b','gi');
+        name = name.replace(re,'');
+      });
+      return name.replace(/\s+/g,' ').trim();
+    }
+
     function addToPlaylist({name, src, poster='', subs=''}){
       const id='ep'+Math.random().toString(36).slice(2);
-      playlist.push({id,name,src,poster,subs});
+      const nice = cleanName(name || src.split('/').pop());
+      playlist.push({id,name:nice,src,poster,subs});
       savePlaylist();
       renderPlaylist();
     }
@@ -250,7 +220,7 @@
           list.forEach(ep=>{
             if(!playlist.some(p=>p.src===ep.src)){
               const id='ep'+Math.random().toString(36).slice(2);
-              playlist.push({id, name: ep.name || ep.src.split('/').pop(), src: ep.src, poster: ep.poster||'', subs: ep.subs||''});
+              playlist.push({id, name: cleanName(ep.name || ep.src.split('/').pop()), src: ep.src, poster: ep.poster||'', subs: ep.subs||''});
             }
           });
           savePlaylist();
@@ -305,9 +275,7 @@
     function playIndex(idx, {resumeIfSame=true, startTime=null}={}){
       if(idx<0 || idx>=playlist.length) return;
       current = idx; saveIndex();
-      const {src, poster, subs, name} = playlist[idx];
-      titleEl.textContent = name || 'Untitled';
-      posterEl.style.backgroundImage = `url('${poster||'https://picsum.photos/seed/p'+idx+'/600/900'}')`;
+      const {src, subs} = playlist[idx];
       tip.textContent = 'Loading…';
 
       // reset
@@ -410,9 +378,6 @@
             playIndex(current, {resumeIfSame:true});
           }
         }
-      } else {
-        // Seed a starter card so the page looks alive
-        addToPlaylist({name:'Sample Trailer', src:'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4', poster:'https://picsum.photos/seed/poster1/600/900'});
       }
     }
     init();


### PR DESCRIPTION
## Summary
- remove sidebar and recommendation rail from `vlc.html`
- clean playlist titles by stripping dots, extensions, and common tags
- drop sample trailer seeding for an empty playlist

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68bb61215120832096b38229c8afda5d