### PR TITLE
Deduplicate playlist before rendering

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -211,6 +211,15 @@
     }
 
     function renderPlaylist(){
+      // Remove duplicate sources before rendering
+      const seen = new Set();
+      playlist = playlist.filter(ep=>{
+        if(seen.has(ep.src)) return false;
+        seen.add(ep.src);
+        return true;
+      });
+      savePlaylist();
+
       epList.innerHTML='';
       playlist.forEach((ep, idx)=>{
         const el=document.createElement('div');


### PR DESCRIPTION
## Summary
- filter playlist to remove duplicate sources before rendering and persist updated list

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68bf70c2a3ac8320ad7fef4d9c85e74b