### PR TITLE
Remove demo playback buttons and sample trailer

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -84,8 +84,6 @@
         </div>
       </div>
       <div class="hero-actions">
-        <button class="btn" id="playDemo">▶ Play Demo</button>
-        <button class="btn ghost" id="playDemoHls">▶ Play Demo (HLS)</button>
         <span class="hint" id="tip">Ready.</span>
       </div>
 
@@ -342,16 +340,6 @@
       closeModal();
       m_url.value = m_poster.value = m_subs.value = '';
       if(current===-1) playIndex(0);
-    });
-
-    // Demo buttons
-    document.getElementById('playDemo').addEventListener('click', ()=>{
-      addToPlaylist({name:'Big Buck Bunny (Demo MP4)', src:'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4', poster:'https://peach.blender.org/wp-content/uploads/title_anouncement.jpg'});
-      playIndex(playlist.length-1, {resumeIfSame:false});
-    });
-    document.getElementById('playDemoHls').addEventListener('click', ()=>{
-      addToPlaylist({name:'MUX Test (Demo HLS)', src:'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8'});
-      playIndex(playlist.length-1, {resumeIfSame:false});
     });
 
     // ---------- Boot: restore previous session ----------


### PR DESCRIPTION
## Summary
- Remove Play Demo and Play Demo (HLS) buttons from the VLC player page
- Drop associated sample trailer event handlers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb663a0b6c83209c242ec13cdb8c6c