### PR TITLE
Ensure landscape orientation when entering fullscreen

### DIFF
--- a/assets/js/vlc-fullscreen.js
+++ b/assets/js/vlc-fullscreen.js
@@ -114,13 +114,35 @@
     resetArrowSeek();
   }
 
+  function lockLandscape() {
+    try {
+      if (screen.orientation && screen.orientation.lock) {
+        screen.orientation.lock('landscape').catch(() => {});
+      } else if (screen.lockOrientation) {
+        screen.lockOrientation('landscape');
+      }
+    } catch (_) {}
+  }
+
+  function unlockOrientation() {
+    try {
+      if (screen.orientation && screen.orientation.unlock) {
+        screen.orientation.unlock();
+      } else if (screen.unlockOrientation) {
+        screen.unlockOrientation();
+      }
+    } catch (_) {}
+  }
+
   function handleFsChange() {
     syncFsIcon();
     if (isFullscreen()) {
+      lockLandscape();
       onEnterFullscreenUI();
       // Some Samsungs steal focus during FS transition
       setTimeout(ensureFocusForTv, 0);
     } else {
+      unlockOrientation();
       onExitFullscreenUI();
     }
   }


### PR DESCRIPTION
## Summary
- Lock screen orientation to landscape when the custom player enters fullscreen
- Restore previous orientation on exit

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb783aece08320ba7ec7e2c88a6741