### PR TITLE
Fetch and cache TMDb posters for playlist

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -136,12 +136,34 @@
       playlist: 'ps_playlist_v1',
       idx: 'ps_current_index_v1',
       tmap: 'ps_time_by_src_v1',
-      lastsrc: 'ps_last_src_v1'
+      lastsrc: 'ps_last_src_v1',
+      posterCache: 'ps_poster_cache_v1'
     };
     const SHEET_CSV = 'https://docs.google.com/spreadsheets/d/16kreaQ7lxmx4FzljUeWtb4AbBowcixXd5UyvediK7vI/export?format=csv';
+    const TMDB_API_KEY = '5c0c73d3cff412c85960b7cd18601fc1';
 
     // ---------- Utilities ----------
     const throttle = (fn, ms) => { let t=0; return (...a)=>{ const n=Date.now(); if(n-t>ms){ t=n; fn(...a); } } };
+
+    function getPosterCache(){ try{ return JSON.parse(localStorage.getItem(LS_KEYS.posterCache)||'{}'); }catch(e){ return {}; } }
+    function setPosterCache(m){ localStorage.setItem(LS_KEYS.posterCache, JSON.stringify(m)); }
+    async function fetchPoster(title){
+      const cache=getPosterCache();
+      if(cache[title]) return cache[title];
+      try{
+        const url=`https://api.themoviedb.org/3/search/movie?api_key=${TMDB_API_KEY}&query=${encodeURIComponent(title)}`;
+        const r=await fetch(url);
+        if(!r.ok) throw new Error('bad');
+        const data=await r.json();
+        const path=data.results&&data.results[0]&&data.results[0].poster_path;
+        if(path){
+          const poster=`https://image.tmdb.org/t/p/w300${path}`;
+          cache[title]=poster; setPosterCache(cache);
+          return poster;
+        }
+      }catch(e){}
+      cache[title]=''; setPosterCache(cache); return '';
+    }
 
     function getTimeMap(){ try{ return JSON.parse(localStorage.getItem(LS_KEYS.tmap) || '{}'); }catch(e){ return {}; } }
     function setTimeFor(src, sec){ const m=getTimeMap(); m[src]=sec; localStorage.setItem(LS_KEYS.tmap, JSON.stringify(m)); }
@@ -224,12 +246,17 @@
       playlist.forEach((ep, idx)=>{
         const el=document.createElement('div');
         el.className='ep'+(idx===current?' active':'');
+        const poster=ep.poster||`https://picsum.photos/seed/${idx}/400/225`;
         el.innerHTML = `
-          <div class="thumb" style="background-image:url('${ep.poster||'https://picsum.photos/seed/'+idx+'/400/225'}')"></div>
+          <div class="thumb" style="background-image:url('${poster}')"></div>
           <div class="txt">
             <div class="name">${ep.name||'Untitled'}</div>
             <div class="sub">${safeHost(ep.src)}</div>
           </div>`;
+        const thumb=el.querySelector('.thumb');
+        if(!ep.poster){
+          fetchPoster(ep.name).then(url=>{ if(url){ ep.poster=url; savePlaylist(); thumb.style.backgroundImage=`url('${url}')`; }});
+        }
         el.addEventListener('click', ()=> playIndex(idx));
         epList.appendChild(el);
       });


### PR DESCRIPTION
## Summary
- cache TMDb poster URLs in localStorage
- load movie posters for playlist items using TMDb search

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf76436bb88320941675516aa6f67b