### PR TITLE
Clean playlist titles in player

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -216,7 +216,7 @@
       name = name.replace(/\.[^./]+$/, '');
       name = name.replace(/[._-]+/g, ' ');
       name = name.replace(/\[[^\]]*\]/g, ' ');
-      const trash = ['WEBRip','WEB-DL','HDRip','BluRay','BRRip','DVDRip','x264','x265','h264','h265','YTS','YIFY','1080p','720p','480p'];
+      const trash = ['WEBRip','WEB-DL','HDRip','BluRay','BRRip','DVDRip','x264','x265','h264','h265','YTS','YIFY','1080p','720p','480p','AAC','LAMA'];
       trash.forEach(t=>{
         const re = new RegExp('\\b'+t.replace(/[.*+?^${}()|[\\]\\]/g,'\\$&')+'\\b','gi');
         name = name.replace(re,'');


### PR DESCRIPTION
## Summary
- Strip extra tokens like AAC and LAMA from playlist item names in the player

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:data`


------
https://chatgpt.com/codex/tasks/task_e_68bf77c2554883208fb11d28e003dd8b