### PR TITLE
Adjust VLC playlist to wrap items

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -37,8 +37,8 @@
     /* Episodes / playlist */
     .episodes{margin:14px 0 0;padding:0 12px 16px}
     .episodes h3{margin:8px 0 10px;font-size:16px}
-    .ep-list{display:flex;overflow:auto;gap:12px;padding-bottom:6px}
-    .ep{min-width:240px;background:var(--panel2);border:1px solid rgba(255,255,255,.08);border-radius:14px;cursor:pointer}
+    .ep-list{display:flex;flex-wrap:wrap;gap:12px;padding-bottom:6px}
+    .ep{flex:0 1 240px;min-width:240px;background:var(--panel2);border:1px solid rgba(255,255,255,.08);border-radius:14px;cursor:pointer}
     .thumb{height:120px;border-bottom:1px solid rgba(255,255,255,.06);background:#0a0f14 center/cover no-repeat}
     .ep .txt{padding:10px}
     .ep .name{font-weight:700}


### PR DESCRIPTION
## Summary
- update the VLC playlist CSS to wrap items onto additional rows
- ensure playlist cards keep a minimum width while avoiding horizontal scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c877aa1b4c83209e5278d8fc96dea4