### PR TITLE
Prevent playback when canceling resume prompt

### DIFF
--- a/vlc.html
+++ b/vlc.html
@@ -334,7 +334,12 @@
         const ov = makeResumeOverlay(saved);
         playerWrap.appendChild(ov);
         document.getElementById('resumeYes').onclick = ()=>{ video.currentTime=Math.max(0,saved-2); plyr.play(); ov.remove(); };
-        document.getElementById('resumeNo').onclick = ()=>{ clearTimeForCurrent(); plyr.play(); ov.remove(); };
+        document.getElementById('resumeNo').onclick = ()=>{
+          clearTimeForCurrent();
+          video.currentTime = 0;
+          plyr.play();
+          ov.remove();
+        };
       };
 
       if(video.readyState>=1) show(); else video.addEventListener('loadedmetadata', show, {once:true});
@@ -431,7 +436,13 @@
               playIndex(current, {resumeIfSame:false, startTime:saved});
             } else {
               clearTimeForCurrent();
-              playIndex(current, {resumeIfSame:false});
+              current = -1;
+              saveIndex();
+              renderPlaylist();
+              plyr.stop();
+              video.removeAttribute('src');
+              video.load();
+              tip.textContent = 'Resume cancelled. Select something to play.';
             }
           } else {
             playIndex(current, {resumeIfSame:true});


### PR DESCRIPTION
## Summary
- stop auto-playing when the resume confirmation is declined by clearing saved progress and leaving the player idle

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8751f30208320acd88c9104d6175a