### PR TITLE
Force landscape orientation during mobile fullscreen video

### DIFF
--- a/assets/js/vlc-fullscreen.js
+++ b/assets/js/vlc-fullscreen.js
@@ -39,8 +39,27 @@
     progress.style.setProperty('--progress', percent + '%');
   }
 
+  const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
   function syncFsIcon(){
-    fsBtn.innerHTML = document.fullscreenElement ? fsExitIcon : fsEnterIcon;
+    const isFs = !!document.fullscreenElement;
+    fsBtn.innerHTML = isFs ? fsExitIcon : fsEnterIcon;
+
+    if(!isMobile || !(screen.orientation)) return;
+
+    try{
+      if(isFs && screen.orientation.lock){
+        screen.orientation.lock('landscape').catch(()=>{});
+      }else if(!isFs){
+        if(screen.orientation.unlock){
+          screen.orientation.unlock();
+        }else if(screen.orientation.lock){
+          screen.orientation.lock('portrait').catch(()=>{});
+        }
+      }
+    }catch(err){
+      // ignore orientation errors
+    }
   }
 
   function toggleFullscreen(){


### PR DESCRIPTION
## Summary
- Lock screen orientation to landscape when video enters fullscreen on mobile devices
- Unlock or reset orientation on fullscreen exit

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf65409eac8320b3d0e5f855e89e1b