### PR TITLE
Fix playback start when declining resume prompt

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -334,7 +334,12 @@
         const ov = makeResumeOverlay(saved);
         playerWrap.appendChild(ov);
         document.getElementById('resumeYes').onclick = ()=>{ video.currentTime=Math.max(0,saved-2); plyr.play(); ov.remove(); };
-        document.getElementById('resumeNo').onclick = ()=>{ clearTimeForCurrent(); plyr.play(); ov.remove(); };
+        document.getElementById('resumeNo').onclick = ()=>{
+          clearTimeForCurrent();
+          video.currentTime = 0;
+          plyr.play();
+          ov.remove();
+        };
       };
 
       if(video.readyState>=1) show(); else video.addEventListener('loadedmetadata', show, {once:true});
@@ -427,12 +432,11 @@
           const sameItem = ep.src===lastSrc && current===lastIdx && saved>0;
           if(sameItem){
             const resume = confirm(`Resume from ${fmtTime(saved)}?`);
-            if(resume){
-              playIndex(current, {resumeIfSame:false, startTime:saved});
-            } else {
+            const startFrom = resume ? saved : 0;
+            if(!resume){
               clearTimeForCurrent();
-              playIndex(current, {resumeIfSame:false});
             }
+            playIndex(current, {resumeIfSame:false, startTime:startFrom});
           } else {
             playIndex(current, {resumeIfSame:true});
           }


### PR DESCRIPTION
## Summary
- reset the video time to the beginning when the in-player resume prompt is declined
- ensure the initial resume confirmation always starts playback with an explicit start time

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c8751f30208320acd88c9104d6175a